### PR TITLE
Simplified Obelisk.CLI API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ ctags
 dist-newstyle
 cabal.project.local
 .ghc.environment.*
+
+**/ghcid-output.txt

--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,21 @@ let #TODO: Upstream
         then removeConfigureFlag drv' "--ghc-option=-optl=-dead_strip"
         else drv';
 
+    applyHpack = dir: pkgs.runCommand "applyHpack" {} ''
+      cp -r "${dir}" "$out"
+      chmod +w "$out"
+      cd $out && ${pkgs.haskellPackages.hpack}/bin/hpack
+    '';
+
+    # Dependencies that should be on the PATH for obelisk when it runs. This does not affect PATH of end user.
+    commandRuntimeDeps = pkgs: with pkgs; [
+      coreutils
+      git
+      gitAndTools.hub
+      nix
+      nix-prefetch-git
+      openssh
+    ];
 
     addOptparseApplicativeCompletionScripts = exeName: pkg: overrideCabal pkg (drv: {
       postInstall = (drv.postInstall or "") + ''
@@ -35,6 +50,13 @@ let #TODO: Upstream
         "$out/bin/${exeName}" --fish-completion-script "$out/bin/${exeName}" >"$FISH_COMP_DIR/ob.fish"
       '';
     });
+
+    unliftioSrc = pkgs.fetchFromGitHub {
+      owner = "fpco";
+      repo = "unliftio";
+      rev = "bc822ac8aaacf9d008e9a6d5d9b79817f34b9c44";
+      sha256 = "1knzamqka92cgyrvq76pzbw02x0h8yw5gxv9n9m7vbdain31n8p0";
+    };
 
     # The haskell environment used to build Obelisk itself, e.g. the 'ob' command
     ghcObelisk = reflex-platform.ghc.override {
@@ -56,6 +78,9 @@ let #TODO: Upstream
           editedCabalFile = null;
         });
 
+        unliftio = self.callCabal2nix "unliftio" (applyHpack (unliftioSrc + /unliftio)) {};
+        unliftio-core = self.callCabal2nix "unliftio-core" (applyHpack (unliftioSrc + /unliftio-core)) {};
+ 
         # Dynamic linking with split objects dramatically increases startup time (about 0.5 seconds on a decent machine with SSD)
         obelisk-command = addOptparseApplicativeCompletionScripts "ob" (justStaticExecutables' super.obelisk-command);
 

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -37,13 +37,12 @@ library
     , time
     , transformers
     , unix
+    , unliftio
     , yaml
   exposed-modules:
     Obelisk.App
     Obelisk.CLI
-    Obelisk.CLI.Logging
-    Obelisk.CLI.Process
-    Obelisk.CLI.Spinner
+    Obelisk.CLI.Demo
     Obelisk.Command
     Obelisk.Command.Deploy
     Obelisk.Command.Nix
@@ -52,6 +51,11 @@ library
     Obelisk.Command.Run
     Obelisk.Command.Thunk
     Obelisk.Command.Utils
+  other-modules:
+    Obelisk.CLI.Logging
+    Obelisk.CLI.Process
+    Obelisk.CLI.Spinner
+    Obelisk.CLI.Types
   -- -fobject-code is so that the StaticPointers extension can work in ghci
   ghc-options: -Wall -fobject-code
 

--- a/lib/command/src/Obelisk/CLI.hs
+++ b/lib/command/src/Obelisk/CLI.hs
@@ -1,66 +1,40 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
 -- | Package for writing great CLI apps.
+--
+-- See Demo.hs for an example
+--
+-- This package should eventually be made its own library.
 module Obelisk.CLI
-  ( withSpinner
-  , cliDemo
-  , module Obelisk.CLI.Logging
-  , module Obelisk.CLI.Process
+  (
+  -- .Types
+    Cli
+  , CliT
+  , runCli
+  , CliConfig
+  , HasCliConfig
+  , getCliConfig
+
+  -- .Spinner
+  , withSpinner
+
+  -- .Logging
+  , newCliConfig
+  , getLogLevel
+  , putLog
+  , failWith
+  , withExitFailMessage
+
+  -- Control.Monad.Log
+  , Severity (..)
+
+  -- .Process
+  , readProcessAndLogStderr
+  , callProcessAndLogOutput
+  , createProcess_
   ) where
 
-import Control.Concurrent (threadDelay)
-import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader (ask)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import qualified Data.Text as T
-import System.Process (proc)
+import Control.Monad.Log (Severity (..))
 
 import Obelisk.CLI.Logging
 import Obelisk.CLI.Process
 import Obelisk.CLI.Spinner
-
-import Obelisk.App (MonadObelisk, _obelisk_logging, _obelisk_noSpinner)
-
--- NOTE: Everything under `Obelisk.CLI` is independent of the rest of Obelisk, with the exception of the
--- below functions, as they read the obelisk cli config using MonadReader.
-
-withSpinner :: MonadObelisk m => Text -> m a -> m a
-withSpinner s action = do
-  conf <- ask
-  case _obelisk_noSpinner conf of
-    True -> putLog Notice s >> action
-    False -> withSpinner' (_obelisk_logging conf) s action
-
-cliDemo :: MonadObelisk m => m ()
-cliDemo = withSpinner "CLI Demo" $ do
-  putLog Notice "This demo will showcase the CLI library functionality"
-  withSpinner "Running some long-running task" $ do
-    delay
-    withSpinner "Nested task" $ do
-      delay
-      putLog Notice "In nested task"
-      withSpinner "Inbetween" $ do
-        withSpinner "Nested task" $ do
-          delay
-          putLog Notice "This task has the same name and still works"
-        delay
-      delay
-      putLog Error "Top nested task finished"
-    delay
-    putLog Error "Some user error while spinning"
-    delay
-    putLog Notice "This is some info mesage"
-    putLog Warning "And now a warning as well"
-    delay
-  putLog Notice "Now we start a 2nd spinner, run a couple of process, the last of which fails:"
-  withSpinner "Looking around" $ do
-    delay
-    output <- readProcessAndLogStderr Notice $ proc "ls" ["-l", "/"]
-    putLog Notice $ "Output was: " <> T.pack output
-    delay
-    callProcessAndLogOutput (Notice, Error) $ proc "ls" ["-l", "/does-not-exist"]
-    delay
-    failWith "Something dangerous happened"
-  where
-    delay = liftIO $ threadDelay 1000000
+import Obelisk.CLI.Types

--- a/lib/command/src/Obelisk/CLI/Demo.hs
+++ b/lib/command/src/Obelisk/CLI/Demo.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Obelisk.CLI.Demo where
+
+import Control.Concurrent (threadDelay)
+import Control.Monad.IO.Class (liftIO)
+import Data.Monoid ((<>))
+import qualified Data.Text as T
+import System.Process (proc)
+
+import Control.Monad.Catch (MonadMask)
+import UnliftIO (MonadUnliftIO)
+
+import Obelisk.CLI
+
+cliDemo
+  :: (MonadUnliftIO m, MonadMask m, Cli m, HasCliConfig m)
+  => m ()
+cliDemo = withSpinner "CLI Demo" $ do
+  putLog Notice "This demo will showcase the CLI library functionality"
+  withSpinner "A long-running task" $ do
+    delay
+    withSpinner "Nested task" $ do
+      delay
+      putLog Notice "In nested task"
+      withSpinner "Inbetween" $ do
+        withSpinner "Runnning something specific" $ do
+          delay
+          putLog Notice "This task has the same name and still works"
+        delay
+      delay
+      putLog Error "Top nested task finished"
+    delay
+    putLog Error "Some user error while spinning"
+    delay
+    putLog Notice "This is some info mesage"
+    putLog Warning "And now a warning as well"
+    delay
+  putLog Notice "Now we start a 2nd spinner, run a couple of process, the last of which fails:"
+  withSpinner "Looking around" $ do
+    delay
+    output <- readProcessAndLogStderr Notice $ proc "ls" ["-l", "/"]
+    putLog Notice $ "Output was: " <> T.pack output
+    delay
+    callProcessAndLogOutput (Notice, Error) $ proc "ls" ["-l", "/does-not-exist"]
+    delay
+    failWith "Something dangerous happened"
+  where
+    delay = liftIO $ threadDelay 1000000

--- a/lib/command/src/Obelisk/CLI/Logging.hs
+++ b/lib/command/src/Obelisk/CLI/Logging.hs
@@ -1,32 +1,20 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Provides a logging handler that facilitates safe ouputting to terminal using MVar based locking.
 -- | Spinner.hs and Process.hs work on this guarantee.
-module Obelisk.CLI.Logging
-  ( Severity (Error, Warning, Notice, Debug)
-  , LoggingConfig (..)
-  , Output (..)
-  , forkML
-  , allowUserToMakeLoggingVerbose
-  , failWith
-  , putLog
-  , putLogRaw
-  , handleLog
-  , getLogLevel
-  , newLoggingConfig
-  , withExitFailMessage
-  ) where
+module Obelisk.CLI.Logging where
 
-import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
-import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar)
+import Control.Concurrent.MVar (modifyMVar_, newMVar)
 import Control.Monad (unless, void, when)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow, bracket, bracket_, catch, throwM)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Loops (iterateUntil)
-import Control.Monad.Reader (MonadIO)
+import Control.Monad.Reader (MonadIO, ReaderT (..))
 import Data.Semigroup ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -36,35 +24,30 @@ import System.Console.ANSI (Color (Red, White, Yellow), ColorIntensity (Vivid),
                             SGR (Reset, SetColor, SetConsoleIntensity), clearLine, setSGR)
 import System.Exit (ExitCode (..), exitWith)
 import System.IO (BufferMode (NoBuffering), hFlush, hReady, hSetBuffering, stdin, stdout)
+import UnliftIO.Concurrent (forkIO, killThread, threadDelay)
 
-import Control.Monad.Log (LoggingT, MonadLog, Severity (..), WithSeverity (..), logMessage, runLoggingT)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef, atomicModifyIORef')
+import Control.Monad.Log (MonadLog, Severity (..), WithSeverity (..), logMessage, runLoggingT)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef, writeIORef)
+import UnliftIO (MonadUnliftIO)
 
-data LoggingConfig = LoggingConfig
-  { _loggingConfig_level :: IORef Severity  -- We are capable of changing the log level at runtime
-  , _loggingConfig_noColor :: Bool  -- Disallow coloured output
-  , _loggingConfig_lock :: MVar Bool  -- Whether the last message was an Overwrite output
-  , _loggingConfig_tipDisplayed :: IORef Bool  -- Whether the user tip (to make verbose) was already displayed
-  , _loggingConfig_stack :: IORef [Text] -- Stack of logs from nested spinners
-  }
+import Obelisk.CLI.Types
 
-newLoggingConfig :: Severity -> Bool -> IO LoggingConfig
-newLoggingConfig sev noColor = do
+newCliConfig :: Severity -> Bool -> Bool -> IO CliConfig
+newCliConfig sev noColor noSpinner = do
   level <- newIORef sev
   lock <- newMVar False
   tipDisplayed <- newIORef False
   stack <- newIORef []
-  return $ LoggingConfig level noColor lock tipDisplayed stack
+  return $ CliConfig level noColor noSpinner lock tipDisplayed stack
+
+runCli :: MonadIO m => CliConfig -> CliT m a -> m a
+runCli c =
+    flip runLoggingT (handleLog c)
+  . flip runReaderT c
+  . unCliT
 
 verboseLogLevel :: Severity
 verboseLogLevel = Debug
-
-data Output
-  = Output_Log (WithSeverity Text)  -- Regular logging message (with colors and newlines)
-  | Output_LogRaw (WithSeverity Text)  -- Like `Output_Log` but without the implicit newline added.
-  | Output_Overwrite [String]  -- Overwrites the current line (i.e. \r followed by `putStr`)
-  | Output_ClearLine  -- Clears the line
-  deriving (Eq, Show, Ord)
 
 isOverwrite :: Output -> Bool
 isOverwrite = \case
@@ -77,17 +60,22 @@ getSeverity = \case
   Output_LogRaw (WithSeverity sev _) -> Just sev
   _ -> Nothing
 
-setLogLevel :: MonadIO m => LoggingConfig -> Severity -> m ()
-setLogLevel conf = liftIO . writeIORef (_loggingConfig_level conf)
+setLogLevel :: (MonadIO m, HasCliConfig m) => Severity -> m ()
+setLogLevel sev = do
+  l <- _cliConfig_logLevel <$> getCliConfig
+  liftIO $ writeIORef l sev
 
-getLogLevel :: MonadIO m => LoggingConfig -> m Severity
-getLogLevel = liftIO . readIORef . _loggingConfig_level
+getLogLevel :: (MonadIO m, HasCliConfig m) => m Severity
+getLogLevel = getLogLevel' =<< getCliConfig
 
-handleLog :: MonadIO m => LoggingConfig -> Output -> m ()
+getLogLevel' :: MonadIO m => CliConfig -> m Severity
+getLogLevel' = liftIO . readIORef . _cliConfig_logLevel
+
+handleLog :: MonadIO m => CliConfig -> Output -> m ()
 handleLog conf output = do
-  level <- getLogLevel conf
-  liftIO $ modifyMVar_ (_loggingConfig_lock conf) $ \wasOverwriting -> do
-    let noColor = _loggingConfig_noColor conf
+  level <- getLogLevel' conf
+  liftIO $ modifyMVar_ (_cliConfig_lock conf) $ \wasOverwriting -> do
+    let noColor = _cliConfig_noColor conf
     case getSeverity output of
       Nothing -> handleLog' noColor output
       Just sev -> if sev > level
@@ -116,21 +104,23 @@ handleLog' noColor output = do
       hFlush stdout
   return $ isOverwrite output
 
--- | Safely log a message to the console. This is what we should use.
-putLog :: MonadLog Output m => Severity -> Text -> m ()
+-- | Log a message to the console.
+--
+-- Logs safely even if there are ongoing spinners.
+putLog :: Cli m => Severity -> Text -> m ()
 putLog sev = logMessage . Output_Log . WithSeverity sev
 
 -- | Like `putLog` but without the implicit newline added.
-putLogRaw :: MonadLog Output m => Severity -> Text -> m ()
+putLogRaw :: Cli m => Severity -> Text -> m ()
 putLogRaw sev = logMessage . Output_LogRaw . WithSeverity sev
 
--- | Like `putLog Error` but also abrupts the program.
-failWith :: (MonadIO m, MonadLog Output m) => Text -> m a
+-- | Like `putLog Alert` but also abrupts the program.
+failWith :: (MonadIO m, Cli m) => Text -> m a
 failWith s = do
   putLog Alert s
   liftIO $ exitWith $ ExitFailure 2
 
--- | Intercepts ExitFailure exceptions and logs the given alert before exiting.
+-- | Intercept ExitFailure exceptions and log the given alert before exiting.
 --
 -- This is useful when you want to provide contextual information to a deeper failure.
 withExitFailMessage :: (MonadIO m, MonadLog Output m, MonadCatch m, MonadThrow m) => Text -> m a -> m a
@@ -154,31 +144,28 @@ writeLogWith f noColor (WithSeverity severity s)
     put sgr = liftIO $ bracket_ (setSGR sgr) reset $ T.putStr s
 
 -- | Allow the user to immediately switch to verbose logging upon pressing a particular key.
+--
+-- Call this function in a thread, and kill it to turn off keystroke monitoring.
 allowUserToMakeLoggingVerbose
-  :: (MonadIO m, MonadMask m, MonadLog Output m)
-  => LoggingConfig
-  -> String  -- ^ The key to press in order to make logging verbose
+  :: (MonadUnliftIO m, MonadMask m, Cli m, HasCliConfig m)
+  => String  -- ^ The key to press in order to make logging verbose
   -> m ()
-allowUserToMakeLoggingVerbose conf keyCode = bracket showTip (liftIO . killThread) $ \_ -> do
+allowUserToMakeLoggingVerbose keyCode = bracket showTip (liftIO . killThread) $ \_ -> do
   unlessVerbose $ do
     liftIO $ hSetBuffering stdin NoBuffering
     _ <- iterateUntil (== keyCode) $ liftIO getChars
-    putLog Warning $ "Ctrl+e pressed; making output verbose (-v)"
-    setLogLevel conf verboseLogLevel
+    putLog Warning "Ctrl+e pressed; making output verbose (-v)"
+    setLogLevel verboseLogLevel
   where
-    showTip = forkML conf $ unlessVerbose $ do
+    showTip = forkIO $ unlessVerbose $ do
+      conf <- getCliConfig
       liftIO $ threadDelay $ 3*1000000  -- Only show tip for actions taking too long (3 seconds or more)
-      tipDisplayed <- liftIO $ atomicModifyIORef' (_loggingConfig_tipDisplayed conf) $ (,) True
+      tipDisplayed <- liftIO $ atomicModifyIORef' (_cliConfig_tipDisplayed conf) $ (,) True
       unless tipDisplayed $ unlessVerbose $ do -- Check again in case the user had pressed Ctrl+e recently
-        putLog Notice $ "Tip: Press Ctrl+e to display full output"
+        putLog Notice "Tip: Press Ctrl+e to display full output"
     unlessVerbose f = do
-      l <- getLogLevel conf
+      l <- getLogLevel
       unless (l == verboseLogLevel) f
-
--- | Like `forkIO` but using MonadLog
--- TODO: Can we obviate passing LoggingConfig just to use forkIO?
-forkML :: (MonadIO m, MonadLog Output m) => LoggingConfig -> LoggingT Output IO () -> m ThreadId
-forkML conf = liftIO . forkIO . flip runLoggingT (handleLog conf)
 
 -- | Like `getChar` but also retrieves the subsequently pressed keys.
 --
@@ -190,5 +177,5 @@ getChars = reverse <$> f mempty
     f xs = do
       x <- getChar
       hReady stdin >>= \case
-        True -> f (x:xs )
+        True -> f (x:xs)
         False -> return (x:xs)

--- a/lib/command/src/Obelisk/CLI/Process.hs
+++ b/lib/command/src/Obelisk/CLI/Process.hs
@@ -19,7 +19,6 @@ import Control.Applicative (liftA2)
 import Control.Monad (void, (<=<))
 import Control.Monad.Catch (MonadMask)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Log (MonadLog)
 import Control.Monad.Reader (MonadIO)
 import qualified Data.ByteString.Char8 as BSC
 import Data.Function (fix)
@@ -32,15 +31,18 @@ import System.IO (Handle)
 import System.IO.Streams (InputStream, handleToInputStream)
 import qualified System.IO.Streams as Streams
 import System.IO.Streams.Concurrent (concurrentMerge)
-import System.Process (CreateProcess, ProcessHandle, StdStream (CreatePipe), cmdspec, std_err, std_out,
-                       waitForProcess)
-import qualified System.Process as Process
+import UnliftIO (MonadUnliftIO)
+import UnliftIO.Process (CreateProcess, ProcessHandle, StdStream (CreatePipe), cmdspec, std_err, std_out,
+                         waitForProcess)
+import qualified UnliftIO.Process as Process
 
-import Obelisk.CLI.Logging (Output, Severity (..), failWith, putLog, putLogRaw)
+import Control.Monad.Log (Severity (..))
+import Obelisk.CLI.Logging (failWith, putLog, putLogRaw)
+import Obelisk.CLI.Types (Cli)
 
 -- | Like `System.Process.readProcess` but logs the stderr instead of letting the external process inherit it.
 readProcessAndLogStderr
-  :: (MonadIO m, MonadMask m, MonadLog Output m)
+  :: (MonadUnliftIO m, MonadMask m, Cli m)
   => Severity -> CreateProcess -> m String
 readProcessAndLogStderr sev process = do
   (out, _err) <- withProcess process $ \_out err -> do
@@ -55,7 +57,7 @@ readProcessAndLogStderr sev process = do
 -- are known to spit out diagnostic or informative messages in stderr, in which case it is advisable to call
 -- it with a non-Error severity for stderr, like `callProcessAndLogOutput (Debug, Debug)`.
 callProcessAndLogOutput
-  :: (MonadIO m, MonadMask m, MonadLog Output m)
+  :: (MonadUnliftIO m, MonadMask m, Cli m)
   => (Severity, Severity) -> CreateProcess -> m ()
 callProcessAndLogOutput (sev_out, sev_err) process = do
   void $ withProcess process $ \out err -> do
@@ -67,37 +69,38 @@ callProcessAndLogOutput (sev_out, sev_err) process = do
 
 -- | Like `System.Process.createProcess` but also logs (debug) the process being run
 createProcess
-  :: (MonadIO m, MonadLog Output m)
+  :: (MonadUnliftIO m, Cli m)
   => CreateProcess -> m (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
 createProcess p = do
   putLog Debug $ "Creating process: " <> T.pack (show p)
-  liftIO $ Process.createProcess p
+  Process.createProcess p
 
 -- | Like `System.Process.createProcess_` but also logs (debug) the process being run
 createProcess_
-  :: (MonadIO m, MonadLog Output m)
+  :: (MonadUnliftIO m, Cli m)
   => String -> CreateProcess -> m (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
 createProcess_ name p = do
   putLog Debug $ "Creating process " <> T.pack name <> ": " <> T.pack (show p)
-  liftIO $ Process.createProcess p
-
+  Process.createProcess p
 
 withProcess
-  :: (MonadIO m, MonadMask m, MonadLog Output m)
+  :: (MonadUnliftIO m, MonadMask m, Cli m)
   => CreateProcess -> (Handle -> Handle -> m ()) -> m (Handle, Handle)
-withProcess process f = do
+withProcess process f = do -- TODO: Use bracket.
   let procTitle = T.pack $ show $ cmdspec process
+  -- FIXME: Using `withCreateProcess` here leads to something operating illegally on closed handles.
   (_, Just out, Just err, p) <- createProcess $ process
-    { std_out = CreatePipe
-    , std_err = CreatePipe
-    }
+    { std_out = CreatePipe , std_err = CreatePipe }
+
   f out err  -- Pass the handles to the passed function
-  liftIO (waitForProcess p) >>= \case
+
+  waitForProcess p >>= \case
     ExitSuccess -> return ()
     ExitFailure code -> do
       -- Log an error. We also fail immediately; however we should probably let the caller control that.
       failWith $ procTitle <> " failed with exit code: " <> T.pack (show code)
   return (out, err)  -- Return the handles
+
 
 -- Create an input stream from the file handle, associating each item with the given severity.
 streamHandle :: Severity -> Handle -> IO (InputStream (Severity, BSC.ByteString))
@@ -105,7 +108,7 @@ streamHandle sev = Streams.map (sev,) <=< handleToInputStream
 
 -- | Read from an input stream and log its contents
 streamToLog
-  :: (MonadIO m, MonadMask m, MonadLog Output m)
+  :: (MonadIO m, MonadMask m, Cli m)
   => InputStream (Severity, BSC.ByteString) -> m ()
 streamToLog stream = fix $ \loop -> do
   liftIO (Streams.read stream) >>= \case

--- a/lib/command/src/Obelisk/CLI/Types.hs
+++ b/lib/command/src/Obelisk/CLI/Types.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+module Obelisk.CLI.Types where
+
+import Control.Concurrent.MVar (MVar)
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Control.Monad.Log (LoggingT (LoggingT), MonadLog, Severity (..), WithSeverity (..), runLoggingT)
+import Control.Monad.Reader (MonadIO, ReaderT (..), ask)
+import Data.IORef (IORef)
+import Data.Text (Text)
+import UnliftIO (MonadUnliftIO, UnliftIO (..), askUnliftIO, withUnliftIO)
+
+
+data CliConfig = CliConfig
+  { _cliConfig_logLevel :: IORef Severity  -- We are capable of changing the log level at runtime
+  , _cliConfig_noColor :: Bool  -- Disallow coloured output
+  , _cliConfig_noSpinner :: Bool  -- Disallow spinners
+  , _cliConfig_lock :: MVar Bool  -- Whether the last message was an Overwrite output
+  , _cliConfig_tipDisplayed :: IORef Bool  -- Whether the user tip (to make verbose) was already displayed
+  , _cliConfig_spinnerStack :: IORef [Text] -- Stack of logs from nested spinners
+  }
+
+data Output
+  = Output_Log (WithSeverity Text)  -- Regular logging message (with colors and newlines)
+  | Output_LogRaw (WithSeverity Text)  -- Like `Output_Log` but without the implicit newline added.
+  | Output_Overwrite [String]  -- Overwrites the current line (i.e. \r followed by `putStr`)
+  | Output_ClearLine  -- Clears the line
+  deriving (Eq, Show, Ord)
+
+type Cli m = MonadLog Output m
+
+newtype CliT m a = CliT
+  { unCliT :: ReaderT CliConfig (LoggingT Output m) a
+  }
+  deriving
+    ( Functor, Applicative, Monad, MonadIO
+    , MonadThrow, MonadCatch, MonadMask
+    , MonadLog Output
+    )
+
+class Monad m => HasCliConfig m where
+  getCliConfig :: m CliConfig
+
+instance Monad m => HasCliConfig (CliT m) where
+  getCliConfig = CliT ask
+
+instance MonadUnliftIO m => MonadUnliftIO (LoggingT Output m) where
+  askUnliftIO = LoggingT $ ReaderT $ \f ->
+    withUnliftIO $ \u ->
+      return (UnliftIO (unliftIO u . flip runLoggingT f))
+
+instance MonadUnliftIO m => MonadUnliftIO (CliT m) where
+  askUnliftIO = CliT $ withUnliftIO $ \u ->
+    return (UnliftIO (unliftIO u . unCliT))

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -9,7 +9,6 @@ module Obelisk.Command where
 
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader (ask)
 import qualified Data.Binary as Binary
 import Data.Bool (bool)
 import qualified Data.ByteString.Base16 as Base16
@@ -29,12 +28,14 @@ import System.Posix.Process (executeFile)
 import System.Process (callCommand)
 
 import Obelisk.App
-import Obelisk.CLI (Severity (..), cliDemo, failWith, getLogLevel, newLoggingConfig, putLog)
+import Obelisk.CLI (Severity (..), failWith, getLogLevel, newCliConfig, putLog)
+import Obelisk.CLI.Demo (cliDemo)
 import Obelisk.Command.Deploy
 import Obelisk.Command.Project
 import Obelisk.Command.Repl
 import Obelisk.Command.Run
 import Obelisk.Command.Thunk
+
 
 data Args = Args
   { _args_noHandOffPassed :: Bool
@@ -220,8 +221,8 @@ mkObeliskConfig :: IO Obelisk
 mkObeliskConfig = do
   notInteractive <- not <$> isInteractiveTerm
   logLevel <- toLogLevel <$> getObArgs
-  loggingConfig <- newLoggingConfig logLevel notInteractive
-  return $ Obelisk notInteractive loggingConfig
+  cliConf <- newCliConfig logLevel notInteractive notInteractive
+  return $ Obelisk cliConf
   where
     toLogLevel = bool Notice Debug . _args_verbose
 
@@ -233,14 +234,12 @@ main = mkObeliskConfig >>= (`runObelisk` ObeliskT main')
 
 main' :: MonadObelisk m => m ()
 main' = do
-  c <- ask
   obPath <- liftIO getExecutablePath
   obArgs <- liftIO getObArgs
-  logLevel <- liftIO $ getLogLevel $ _obelisk_logging c
+  logLevel <- getLogLevel
   putLog Debug $ T.pack $ unwords
     [ "Starting Obelisk <" <> obPath <> ">"
     , "args=" <> show obArgs
-    , "noSpinner=" <> show (_obelisk_noSpinner c)
     , "logging-level=" <> show logLevel
     ]
 
@@ -313,7 +312,7 @@ ob = \case
     ObInternal_RunStaticIO k -> liftIO (unsafeLookupStaticPtr @(ObeliskT IO ()) k) >>= \case
       Nothing -> failWith $ "ObInternal_RunStaticIO: no such StaticKey: " <> T.pack (show k)
       Just p -> do
-        c <- ask
+        c <- getObelisk
         liftIO $ runObelisk c $ deRefStaticPtr p
     ObInternal_CLIDemo -> cliDemo
 

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -1,31 +1,31 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Obelisk.Command.Run where
 
 import qualified Control.Exception as E
 import Control.Monad
+import Control.Monad.IO.Class (liftIO)
 import Data.Either
 import Data.List
-import Control.Monad.Reader (ask)
+import Data.List.NonEmpty as NE
 import Data.Maybe
-import Control.Monad.IO.Class (liftIO)
 import Data.Monoid
 import qualified Data.Text as T
-import Data.List.NonEmpty as NE
-import Distribution.Utils.Generic (withUTF8FileContents)
-import Distribution.PackageDescription.Parse (parseGenericPackageDescription, ParseResult(..))
+import Distribution.PackageDescription.Parse (ParseResult (..), parseGenericPackageDescription)
 import Distribution.Types.BuildInfo
 import Distribution.Types.CondTree
-import Distribution.Types.Library
 import Distribution.Types.GenericPackageDescription
+import Distribution.Types.Library
+import Distribution.Utils.Generic (withUTF8FileContents)
 import Network.Socket
 import System.Directory
 import System.FilePath
 import System.IO.Temp (withSystemTempDirectory)
 import System.Process (callCommand)
+import UnliftIO (MonadUnliftIO, withRunInIO)
 
-import Obelisk.App (MonadObelisk, ObeliskT, runObelisk)
-import Obelisk.CLI (putLog, failWith, Severity(..))
+import Obelisk.App (MonadObelisk, ObeliskT)
+import Obelisk.CLI (Severity (..), failWith, putLog)
 
 -- NOTE: `run` is not polymorphic like the rest because we use StaticPtr to invoke it.
 run :: ObeliskT IO ()
@@ -60,25 +60,28 @@ getLocalPkgs :: IO [FilePath]
 getLocalPkgs = return ["backend", "common", "frontend"]
 
 parseHsSrcDir
-  :: MonadObelisk m
+  :: (MonadObelisk m)
   => FilePath -- ^ package cabal file path
   -> m (Maybe (NE.NonEmpty FilePath)) -- ^ List of hs src dirs of the library component
 parseHsSrcDir cabalFp = do
   exists <- liftIO $ doesFileExist cabalFp
   if exists
     then do
-      c <- ask
-      liftIO $ withUTF8FileContents cabalFp $ \cabal -> runObelisk c $ do
-      case parseGenericPackageDescription cabal of
-        ParseOk warnings gpkg -> do
-          mapM_ (putLog Warning) $ fmap (T.pack . show) warnings
-          return $ do
-            (_, lib) <- simplifyCondTree (const $ pure True) <$> condLibrary gpkg
-            pure $ fromMaybe (pure ".") $ NE.nonEmpty $ hsSourceDirs $ libBuildInfo lib
-        ParseFailed e -> do 
-          putLog Error $ T.pack $ "Failed to parse cabal file: " <> show e
-          return Nothing
+      withUTF8FileContentsM cabalFp $ \cabal -> do
+        case parseGenericPackageDescription cabal of
+          ParseOk warnings gpkg -> do
+            mapM_ (putLog Warning) $ fmap (T.pack . show) warnings
+            return $ do
+              (_, lib) <- simplifyCondTree (const $ pure True) <$> condLibrary gpkg
+              pure $ fromMaybe (pure ".") $ NE.nonEmpty $ hsSourceDirs $ libBuildInfo lib
+          ParseFailed e -> do
+            putLog Error $ T.pack $ "Failed to parse cabal file: " <> show e
+            return Nothing
     else return Nothing
+
+withUTF8FileContentsM :: MonadUnliftIO m => FilePath -> (String -> m a) -> m a
+withUTF8FileContentsM fp f = withRunInIO $ \runInIO ->
+  withUTF8FileContents fp $ runInIO . f
 
 -- | Dev
 runDev :: FilePath -> Maybe String -> IO ()


### PR DESCRIPTION
**Changes**

- Replace `MonadReader` with the Has pattern
- Start using the `unliftio` library

**Benefits**:

- Obelisk developers do not need to know the internals of the CLI library (eg: `MonadLog Output m`). A simplified interface is exposed (see below). See `Demo.hs` for example use, and `App.hs` for integrating with the app transformer stack.

- `with*` family of IO functions can now be used in MonadIO without having to extract and manually pass around config ([see explanation](https://github.com/fpco/unliftio#unlifting-in-2-minutes)). This is the primary reason for using `unliftio` (this doesn't impact our use of existing libraries or their interfaces, such as `MonadMask`). A `MonadUnliftIO` constraint is added to `MonadObelisk` - that's about it.

**Note to Obelisk dev**:

- Import `Obelisk.CLI` and use the functions exported (see below). No need to look at the internal modules. 
```haskell
module Obelisk.CLI
  (
  -- .Types
    Cli
  , CliT
  , runCli
  , CliConfig
  , HasCliConfig
  , getCliConfig

  -- .Spinner
  , withSpinner

  -- .Logging
  , newCliConfig
  , getLogLevel
  , putLog
  , failWith

  -- Control.Monad.Log
  , Severity (..)

  -- .Process
  , readProcessAndLogStderr
  , callProcessAndLogOutput
  , createProcess_
  ) where
```