### PR TITLE
Reuse the same official package name so nix-env does an upgrade properly

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -123,7 +123,7 @@ rec {
   inherit (reflex-platform) nixpkgs pinBuildInputs;
   path = reflex-platform.filterGit ./.;
   obelisk = ghcObelisk;
-  command = pkgs.runCommand "ob" { nativeBuildInputs = [pkgs.makeWrapper]; } ''
+  command = pkgs.runCommand "obelisk-command" { nativeBuildInputs = [pkgs.makeWrapper]; } ''
     mkdir -p "$out/bin"
     ln -s '${ghcObelisk.obelisk-command}/bin/ob' "$out/bin/ob"
     wrapProgram "$out"/bin/ob --prefix PATH : ${pkgs.lib.makeBinPath (commandRuntimeDeps pkgs)}

--- a/default.nix
+++ b/default.nix
@@ -123,7 +123,7 @@ rec {
   inherit (reflex-platform) nixpkgs pinBuildInputs;
   path = reflex-platform.filterGit ./.;
   obelisk = ghcObelisk;
-  command = pkgs.runCommand "obelisk-command" { nativeBuildInputs = [pkgs.makeWrapper]; } ''
+  command = pkgs.runCommand ghcObelisk.obelisk-command.name { nativeBuildInputs = [pkgs.makeWrapper]; } ''
     mkdir -p "$out/bin"
     ln -s '${ghcObelisk.obelisk-command}/bin/ob' "$out/bin/ob"
     wrapProgram "$out"/bin/ob --prefix PATH : ${pkgs.lib.makeBinPath (commandRuntimeDeps pkgs)}


### PR DESCRIPTION
@srid pointed out that the official package name had changed with my #84 PR which makes `nix-env` try to install a new package that has conflicting binaries on the path (both have `ob`). This changes the package name to what it was before so that nix-env does the right thing.