### PR TITLE
Fix overflowing spinners

### DIFF
--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -33,6 +33,7 @@ library
     , placeholders
     , process
     , temporary
+    , terminal-size
     , text
     , time
     , transformers
@@ -53,6 +54,7 @@ library
     Obelisk.CLI.Logging
     Obelisk.CLI.Process
     Obelisk.CLI.Spinner
+    Obelisk.CLI.TerminalString
     Obelisk.CLI.Types
   -- -fobject-code is so that the StaticPointers extension can work in ghci
   ghc-options: -Wall -fobject-code

--- a/lib/command/src/Obelisk/CLI/TerminalString.hs
+++ b/lib/command/src/Obelisk/CLI/TerminalString.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- | Types and functions dealing with strings to be printed on terminal.
+module Obelisk.CLI.TerminalString
+  ( TerminalString(..)
+  , render
+  , putStrWithSGR
+  , getTerminalWidth
+  , enquiryCode
+  ) where
+
+import Control.Monad (when)
+import Control.Monad.Catch (bracket_)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (MonadIO)
+import Data.Semigroup ((<>))
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import System.Console.ANSI (Color, ColorIntensity (Vivid), ConsoleLayer (Foreground), SGR (Reset, SetColor),
+                            SGR, setSGR, setSGRCode)
+import qualified System.Console.Terminal.Size as TerminalSize
+
+-- | Printable text on terminals
+--
+-- Represents text with an optional color code.
+data TerminalString
+  = TerminalString_Normal Text
+  | TerminalString_Colorized Color Text
+  deriving (Eq, Show, Ord)
+
+printableLength :: [TerminalString] -> Int
+printableLength = T.length . toText False
+
+-- Render a list of TerminalString as Text that can be directly putStr'ed.
+render
+  :: Bool -- ^ with color
+  -> Maybe Int -- ^ optionally, trim to maximum width
+  -> [TerminalString]
+  -> Text
+render withColor w ts = trim w $ toText withColor ts
+  where
+    trim = \case
+      Nothing -> id
+      Just n -> \s -> if printableLength ts > n
+        then T.take (n-3) s <> "..." <> T.pack resetCode
+        else s
+
+toText :: Bool -> [TerminalString] -> Text
+toText withColor = mconcat . map (toText' withColor)
+
+-- | Convert to Text, controlling whether colorization should happen.
+toText' :: Bool -> TerminalString -> Text
+toText' withColor = \case
+  TerminalString_Normal s -> s
+  TerminalString_Colorized c s -> if withColor then colorizeText c s else s
+
+-- | Colorize the given text so that it is printed in color when using putStr.
+colorizeText :: Color -> Text -> Text
+colorizeText color s = mconcat
+  [ T.pack $ setSGRCode [SetColor Foreground Vivid color]
+  , s
+  , T.pack resetCode
+  ]
+
+-- | Safely print the string with the given ANSI control codes, resetting in the end.
+putStrWithSGR :: MonadIO m => [SGR] -> Bool -> Text -> m ()
+putStrWithSGR sgr withNewLine s = liftIO $ bracket_ (setSGR sgr) reset $ T.putStr s
+  where
+    reset = setSGR [Reset] >> newline -- New line should come *after* reset (to reset cursor color).
+    newline = when withNewLine $ T.putStrLn ""
+
+-- | Code for https://en.wikipedia.org/wiki/Enquiry_character
+enquiryCode :: String
+enquiryCode = "\ENQ"
+
+-- | Code to reset ANSI colors
+resetCode :: String
+resetCode = setSGRCode [Reset]
+
+getTerminalWidth :: IO (Maybe Int)
+getTerminalWidth = fmap TerminalSize.width <$> TerminalSize.size
+

--- a/lib/command/src/Obelisk/CLI/Types.hs
+++ b/lib/command/src/Obelisk/CLI/Types.hs
@@ -12,20 +12,23 @@ import Control.Monad.Reader (MonadIO, ReaderT (..), ask)
 import Data.IORef (IORef)
 import Data.Text (Text)
 
+import Obelisk.CLI.TerminalString (TerminalString)
+
 data CliConfig = CliConfig
   { _cliConfig_logLevel :: IORef Severity  -- We are capable of changing the log level at runtime
   , _cliConfig_noColor :: Bool  -- Disallow coloured output
   , _cliConfig_noSpinner :: Bool  -- Disallow spinners
   , _cliConfig_lock :: MVar Bool  -- Whether the last message was an Overwrite output
   , _cliConfig_tipDisplayed :: IORef Bool  -- Whether the user tip (to make verbose) was already displayed
-  , _cliConfig_spinnerStack :: IORef [Text] -- Stack of logs from nested spinners
+  , _cliConfig_spinnerStack :: IORef [TerminalString] -- Stack of logs from nested spinners
   }
 
 data Output
   = Output_Log (WithSeverity Text)  -- Regular logging message (with colors and newlines)
   | Output_LogRaw (WithSeverity Text)  -- Like `Output_Log` but without the implicit newline added.
-  | Output_Overwrite [String]  -- Overwrites the current line (i.e. \r followed by `putStr`)
-  | Output_ClearLine  -- Clears the line
+  | Output_Write [TerminalString]  -- Render and write a TerminalString using putstrLn
+  | Output_Overwrite [TerminalString]  -- Overwrite the current line (i.e. \r followed by `putStr`)
+  | Output_ClearLine  -- Clear the line
   deriving (Eq, Show, Ord)
 
 type Cli m = MonadLog Output m


### PR DESCRIPTION
Fixes #23 

This turned out to be a little more involved that I had thought. To count the actual printable width of a spinner line, we need to use a new type that distinguishes between regular text and non-printable terminal codes.