### PR TITLE
Add per-platform sandboxing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,22 @@ Obelisk provides an easy way to develop and deploy your [Reflex](https://github.
         ```
     1. If you are using another operating system or linux distribution, ensure that these lines are present in `/etc/nix/nix.conf`:
         ```
-        sandbox = true
         substituters = https://cache.nixos.org https://nixcache.reflex-frp.org
         trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=
         ```
-		* If you are on MacOS, restart the nix daemon
-		```
-		sudo launchctl stop org.nixos.nix-daemon
-		sudo launchctl start org.nixos.nix-daemon
-		```
+        * other Linux: enable sandboxing (see https://github.com/obsidiansystems/obelisk/issues/6)
+          ```
+          sandbox = true
+          ```
+        * MacOS: disable sandboxing (there are still some impure dependencies for now)
+          ```
+          sandbox = false
+          ```
+          then restart the nix daemon
+          ```
+          sudo launchctl stop org.nixos.nix-daemon
+          sudo launchctl start org.nixos.nix-daemon
+          ```
 1. Install obelisk: `nix-env -f https://github.com/obsidiansystems/obelisk/archive/master.tar.gz -iA command`
 
 ### Contributing to Obelisk


### PR DESCRIPTION
It seems that even with `sandbox = relaxed` there are problems for macOS, so I think we need to separate the instructions.

I'd say #28 still makes sense, as long as it takes both platforms into consideration.

IMO #33 #55 should be closed and we'll want to have a ticket for all sandbox-related problems that tracks what needs to be fixed for each platform/sandbox-mode pair