### PR TITLE
Adds some GHCJS options to the frontend cabal file

### DIFF
--- a/skeleton/frontend/frontend.cabal
+++ b/skeleton/frontend/frontend.cabal
@@ -13,6 +13,9 @@ library
   exposed-modules:
     Frontend
   ghc-options: -Wall
+  if impl(ghcjs -any)
+    ghc-options: -dedupe
+    cpp-options: -DGHCJS_BROWSER
 
 executable frontend
   main-is: main.hs
@@ -27,3 +30,6 @@ executable frontend
   ghc-options: -threaded
   if os(darwin)
      ghc-options: -dynamic
+  if impl(ghcjs -any)
+    ghc-options: -dedupe
+    cpp-options: -DGHCJS_BROWSER


### PR DESCRIPTION
The [GHCJS Deployment page](https://github.com/ghcjs/ghcjs/wiki/Deployment) mentions `-DGHCJS_BROWSER`, and `-dedupe` is mentioned elsewhere.  I've found that they result in smaller output for the stuff I've been playing with.

This PR adds those options to the skeleton for `frontend.cabal`.