### PR TITLE
Add VM builder support using Docker

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,105 +8,105 @@ let
   inherit (reflex-platform) hackGet;
   pkgs = reflex-platform.nixpkgs;
 in with pkgs.haskell.lib; with pkgs.lib;
-let #TODO: Upstream
-    # Modify a Haskell package to add completion scripts for the given
-    # executable produced by it.  These completion scripts will be picked up
-    # automatically if the resulting derivation is installed, e.g. by
-    # `nix-env -i`.
+let
+  # TODO: Remove this after updating nixpkgs: https://github.com/NixOS/nixpkgs/issues/37750
+  justStaticExecutables' = drv: let
+      drv' = justStaticExecutables drv;
+    in if pkgs.stdenv.isDarwin
+      then removeConfigureFlag drv' "--ghc-option=-optl=-dead_strip"
+      else drv';
 
-    # TODO: Remove this after updating nixpkgs: https://github.com/NixOS/nixpkgs/issues/37750
-    justStaticExecutables' = drv: let
-        drv' = justStaticExecutables drv;
-      in if pkgs.stdenv.isDarwin
-        then removeConfigureFlag drv' "--ghc-option=-optl=-dead_strip"
-        else drv';
+  #TODO: Upstream
+  # Modify a Haskell package to add completion scripts for the given
+  # executable produced by it.  These completion scripts will be picked up
+  # automatically if the resulting derivation is installed, e.g. by
+  # `nix-env -i`.
+  addOptparseApplicativeCompletionScripts = exeName: pkg: overrideCabal pkg (drv: {
+    postInstall = (drv.postInstall or "") + ''
+      BASH_COMP_DIR="$out/share/bash-completion/completions"
+      mkdir -p "$BASH_COMP_DIR"
+      "$out/bin/${exeName}" --bash-completion-script "$out/bin/${exeName}" >"$BASH_COMP_DIR/ob"
 
-    addOptparseApplicativeCompletionScripts = exeName: pkg: overrideCabal pkg (drv: {
-      postInstall = (drv.postInstall or "") + ''
-        BASH_COMP_DIR="$out/share/bash-completion/completions"
-        mkdir -p "$BASH_COMP_DIR"
-        "$out/bin/${exeName}" --bash-completion-script "$out/bin/${exeName}" >"$BASH_COMP_DIR/ob"
+      ZSH_COMP_DIR="$out/share/zsh/vendor-completions"
+      mkdir -p "$ZSH_COMP_DIR"
+      "$out/bin/${exeName}" --zsh-completion-script "$out/bin/${exeName}" >"$ZSH_COMP_DIR/_ob"
 
-        ZSH_COMP_DIR="$out/share/zsh/vendor-completions"
-        mkdir -p "$ZSH_COMP_DIR"
-        "$out/bin/${exeName}" --zsh-completion-script "$out/bin/${exeName}" >"$ZSH_COMP_DIR/_ob"
+      FISH_COMP_DIR="$out/share/fish/vendor_completions.d"
+      mkdir -p "$FISH_COMP_DIR"
+      "$out/bin/${exeName}" --fish-completion-script "$out/bin/${exeName}" >"$FISH_COMP_DIR/ob.fish"
+    '';
+  });
 
-        FISH_COMP_DIR="$out/share/fish/vendor_completions.d"
-        mkdir -p "$FISH_COMP_DIR"
-        "$out/bin/${exeName}" --fish-completion-script "$out/bin/${exeName}" >"$FISH_COMP_DIR/ob.fish"
-      '';
-    });
-
-    # The haskell environment used to build Obelisk itself, e.g. the 'ob' command
-    ghcObelisk = reflex-platform.ghc.override {
-      overrides = composeExtensions defaultHaskellOverrides (self: super: {
-        mkDerivation = args: super.mkDerivation (args // {
-          enableLibraryProfiling = profiling;
-        });
-
-        #TODO: Eliminate this when https://github.com/phadej/github/pull/307 makes its way to reflex-platform
-        github = overrideCabal super.github (drv: {
-          src = pkgs.fetchFromGitHub {
-            owner = "ryantrinkle";
-            repo = "github";
-            rev = "8f543cdc07876bfb7b924d3722e3dbc1df4b02ca";
-            sha256 = "0vcnx9cxqd821kmjx1r4cvj95zs742qm1pwqnb52vw3djplbqd86";
-          };
-          sha256 = null;
-          revision = null;
-          editedCabalFile = null;
-        });
-
-        # Dynamic linking with split objects dramatically increases startup time (about 0.5 seconds on a decent machine with SSD)
-        obelisk-command = addOptparseApplicativeCompletionScripts "ob" (justStaticExecutables' super.obelisk-command);
-
-        optparse-applicative = self.callHackage "optparse-applicative" "0.14.0.0" {};
+  # The haskell environment used to build Obelisk itself, e.g. the 'ob' command
+  ghcObelisk = reflex-platform.ghc.override {
+    overrides = composeExtensions defaultHaskellOverrides (self: super: {
+      mkDerivation = args: super.mkDerivation (args // {
+        enableLibraryProfiling = profiling;
       });
-    };
 
-    fixUpstreamPkgs = self: super: {
-      heist = doJailbreak super.heist; #TODO: Move up to reflex-platform; create tests for r-p supported packages
-      modern-uri =
-        let src = pkgs.fetchFromGitHub {
-              owner = "mrkkrp";
-              repo = "modern-uri";
-              rev = "21064285deb284cb3328094c69c34f9f67919cc9";
-              sha256 = "0vddw8r9sb31h1fz1anzxrs9p3a3p8ygpxlj398z5j47wmr86cmi";
-            };
-        in (overrideCabal (self.callCabal2nix "modern-uri" src {}) (drv: {
-             doCheck = false;
-             postPatch = (drv.postPatch or "") + ''
-               substituteInPlace Text/URI/Types.hs \
-                 --replace "instance Arbitrary (NonEmpty (RText 'PathPiece)) where" "" \
-                 --replace "  arbitrary = (:|) <$> arbitrary <*> arbitrary" ""
-             '';
-           })).override { megaparsec = super.megaparsec_6_1_1; };
-      network-transport = self.callHackage "network-transport" "0.5.2" {};
-      network-transport-tcp = self.callHackage "network-transport-tcp" "0.6.0" {};
-    };
+      #TODO: Eliminate this when https://github.com/phadej/github/pull/307 makes its way to reflex-platform
+      github = overrideCabal super.github (drv: {
+        src = pkgs.fetchFromGitHub {
+          owner = "ryantrinkle";
+          repo = "github";
+          rev = "8f543cdc07876bfb7b924d3722e3dbc1df4b02ca";
+          sha256 = "0vcnx9cxqd821kmjx1r4cvj95zs742qm1pwqnb52vw3djplbqd86";
+        };
+        sha256 = null;
+        revision = null;
+        editedCabalFile = null;
+      });
 
-    cleanSource = builtins.filterSource (name: _: let baseName = builtins.baseNameOf name; in !(
-      builtins.match "^\\.ghc\\.environment.*" baseName != null ||
-      baseName == "cabal.project.local"
-    ));
+      # Dynamic linking with split objects dramatically increases startup time (about 0.5 seconds on a decent machine with SSD)
+      obelisk-command = addOptparseApplicativeCompletionScripts "ob" (justStaticExecutables' super.obelisk-command);
 
-    executableConfig = import ./lib/executable-config { nixpkgs = pkgs; filterGitSource = cleanSource; };
+      optparse-applicative = self.callHackage "optparse-applicative" "0.14.0.0" {};
+    });
+  };
 
-    addLibs = self: super: {
-      obelisk-asset-manifest = self.callCabal2nix "obelisk-asset-manifest" (hackGet ./lib/asset + "/manifest") {};
-      obelisk-asset-serve-snap = self.callCabal2nix "obelisk-asset-serve-snap" (hackGet ./lib/asset + "/serve-snap") {};
-      obelisk-cliapp = self.callCabal2nix "obelisk-cliapp" (cleanSource ./lib/cliapp) {};
-      obelisk-backend = self.callCabal2nix "obelisk-backend" (cleanSource ./lib/backend) {};
-      obelisk-command = (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}).override { Cabal = super.Cabal_2_0_0_2; };
-      obelisk-executable-config = executableConfig.haskellPackage self;
-      obelisk-executable-config-inject = executableConfig.platforms.web.inject self; # TODO handle platforms.{ios,android}
-      obelisk-run = self.callCabal2nix "obelisk-run" (cleanSource ./lib/run) {};
-      obelisk-selftest = self.callCabal2nix "obelisk-selftest" (cleanSource ./lib/selftest) {};
-      obelisk-snap = self.callCabal2nix "obelisk-snap" (cleanSource ./lib/snap) {};
-      obelisk-snap-extras = self.callCabal2nix "obelisk-snap-extras" (cleanSource ./lib/snap-extras) {};
-    };
+  fixUpstreamPkgs = self: super: {
+    heist = doJailbreak super.heist; #TODO: Move up to reflex-platform; create tests for r-p supported packages
+    modern-uri =
+      let src = pkgs.fetchFromGitHub {
+            owner = "mrkkrp";
+            repo = "modern-uri";
+            rev = "21064285deb284cb3328094c69c34f9f67919cc9";
+            sha256 = "0vddw8r9sb31h1fz1anzxrs9p3a3p8ygpxlj398z5j47wmr86cmi";
+          };
+      in (overrideCabal (self.callCabal2nix "modern-uri" src {}) (drv: {
+            doCheck = false;
+            postPatch = (drv.postPatch or "") + ''
+              substituteInPlace Text/URI/Types.hs \
+                --replace "instance Arbitrary (NonEmpty (RText 'PathPiece)) where" "" \
+                --replace "  arbitrary = (:|) <$> arbitrary <*> arbitrary" ""
+            '';
+          })).override { megaparsec = super.megaparsec_6_1_1; };
+    network-transport = self.callHackage "network-transport" "0.5.2" {};
+    network-transport-tcp = self.callHackage "network-transport-tcp" "0.6.0" {};
+  };
 
-    defaultHaskellOverrides = composeExtensions fixUpstreamPkgs addLibs;
+  cleanSource = builtins.filterSource (name: _: let baseName = builtins.baseNameOf name; in !(
+    builtins.match "^\\.ghc\\.environment.*" baseName != null ||
+    baseName == "cabal.project.local"
+  ));
+
+  executableConfig = import ./lib/executable-config { nixpkgs = pkgs; filterGitSource = cleanSource; };
+
+  addLibs = self: super: {
+    obelisk-asset-manifest = self.callCabal2nix "obelisk-asset-manifest" (hackGet ./lib/asset + "/manifest") {};
+    obelisk-asset-serve-snap = self.callCabal2nix "obelisk-asset-serve-snap" (hackGet ./lib/asset + "/serve-snap") {};
+    obelisk-cliapp = self.callCabal2nix "obelisk-cliapp" (cleanSource ./lib/cliapp) {};
+    obelisk-backend = self.callCabal2nix "obelisk-backend" (cleanSource ./lib/backend) {};
+    obelisk-command = (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}).override { Cabal = super.Cabal_2_0_0_2; };
+    obelisk-executable-config = executableConfig.haskellPackage self;
+    obelisk-executable-config-inject = executableConfig.platforms.web.inject self; # TODO handle platforms.{ios,android}
+    obelisk-run = self.callCabal2nix "obelisk-run" (cleanSource ./lib/run) {};
+    obelisk-selftest = self.callCabal2nix "obelisk-selftest" (cleanSource ./lib/selftest) {};
+    obelisk-snap = self.callCabal2nix "obelisk-snap" (cleanSource ./lib/snap) {};
+    obelisk-snap-extras = self.callCabal2nix "obelisk-snap-extras" (cleanSource ./lib/snap-extras) {};
+  };
+
+  defaultHaskellOverrides = composeExtensions fixUpstreamPkgs addLibs;
 in
 with pkgs.lib;
 rec {

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -10,7 +10,6 @@ library
     , ansi-terminal
     , Cabal
     , aeson-pretty
-    , attoparsec
     , base
     , base16-bytestring
     , binary

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -22,6 +22,7 @@ library
     , either
     , filepath
     , github
+    , here
     , hit
     , io-streams
     , exceptions
@@ -49,6 +50,7 @@ library
     Obelisk.Command.Run
     Obelisk.Command.Thunk
     Obelisk.Command.Utils
+    Obelisk.Command.VmBuilder
   -- -fobject-code is so that the StaticPointers extension can work in ghci
   ghc-options: -Wall -fobject-code
 

--- a/lib/command/src/Obelisk/App.hs
+++ b/lib/command/src/Obelisk/App.hs
@@ -10,6 +10,7 @@ module Obelisk.App where
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Reader (MonadIO, ReaderT (..), ask, runReaderT)
 import Control.Monad.Trans.Class (lift)
+import System.Directory (XdgDirectory (XdgData), getXdgDirectory)
 
 import Obelisk.CliApp (Cli, CliConfig, CliT, HasCliConfig, getCliConfig, runCli)
 
@@ -48,3 +49,6 @@ type MonadObelisk m =
   , MonadIO m
   , MonadMask m
   )
+
+getObeliskUserStateDir :: IO FilePath
+getObeliskUserStateDir = getXdgDirectory XdgData "obelisk"

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -153,7 +153,7 @@ deployCommand cfg = hsubparser $ mconcat
         enabledByDefault = _argsConfig_enableVmBuilderByDefault cfg
         enabled = Just RemoteBuilder_ObeliskVM
         flagBase = "vm-builder"
-        flagDesc = "managed Linux virtual machine and allow builds to use it (requires Docker)"
+        flagDesc = "managed Linux virtual machine as a Nix remote builder (requires Docker)"
 
 
 deployInitOpts :: Parser DeployInitOpts

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -23,6 +23,7 @@ import Options.Applicative
 import System.Directory
 import System.Environment
 import System.FilePath
+import qualified System.Info
 import System.IO (hIsTerminalDevice, stdout)
 import System.Posix.Process (executeFile)
 
@@ -31,6 +32,7 @@ import Obelisk.CliApp (Severity (..), failWith, getLogLevel, newCliConfig, putLo
 import Obelisk.CliApp.Demo (cliDemo)
 import Obelisk.Command.Deploy
 import Obelisk.Command.Project
+import qualified Obelisk.Command.VmBuilder as VmBuilder
 import Obelisk.Command.Run
 import Obelisk.Command.Thunk
 
@@ -45,8 +47,12 @@ data Args = Args
   }
   deriving Show
 
-args :: Parser Args
-args = Args <$> noHandoff <*> verbose <*> obCommand
+newtype ArgsConfig = ArgsConfig
+  { _argsConfig_enableVmBuilderByDefault :: Bool
+  }
+
+args :: ArgsConfig -> Parser Args
+args cfg = Args <$> noHandoff <*> verbose <*> obCommand cfg
 
 noHandoff :: Parser Bool
 noHandoff = flag False True $ mconcat
@@ -62,8 +68,8 @@ verbose = flag False True $ mconcat
   , help "Be more verbose"
   ]
 
-argsInfo :: ParserInfo Args
-argsInfo = info (args <**> helper) $ mconcat
+argsInfo :: ArgsConfig -> ParserInfo Args
+argsInfo cfg = info (args cfg <**> helper) $ mconcat
   [ fullDesc
   , progDesc "Manage Obelisk projects"
   ]
@@ -95,7 +101,7 @@ inNixShell' p = withProjectRoot "." $ \root -> do
   projectShell root False "ghc" cmd
   where
     mkCmd = do
-      obArgs <- getObArgs
+      obArgs <- getObArgs =<< getArgsConfig
       progName <- getExecutablePath
       return $ progName : catMaybes
         [ Just "--no-handoff"
@@ -105,11 +111,11 @@ inNixShell' p = withProjectRoot "." $ \root -> do
         , Just $ encodeStaticKey $ staticKey p
         ]
 
-obCommand :: Parser ObCommand
-obCommand = hsubparser
+obCommand :: ArgsConfig -> Parser ObCommand
+obCommand cfg = hsubparser
     (mconcat
       [ command "init" $ info (ObCommand_Init <$> initSource) $ progDesc "Initialize an Obelisk project"
-      , command "deploy" $ info (ObCommand_Deploy <$> deployCommand) $ progDesc "Prepare a deployment for an Obelisk project"
+      , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
       , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
       , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
       , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
@@ -120,10 +126,10 @@ obCommand = hsubparser
       , command "internal" (info (ObCommand_Internal <$> internalCommand) mempty)
       ])
 
-deployCommand :: Parser DeployCommand
-deployCommand = hsubparser $ mconcat
-  [ command "init" $ info deployInitCommand $ progDesc "Initialize a deployment configuration directory"
-  , command "push" $ info (pure DeployCommand_Push) mempty
+deployCommand :: ArgsConfig -> Parser DeployCommand
+deployCommand cfg = hsubparser $ mconcat
+  [ command "init" $ info (DeployCommand_Init <$> deployInitOpts) $ progDesc "Initialize a deployment configuration directory"
+  , command "push" $ info (DeployCommand_Push <$> remoteBuilderParser) mempty
   , command "test" $ info (DeployCommand_Test <$> platformP) $ progDesc "Test your obelisk project from a mobile platform."
   , command "update" $ info (pure DeployCommand_Update) $ progDesc "Update the deployment's src thunk to latest"
   ]
@@ -133,8 +139,25 @@ deployCommand = hsubparser $ mconcat
       , command "ios"     $ info (pure IOS <*> strArgument (metavar "TEAMID" <> help "Your Team ID - found in the Apple developer portal")) mempty
       ]
 
-deployInitCommand :: Parser DeployCommand
-deployInitCommand = fmap DeployCommand_Init $ DeployInitOpts
+    remoteBuilderParser :: Parser (Maybe RemoteBuilder)
+    remoteBuilderParser =
+      flag (if enabledByDefault then enabled else Nothing) enabled (mconcat
+        [ long $ "enable-" <> flagBase
+        , help $ "Enable " <> flagDesc <> (if enabledByDefault then " (default)" else "")
+        ])
+      <|> flag enabled Nothing (mconcat
+        [ long $ "disable-" <> flagBase
+        , help $ "Disable a " <> flagDesc <> (if not enabledByDefault then " (default)" else "")
+        ])
+      where
+        enabledByDefault = _argsConfig_enableVmBuilderByDefault cfg
+        enabled = Just RemoteBuilder_ObeliskVM
+        flagBase = "vm-builder"
+        flagDesc = "managed Linux virtual machine and allow builds to use it (requires Docker)"
+
+
+deployInitOpts :: Parser DeployInitOpts
+deployInitOpts = DeployInitOpts
   <$> strArgument (action "directory" <> metavar "DEPLOYDIR" <> help "Path to a directory that it will create")
   <*> strOption (long "ssh-key" <> action "file" <> metavar "SSHKEY" <> help "Path to an ssh key that it will symlink to")
   <*> some (strOption (long "hostname" <> metavar "HOSTNAME" <> help "hostname of the deployment target"))
@@ -144,9 +167,12 @@ type TeamID = String
 data PlatformDeployment = Android | IOS TeamID
   deriving (Show)
 
+data RemoteBuilder = RemoteBuilder_ObeliskVM
+  deriving (Eq, Show)
+
 data DeployCommand
   = DeployCommand_Init DeployInitOpts
-  | DeployCommand_Push
+  | DeployCommand_Push (Maybe RemoteBuilder)
   | DeployCommand_Test PlatformDeployment
   | DeployCommand_Update
   deriving Show
@@ -214,25 +240,27 @@ isInteractiveTerm = do
   inShellCompletion <- liftIO $ isInfixOf "completion" . unwords <$> getArgs
   return $ isTerm && not inShellCompletion
 
-mkObeliskConfig :: IO Obelisk
-mkObeliskConfig = do
+mkObeliskConfig :: ArgsConfig -> IO Obelisk
+mkObeliskConfig argsCfg = do
   notInteractive <- not <$> isInteractiveTerm
-  logLevel <- toLogLevel <$> getObArgs
+  logLevel <- toLogLevel <$> getObArgs argsCfg
   cliConf <- newCliConfig logLevel notInteractive notInteractive
   return $ Obelisk cliConf
   where
     toLogLevel = bool Notice Debug . _args_verbose
 
-getObArgs :: IO Args
-getObArgs = getArgs >>= handleParseResult . execParserPure parserPrefs argsInfo
+getObArgs :: ArgsConfig -> IO Args
+getObArgs cfg = getArgs >>= handleParseResult . execParserPure parserPrefs (argsInfo cfg)
 
 main :: IO ()
-main = mkObeliskConfig >>= (`runObelisk` ObeliskT main')
+main = do
+  argsCfg <- getArgsConfig
+  mkObeliskConfig argsCfg >>= (`runObelisk` ObeliskT (main' argsCfg))
 
-main' :: MonadObelisk m => m ()
-main' = do
+main' :: MonadObelisk m => ArgsConfig -> m ()
+main' argsCfg = do
   obPath <- liftIO getExecutablePath
-  obArgs <- liftIO getObArgs
+  obArgs <- liftIO $ getObArgs argsCfg
   logLevel <- getLogLevel
   putLog Debug $ T.pack $ unwords
     [ "Starting Obelisk <" <> obPath <> ">"
@@ -246,7 +274,7 @@ main' = do
   --with optparse-applicative until we've done the handoff.
   myArgs <- liftIO getArgs
   let go as = do
-        args' <- liftIO $ handleParseResult (execParserPure parserPrefs argsInfo as)
+        args' <- liftIO $ handleParseResult (execParserPure parserPrefs (argsInfo argsCfg) as)
         case _args_noHandOffPassed args' of
           False -> return ()
           True -> putLog Warning "--no-handoff should only be passed once and as the first argument; ignoring"
@@ -289,7 +317,9 @@ ob = \case
       let sshKeyPath = _deployInitOpts_sshKey deployOpts
           hostname = _deployInitOpts_hostname deployOpts
       deployInit thunkPtr (root </> "config") deployDir sshKeyPath hostname
-    DeployCommand_Push -> deployPush "."
+    DeployCommand_Push remoteBuilder -> deployPush "." $ case remoteBuilder of
+      Nothing -> pure []
+      Just RemoteBuilder_ObeliskVM -> (:[]) <$> VmBuilder.getNixBuildersArg
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test Android -> deployMobile "android" []
     DeployCommand_Test (IOS teamID) -> deployMobile "ios" [teamID]
@@ -309,6 +339,9 @@ ob = \case
     ObInternal_CLIDemo -> cliDemo
 
 --TODO: Clean up all the magic strings throughout this codebase
+
+getArgsConfig :: IO ArgsConfig
+getArgsConfig = pure $ ArgsConfig { _argsConfig_enableVmBuilderByDefault = System.Info.os == "darwin" }
 
 encodeStaticKey :: StaticKey -> String
 encodeStaticKey = T.unpack . decodeUtf8 . Base16.encode . LBS.toStrict . Binary.encode

--- a/lib/command/src/Obelisk/Command/VmBuilder.hs
+++ b/lib/command/src/Obelisk/Command/VmBuilder.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Obelisk.Command.VmBuilder where
+
+import Control.Applicative (liftA2)
+import Control.Monad (unless)
+import Control.Monad.Catch (try)
+import Control.Monad.IO.Class (liftIO)
+import Data.Either (isRight)
+import Data.Monoid ((<>))
+import Data.String (IsString)
+import Data.String.Here.Uninterpolated (hereLit)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import System.Directory (createDirectoryIfMissing)
+import System.Exit (ExitCode)
+import System.FilePath ((</>), (<.>))
+import qualified System.Info
+import System.Process (proc)
+
+import Obelisk.App (MonadObelisk, getObeliskUserStateDir)
+import Obelisk.CliApp (Severity (..), callProcessAndLogOutput, failWith, readProcessAndLogStderr,
+                       withExitFailMessage, withSpinner)
+
+-- | Generate the `--builders` argument string to enable the VM builder after ensuring it is available.
+getNixBuildersArg :: MonadObelisk m => m String
+getNixBuildersArg = do
+  stateDir <- liftIO getDockerBuilderStateDir
+  exists <- containerExists
+  if exists then startContainer else setupNixDocker stateDir
+  pure $ nixBuildersArgString stateDir
+
+-- | String to pass to nix's `--builders` arguments to enable the VM builder.
+nixBuildersArgString :: FilePath -> String
+nixBuildersArgString stateDir = unwords [containerName, "x86_64-linux", stateDir </> sshKeyFileName, "1", "1", "kvm"]
+
+-- | Name of Docker container used for the VM builder.
+containerName :: IsString str => str
+containerName = "obelisk-docker-nix-builder"
+
+-- | Check to see if the Docker container exists. This will exit with a helpful message if Docker is not installed.
+containerExists :: MonadObelisk m => m Bool
+containerExists = withExitFailMessage needDockerMsg $ do
+  containerNames <- fmap (map T.strip . T.lines . T.pack) $
+    readProcessAndLogStderr Warning $
+      proc "docker" ["container", "list", "--format", "{{.Names}}"]
+  pure $ containerName `elem` containerNames
+  where
+    needDockerMsg = "This feature requires that you have Docker installed and the `docker` command available on your PATH. Please go https://docs.docker.com/ to install Docker and try this command again."
+
+-- | SSH port on localhost that connects to the container.
+containerSshPort :: Int
+containerSshPort = 2222
+
+-- | Start the Docker container; assumes it already exists.
+startContainer :: MonadObelisk m => m ()
+startContainer = callProcessAndLogOutput (Notice, Warning) $
+  proc "docker" ["start", containerName]
+
+-- | Creates the Docker container; assumes it does not exist.
+setupNixDocker :: MonadObelisk m => FilePath -> m ()
+setupNixDocker stateDir = withSpinner ("Creating Docker container named " <> containerName) $ do
+  liftIO $ do
+    createDirectoryIfMissing True stateDir
+    T.writeFile (stateDir </> "Dockerfile") dockerfile
+
+  -- Create new SSH keys for this container
+  callProcessAndLogOutput (Notice, Warning) $
+    proc "rm" ["-f", stateDir </> sshKeyFileName, stateDir </> sshKeyFileName <.> "pub"]
+  callProcessAndLogOutput (Notice, Warning) $
+    proc "ssh-keygen" ["-t", "ed25519", "-f", stateDir </> sshKeyFileName, "-P", ""]
+
+  -- Build the docker container (which uses the SSH keys in the 'ssh' folder)
+  containerId <- readProcessAndLogStderr Warning $
+    proc "docker" ["build", stateDir, "--quiet"]
+  callProcessAndLogOutput (Notice, Warning) $ proc "docker"
+    [ "run"
+    , "--restart", "always"
+    , "--detach"
+    , "--publish", show containerSshPort <> ":22"
+    , "--name", containerName, containerId
+    ]
+  exists <- containerExists
+  unless exists $
+    failWith $ "Expected to see docker container named " <> containerName <> " but it does not exist."
+
+  linuxBuildWorked <- if System.Info.os == "linux"
+    then pure False -- The Linux test is useless on Linux so just assume the setup is incomplete.
+    else testLinuxBuild stateDir
+  unless linuxBuildWorked $ do
+    let sshIdFile = stateDir </> sshKeyFileName
+    failWith $ setupInstructions sshIdFile
+
+-- | The instructions for setting up SSH access to the container for the Nix daemon.
+setupInstructions :: FilePath -> Text
+setupInstructions sshIdFile = T.unlines
+  [ "Setting Up Docker Nix Builder"
+  , "-----------------------------"
+  , ""
+  , "We've created a Docker container that can build for Linux. However, the Nix"
+  , "daemon needs to connect to this container as root. Please run the following"
+  , "commands in a root shell (`sudo su -`) to tell SSH how to access the"
+  , "container. Then try your obelisk command again."
+  , ""
+  , "# sudo su -"
+  , "touch ~/.ssh/config"
+  , "cat >> ~/.ssh/config <<CONF"
+  , ""
+  , sshConfigHost sshIdFile
+  , "CONF"
+  , "ssh " <> containerName <> " nix --version # Answer 'yes' if prompted"
+  ]
+
+-- | SSH configuration for `.ssh/config` to connect to the Docker container.
+sshConfigHost :: FilePath -> Text
+sshConfigHost sshIdFile = T.unlines
+  [ "Host " <> containerName
+  , "  User root"
+  , "  HostName 127.0.0.1"
+  , "  Port " <> T.pack (show containerSshPort)
+  , "  IdentityFile " <> T.pack (show sshIdFile) -- TODO: Check to see how weird paths should be encoded here.
+  ]
+
+-- | User directory where state (namely the SSH keys) is kept for the Docker container.
+getDockerBuilderStateDir :: IO FilePath
+getDockerBuilderStateDir = liftA2 (</>) getObeliskUserStateDir (pure "nix-docker-builder")
+
+-- | Run a test build to see if a Linux build can finish successfully.
+testLinuxBuild :: MonadObelisk m => FilePath -> m Bool
+testLinuxBuild stateDir =
+  fmap (isRight :: Either ExitCode () -> Bool) $ try $
+  callProcessAndLogOutput (Debug, Debug) $ proc "nix-build"
+    [ "-E", "(import <nixpkgs> { system = \"x86_64-linux\"; }).writeText \"test\" builtins.currentTime"
+    , "--builders", nixBuildersArgString stateDir
+    ]
+
+-- Copied from https://raw.githubusercontent.com/LnL7/nix-docker/bf28b99aebd8e403d2fc2171f4fa8878f857171c/ssh/Dockerfile
+-- Renamed "insecure_rsa" to 'sshKeyFileName'
+dockerfile :: Text
+dockerfile = [hereLit|
+FROM lnl7/nix:2018-04-17
+
+RUN nix-env -f '<nixpkgs>' -iA \
+    gnused \
+    openssh \
+ && nix-store --gc
+
+RUN mkdir -p /etc/ssh \
+ && echo "sshd:x:498:65534::/var/empty:/run/current-system/sw/bin/nologin" >> /etc/passwd \
+ && cp /root/.nix-profile/etc/ssh/sshd_config /etc/ssh \
+ && sed -i '/^PermitRootLogin/d' /etc/ssh/sshd_config \
+ && echo "PermitRootLogin yes" >> /etc/ssh/sshd_config \
+ && ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N "" -t rsa \
+ && ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N "" -t dsa \
+ && echo "export SSL_CERT_FILE=$SSL_CERT_FILE" >> /etc/bashrc \
+ && echo "export PATH=$PATH" >> /etc/bashrc \
+ && echo "export NIX_PATH=$NIX_PATH" >> /etc/bashrc \
+ && echo "source /etc/bashrc" >> /etc/profile
+
+|] <> T.unlines
+  [ "ADD " <> T.pack sshKeyFileName <> " /root/.ssh/id_rsa"
+  , "ADD " <> T.pack (sshKeyFileName <.> "pub") <> " /root/.ssh/authorized_keys"
+  ] <> [hereLit|
+
+EXPOSE 22
+CMD ["/nix/store/hpnx760s247labqc3nbn2kripk73p0ca-openssh-7.6p1/bin/sshd", "-D", "-e"]
+|]
+
+sshKeyFileName :: FilePath
+sshKeyFileName = "id_ed25519_obelisk_vm"

--- a/lib/command/src/Obelisk/Command/VmBuilder.hs
+++ b/lib/command/src/Obelisk/Command/VmBuilder.hs
@@ -45,7 +45,7 @@ containerName = "obelisk-docker-nix-builder"
 containerExists :: MonadObelisk m => m Bool
 containerExists = withExitFailMessage needDockerMsg $ do
   containerNames <- fmap (map T.strip . T.lines . T.pack) $
-    readProcessAndLogStderr Warning $
+    readProcessAndLogStderr Error $
       proc "docker" ["container", "list", "--format", "{{.Names}}"]
   pure $ containerName `elem` containerNames
   where
@@ -57,8 +57,9 @@ containerSshPort = 2222
 
 -- | Start the Docker container; assumes it already exists.
 startContainer :: MonadObelisk m => m ()
-startContainer = callProcessAndLogOutput (Notice, Warning) $
-  proc "docker" ["start", containerName]
+startContainer = withSpinner "Starting VM builder" $
+  callProcessAndLogOutput (Debug, Debug) $
+    proc "docker" ["start", containerName]
 
 -- | Creates the Docker container; assumes it does not exist.
 setupNixDocker :: MonadObelisk m => FilePath -> m ()


### PR DESCRIPTION
I would appreciate various testing attempts on both Mac and Linux. You should be able to just run `ob deploy push --enable-vm-builder` on any OS and Obelisk will tell you what to do each step of the way. I've tried to think of useful automated tests we could add for this feature, but it's not easy to write tests that require a VM running and possibly modify root's SSH config.

Note that we do *not* actually modify root's SSH config. We just tell the user how to do it themselves. We could add this automation if desired but @luigy and I thought best not to.

Also, I've been chatting with @cleverca22 about his linux-build-slave generator (https://github.com/cleverca22/not-os/blob/master/linux-build-slave.nix) and he's made some changes such that we could likely drop the need for Docker entirely. However, there are some unknowns that I'd want to hash out first (e.g. performance, reliability, bootstrapping the build [which requires Linux], etc.). Because of this I've made the CLI API abstract enough that we could swap this out underneath without needing to change any user-facing APIs. I designed it in such a way that I think we can move to this model without breaking users who used Docker in the past.



