### PR TITLE
Use wrapProgram make ob supply its own runtime deps

### DIFF
--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -34,21 +34,19 @@ deployInit thunkPtr configDir deployDir sshKeyPath hostnames = do
   localKey <- liftIO (doesFileExist sshKeyPath) >>= \case
     False -> failWith $ T.pack $ "ob deploy init: file does not exist: " <> sshKeyPath
     True -> pure $ deployDir </> "ssh_key"
-  callProcessAndLogOutput (Notice, Error) $
-    cp [sshKeyPath, localKey]
+  callProcessAndLogOutput (Notice, Error) $ proc "cp" [sshKeyPath, localKey]
   liftIO $ setFileMode localKey $ ownerReadMode .|. ownerWriteMode
   liftIO $ writeFile (deployDir </> "backend_hosts") $ unlines hostnames
   forM_ hostnames $ \hostname -> do
     putLog Notice $ "Verifying host keys (" <> T.pack hostname <> ")"
     verifyHostKey (deployDir </> "backend_known_hosts") localKey hostname
   when hasConfigDir $ do
-    callProcessAndLogOutput (Notice, Error) $
-      cp
-        [ "-r"
-        , "-T"
-        , configDir
-        , deployDir </> "config"
-        ]
+    callProcessAndLogOutput (Notice, Error) $ proc "cp"
+      [ "-r"
+      , "-T"
+      , configDir
+      , deployDir </> "config"
+      ]
   liftIO $ createThunk (deployDir </> "src") thunkPtr
   liftIO $ setupObeliskImpl deployDir
   initGit deployDir

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -35,7 +35,6 @@ import GitHub.Data.Name (Name)
 import Obelisk.App (MonadObelisk)
 import Obelisk.CliApp (Severity (..), callProcessAndLogOutput, createProcess_, failWith, putLog, withSpinner)
 import Obelisk.Command.Thunk
-import Obelisk.Command.Utils (cp)
 --TODO: Make this module resilient to random exceptions
 
 --TODO: Don't hardcode this
@@ -86,7 +85,7 @@ initProject source = withSystemTempDirectory "ob-init" $ \tmpDir -> do
     skel <- nixBuildAttrWithCache implDir "skeleton" --TODO: I don't think there's actually any reason to cache this
 
     callProcessAndLogOutput (Notice, Error) $
-      cp
+      proc "cp"
         [ "-r"
         , "--preserve=links"
         , obDir
@@ -96,7 +95,7 @@ initProject source = withSystemTempDirectory "ob-init" $ \tmpDir -> do
 
   withSpinner "Copying project skeleton" $ do
     callProcessAndLogOutput (Notice, Error) $
-      cp --TODO: Make this package depend on nix-prefetch-url properly
+      proc "cp"
         [ "-r"
         , "--no-preserve=mode"
         , "-T"

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-
 module Obelisk.Command.Thunk
   ( ThunkPtr (..)
   , ThunkRev (..)
@@ -74,7 +73,7 @@ import System.Process (proc)
 import Obelisk.App (MonadObelisk)
 import Obelisk.CliApp (Severity (..), callProcessAndLogOutput, failWith, putLog, readProcessAndLogStderr,
                        withExitFailMessage, withSpinner)
-import Obelisk.Command.Utils (checkGitCleanStatus, cp, git, procWithPackages)
+import Obelisk.Command.Utils (checkGitCleanStatus, gitProc)
 
 --TODO: Support symlinked thunk data
 data ThunkData
@@ -131,7 +130,7 @@ getNixSha256ForUriUnpacked :: MonadObelisk m => URI -> m NixSha256
 getNixSha256ForUriUnpacked uri =
   withExitFailMessage ("nix-prefetch-url: Failed to determine sha256 hash of URL " <> T.pack (show uri)) $ do
     fmap T.pack $ readProcessAndLogStderr Debug $
-      procWithPackages ["nix-prefetch-scripts"] "nix-prefetch-url" ["--unpack" , "--type" , "sha256" , show uri]
+      proc "nix-prefetch-url" ["--unpack" , "--type" , "sha256" , show uri]
 
 nixPrefetchGit :: MonadObelisk m => URI -> Text -> Bool -> m NixSha256
 nixPrefetchGit uri rev fetchSubmodules =
@@ -151,10 +150,10 @@ nixPrefetchGit uri rev fetchSubmodules =
 getLatestGitRev :: MonadObelisk m => GitSource -> m ThunkRev
 getLatestGitRev s = withSystemTempDirectory "git-clone" $ \tmpDir -> do
   withExitFailMessage ("Unable to determine latest git revision for branch " <> branch) $ do
-    out <- fmap T.pack $ readProcessAndLogStderr Debug $ git tmpDir
-      [ ["clone", "--no-checkout", show $ _gitSource_url s] -- Might be able to use --bare here instead to go faster.
-      , ["log", T.unpack branch, "--max-count=1", "--format=%H"]
-      ]
+    let git = fmap T.pack . readProcessAndLogStderr Debug . gitProc tmpDir
+    out <- liftA2 (<>)
+      (git ["clone", "--no-checkout", show $ _gitSource_url s]) -- Might be able to use --bare here instead to go faster.
+      (git ["log", T.unpack branch, "--max-count=1", "--format=%H"])
 
     case T.strip <$> safeLast (T.lines out) of
       Nothing -> failWith $ "Unable to parse git log: " <> out
@@ -599,7 +598,7 @@ unpackThunk thunkDir = readThunk thunkDir >>= \case
             --If this directory already exists then something is weird and we should fail
             liftIO $ createDirectory obGitDir
             callProcessAndLogOutput (Notice, Error) $
-              cp ["-r", "-T", thunkDir </> ".", obGitDir </> "orig-thunk"]
+              proc "cp" ["-r", "-T", thunkDir </> ".", obGitDir </> "orig-thunk"]
 
           withSpinner ("Preparing thunk in " <> T.pack thunkDir) $ do
             -- Checkout
@@ -615,28 +614,26 @@ unpackThunk thunkDir = readThunk thunkDir >>= \case
             forM_ (_gitHubSource_branch s) $ \branch ->
               callProcessAndLogOutput (Notice, Error) $
                 proc "hub" ["-C", tmpRepo, "branch", "-u", "origin/" <> T.unpack (untagName branch)]
-            callProcessAndLogOutput (Notice, Error) $
-              proc "rm" ["-r", thunkDir]
-            callProcessAndLogOutput (Notice, Error) $
-              procWithPackages ["coreutils"] "mv" ["-T", tmpRepo, thunkDir]
+            callProcessAndLogOutput (Notice, Error) $ proc "rm" ["-r", thunkDir]
+            callProcessAndLogOutput (Notice, Error) $ proc "mv" ["-T", tmpRepo, thunkDir]
 
         ThunkSource_Git s -> do
-          withSpinner ("Retreiving thunk " <> T.pack thunkName <> " from Git repo") $
-            callProcessAndLogOutput (Notice, Notice) $ git tmpRepo
-              [ ["clone", if _gitSource_fetchSubmodules s then "--recursive" else "", show (_gitSource_url s)]
-              , ["reset", "--hard", Ref.toHexString $ _thunkRev_commit $ _thunkPtr_rev tptr]
-              , if _gitSource_fetchSubmodules s then ["submodule", "update", "--recursive"] else []
-              , ["branch", "-u", "origin/" <> T.unpack (untagName $ _gitSource_branch s)]
-              ]
+          withSpinner ("Retreiving thunk " <> T.pack thunkName <> " from Git repo") $ do
+            let git = callProcessAndLogOutput (Notice, Notice) . gitProc tmpRepo
+            git ["clone", if _gitSource_fetchSubmodules s then "--recursive" else "", show (_gitSource_url s)]
+            git ["reset", "--hard", Ref.toHexString $ _thunkRev_commit $ _thunkPtr_rev tptr]
+            when (_gitSource_fetchSubmodules s) $
+              git ["submodule", "update", "--recursive", "--init"]
+            git ["branch", "-u", "origin/" <> T.unpack (untagName $ _gitSource_branch s)]
 
           withSpinner ("Preparing thunk in " <> T.pack thunkDir) $ do
             liftIO $ createDirectory obGitDir
             callProcessAndLogOutput (Notice, Error) $
-              cp ["-r", "-T", thunkDir </> ".", obGitDir </> "orig-thunk"]
+              proc "cp" ["-r", "-T", thunkDir </> ".", obGitDir </> "orig-thunk"]
             callProcessAndLogOutput (Notice, Error) $
               proc "rm" ["-r", thunkDir]
             callProcessAndLogOutput (Notice, Error) $
-              procWithPackages ["coreutils"] "mv" ["-T", tmpRepo, thunkDir]
+              proc "mv" ["-T", tmpRepo, thunkDir]
 
 --TODO: add force mode to pack even if changes are present
 --TODO: add a rollback mode to pack to the original thunk
@@ -661,8 +658,7 @@ getThunkPtr' :: MonadObelisk m => Bool -> FilePath -> Text -> m ThunkPtr
 getThunkPtr' checkClean thunkDir upstream = do
     when checkClean $ checkGitCleanStatus thunkDir >>= \case
       False -> do
-        statusDebug <- fmap T.pack $ readProcessAndLogStderr Notice $
-          git thunkDir [["status", "--ignored"]]
+        statusDebug <- readGitProcess thunkDir ["status", "--ignored"]
         putLog Warning "cannot proceed with unsaved working copy (git status):"
         putLog Notice statusDebug
         failWith "thunk pack: thunk checkout contains unsaved modifications"
@@ -795,4 +791,4 @@ parseSshShorthand uri = do
 
 
 readGitProcess :: MonadObelisk m => FilePath -> [String] -> m Text
-readGitProcess repo args = fmap T.pack $ readProcessAndLogStderr Notice $ git repo [args]
+readGitProcess repo = fmap T.pack . readProcessAndLogStderr Notice . gitProc repo

--- a/lib/command/src/Obelisk/Command/VmBuilder.hs
+++ b/lib/command/src/Obelisk/Command/VmBuilder.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
-
 module Obelisk.Command.VmBuilder where
 
 import Control.Applicative (liftA2)


### PR DESCRIPTION
The test `can build everything` is failing and I haven't looked into why yet. If you happen to have an idea why, let me know.

Also, installing this makes obelisk show up as `ob` instead of `obelisk-command` in `nix-env -q`. I can change this if we liked `obelisk-command` as the CLI package name. I thought `ob` was a bit more `ob`vious.

For devs, you now should use `nix-shell -A commandEnv` instead of `nix-shell -A command.env` to get into dev shell for `command`.

Fixes #78 