### PR TITLE
Add custom routes to backend config

### DIFF
--- a/skeleton/backend/backend.cabal
+++ b/skeleton/backend/backend.cabal
@@ -8,9 +8,11 @@ library
   if impl(ghcjs)
     buildable: False
   build-depends: base
+               , bytestring
                , common
                , frontend
                , obelisk-backend
+               , snap
   exposed-modules:
     Backend
   ghc-options: -Wall
@@ -22,6 +24,7 @@ executable backend
     buildable: False
   build-depends: base
                , backend
+               , bytestring
                , common
                , frontend
                , lens
@@ -29,4 +32,5 @@ executable backend
                , obelisk-backend
                , obelisk-executable-config
                , obelisk-executable-config-inject
+               , snap
                , text

--- a/skeleton/backend/src/Backend.hs
+++ b/skeleton/backend/src/Backend.hs
@@ -1,10 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Backend where
 
-import Common.Api
-import Frontend
+import qualified Data.ByteString.Char8 as BSC
+
 import qualified Obelisk.Backend as Ob
+import Snap (Snap, writeBS)
+
+import Common.Api (commonStuff)
+import Frontend (frontend)
 
 backend :: IO ()
-backend = Ob.backend Ob.def
+backend = Ob.backend $ Ob.def
   { Ob._backendConfig_head = fst frontend
+  , Ob._backendConfig_routes =
+      [ ("/api", someApi)
+      ]
   }
+
+someApi :: Snap ()
+someApi = do
+  writeBS $ BSC.pack commonStuff


### PR DESCRIPTION
Example:

```haskell
backend :: IO ()
backend = Ob.backend $ Ob.def
  { Ob._backendConfig_head = fst frontend
  , Ob._backendConfig_routes =
      [ ("/api", someApi)
      ]
  }

someApi :: Snap ()
someApi = do
  writeBS $ BSC.pack commonStuff
```