### PR TITLE
Isolate main.hs

### DIFF
--- a/skeleton/backend/backend.cabal
+++ b/skeleton/backend/backend.cabal
@@ -16,17 +16,13 @@ library
   ghc-options: -Wall
 
 executable backend
-  main-is: main.hs
-  hs-source-dirs: src
+  main-is: Main.hs
+  hs-source-dirs: src-bin
   if impl(ghcjs)
     buildable: False
   build-depends: base
                , backend
-               , common
-               , frontend
                , lens
                , modern-uri
-               , obelisk-backend
                , obelisk-executable-config
-               , obelisk-executable-config-inject
                , text

--- a/skeleton/backend/src-bin/Main.hs
+++ b/skeleton/backend/src-bin/Main.hs
@@ -3,10 +3,11 @@ import Control.Exception
 import Control.Lens
 import Data.Maybe
 import Data.Text.Encoding
-import Obelisk.ExecutableConfig (get)
 import System.Environment
 import qualified Text.URI as URI
 import Text.URI.Lens
+
+import Obelisk.ExecutableConfig (get)
 
 import Backend
 
@@ -17,4 +18,3 @@ main = do
     Left err -> fail $ show err
     Right uri -> return $ fromMaybe 8000 $ uri ^? uriAuthority . _Right . authPort . _Just
   withArgs ["--port", show port] backend
-

--- a/skeleton/frontend/frontend.cabal
+++ b/skeleton/frontend/frontend.cabal
@@ -15,13 +15,10 @@ library
   ghc-options: -Wall
 
 executable frontend
-  main-is: main.hs
-  hs-source-dirs: src
+  main-is: Main.hs
+  hs-source-dirs: src-bin
   build-depends: base
-               , common
                , reflex-dom
-               , static
-               , text
                , frontend
   --TODO: Make these ghc-options optional
   ghc-options: -threaded

--- a/skeleton/frontend/src-bin/Main.hs
+++ b/skeleton/frontend/src-bin/Main.hs
@@ -1,0 +1,6 @@
+import Reflex.Dom (mainWidget)
+
+import Frontend (frontend)
+
+main :: IO ()
+main = mainWidget $ snd frontend

--- a/skeleton/frontend/src/main.hs
+++ b/skeleton/frontend/src/main.hs
@@ -1,5 +1,0 @@
-import Reflex.Dom
-import Frontend
-
-main :: IO ()
-main = mainWidget $ snd frontend


### PR DESCRIPTION
So it doesn't end up building the library sources along with it. Consequently we do not have to repeat the library cabal dependencies in the executable stanza.

Fixes #51 
Clarifies #50 a bit