### PR TITLE
ob run: Handle application websocket requests

### DIFF
--- a/lib/run/obelisk-run.cabal
+++ b/lib/run/obelisk-run.cabal
@@ -24,6 +24,7 @@ library
     , streaming-commons
     , text
     , wai
+    , wai-websockets
     , warp
     , websockets
   exposed-modules:


### PR DESCRIPTION
Workaround `jsaddleOr` wanting to handle all websockets requests without
giving a chance for `run` to proxy non jsaddle websocket requests to the
backend. This assumes that websocket requests to "/" are meant for
jsaddle which is what the current version pinned does