### PR TITLE
ob deploy: HTTPs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,21 +116,27 @@ First create a new EC2 instance:
 1. Launch a NixOS 17.09 EC2 instance (we recommend [this AMI](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-40bee63a))
 1. In the instance configuration wizard ensure that your instance has at least 1GB RAM and 10GB disk space.
 1. When prompted save your AWS private key (`~/myaws.pem`) somewhere safe. We'll need it later during deployment.
-1. Go to "Security Groups", select your instance's security group and under "Inbound" tab add a new rule for HTTP port 80.
+1. Go to "Security Groups", select your instance's security group and under "Inbound" tab add a new rule for HTTP port 80 and 443.
 
-At this stage your instance should be booting and become accessible shortly. Note down the hostname of your instance. It should look like this:
-
-```
-INSTANCE_HOSTNAME=ec2-??-??-??-??.ca-central-1.compute.amazonaws.com
-```
+At this stage your instance should be booting and become accessible shortly. Note down the hostname of your EC2 instance.
 
 Now go to your Obelisk project directory (`~/code/myapp`), and initialize a deployment config (`~/code/myapp-deploy`):
 Your project directory must be "thunkable", i.e. something on which `ob thunk pack` can be called. Usually it will be a git repository whose current revision has been pushed upstream.
 
 ```
 cd ~/code/myapp
-ob deploy init --ssh-key ~/myaws.pem --hostname ${INSTANCE_HOSTNAME} ~/code/myapp-deploy
+SERVER=ec2-35-183-22-197.ca-central-1.compute.amazonaws.com
+ROUTE=https://myapp.com   # Publicly accessible route to your app
+EMAIL=myname@myapp.com
+ob deploy init \
+  --ssh-key ~/myaws.pem \
+  --hostname $SERVER \
+  --route $ROUTE \
+  --admin-email $EMAIL \
+  ~/code/myapp-deploy
 ```
+
+NOTE: HTTPS is enabled by default; to disable https, pass `--disable-https` to the `ob deploy init` command above.
 
 Then go to that created deployment configuration directory, and initiate the deployment:
 
@@ -139,9 +145,9 @@ cd ~/code/myapp-deploy
 ob deploy push
 ```
 
-`ob deploy push` will locally build your app and then transfer it, along with all the Nix package dependencies, via ssh to the EC2 instance. It will also configure Nginx so that the public port 80 proxies to the running app.
+`ob deploy push` will locally build your app and then transfer it, along with all the Nix package dependencies, via ssh to the EC2 instance.
 
-At this point you are done. Your app will be accessible at `http://${HOSTNAME}`!
+At this point you are done. Your app will be accessible at `${ROUTE}`.
 
 ### Deploying an updated version
 

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -27,6 +27,8 @@ library
     , io-streams
     , exceptions
     , logging-effect
+    , lens
+    , modern-uri
     , monad-loops
     , mtl
     , network

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -175,6 +175,9 @@ deployInitOpts = DeployInitOpts
   <$> strArgument (action "directory" <> metavar "DEPLOYDIR" <> help "Path to a directory that it will create")
   <*> strOption (long "ssh-key" <> action "file" <> metavar "SSHKEY" <> help "Path to an ssh key that it will symlink to")
   <*> some (strOption (long "hostname" <> metavar "HOSTNAME" <> help "hostname of the deployment target"))
+  <*> strOption (long "route" <> metavar "PUBLICROUTE" <> help "Publicly accessible URL of your app")
+  <*> strOption (long "admin-email" <> metavar "ADMINEMAIL" <> help "Email address where administrative alerts will be sent")
+  <*> flag True False (long "disable-https" <> help "Disable automatic https configuration for the backend")
   <*> strOption (long "upstream" <> value "origin" <> metavar "REMOTE" <> help "git remote to use for the src thunk" <> showDefault)
 
 type TeamID = String
@@ -195,6 +198,9 @@ data DeployInitOpts = DeployInitOpts
   { _deployInitOpts_outputDir :: FilePath
   , _deployInitOpts_sshKey :: FilePath
   , _deployInitOpts_hostname :: [String]
+  , _deployInitOpts_route :: String
+  , _deployInitOpts_adminEmail :: String
+  , _deployInitOpts_enableHttps :: Bool
   , _deployInitOpts_remote :: String
   }
   deriving Show
@@ -376,7 +382,11 @@ ob = \case
           getThunkPtr' False root (T.pack $ _deployInitOpts_remote deployOpts)
       let sshKeyPath = _deployInitOpts_sshKey deployOpts
           hostname = _deployInitOpts_hostname deployOpts
-      deployInit thunkPtr (root </> "config") deployDir sshKeyPath hostname
+          route = _deployInitOpts_route deployOpts
+          adminEmail = _deployInitOpts_adminEmail deployOpts
+          enableHttps = _deployInitOpts_enableHttps deployOpts
+      deployInit thunkPtr (root </> "config") deployDir
+        sshKeyPath hostname route adminEmail enableHttps
     DeployCommand_Push remoteBuilder -> deployPush "." $ case remoteBuilder of
       Nothing -> pure []
       Just RemoteBuilder_ObeliskVM -> (:[]) <$> VmBuilder.getNixBuildersArg

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -2,9 +2,12 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
 module Obelisk.Command.Deploy where
 
+import Control.Lens
 import Control.Monad
+import Control.Monad.Catch (Exception (displayException), MonadThrow, throwM, try)
 import Control.Monad.IO.Class (liftIO)
 import Data.Bits
 import Data.Default
@@ -18,6 +21,9 @@ import System.Environment (getEnvironment)
 import System.FilePath
 import System.Posix.Files
 import System.Process (delegate_ctlc, env, proc)
+import Text.URI (URI)
+import qualified Text.URI as URI
+import Text.URI.Lens
 
 import Obelisk.App (MonadObelisk)
 import Obelisk.CliApp (Severity (..), callProcessAndLogOutput, failWith, putLog, withSpinner)
@@ -26,30 +32,48 @@ import Obelisk.Command.Project
 import Obelisk.Command.Thunk
 import Obelisk.Command.Utils
 
-deployInit :: MonadObelisk m => ThunkPtr -> FilePath -> FilePath -> FilePath -> [String] -> m ()
-deployInit thunkPtr configDir deployDir sshKeyPath hostnames = do
-  hasConfigDir <- liftIO $ do
-    createDirectoryIfMissing True deployDir
-    doesDirectoryExist configDir
-  localKey <- liftIO (doesFileExist sshKeyPath) >>= \case
-    False -> failWith $ T.pack $ "ob deploy init: file does not exist: " <> sshKeyPath
-    True -> pure $ deployDir </> "ssh_key"
-  callProcessAndLogOutput (Notice, Error) $ proc "cp" [sshKeyPath, localKey]
-  liftIO $ setFileMode localKey $ ownerReadMode .|. ownerWriteMode
-  liftIO $ writeFile (deployDir </> "backend_hosts") $ unlines hostnames
+deployInit
+  :: MonadObelisk m
+  => ThunkPtr
+  -> FilePath
+  -> FilePath
+  -> FilePath
+  -> [String] -- ^ hostnames
+  -> String -- ^ route
+  -> String -- ^ admin email
+  -> Bool -- ^ enable https
+  -> m ()
+deployInit thunkPtr configDir deployDir sshKeyPath hostnames route adminEmail enableHttps = do
+  (hasConfigDir, localKey) <- withSpinner ("Preparing " <> T.pack deployDir) $ do
+    hasConfigDir <- liftIO $ do
+      createDirectoryIfMissing True deployDir
+      doesDirectoryExist configDir
+    localKey <- liftIO (doesFileExist sshKeyPath) >>= \case
+      False -> failWith $ T.pack $ "ob deploy init: file does not exist: " <> sshKeyPath
+      True -> pure $ deployDir </> "ssh_key"
+    callProcessAndLogOutput (Notice, Error) $
+      proc "cp" [sshKeyPath, localKey]
+    liftIO $ setFileMode localKey $ ownerReadMode .|. ownerWriteMode
+    return $ (hasConfigDir, localKey)
+  withSpinner "Validating configuration" $ do
+    void $ getHostFromRoute enableHttps route -- make sure that hostname is present
   forM_ hostnames $ \hostname -> do
     putLog Notice $ "Verifying host keys (" <> T.pack hostname <> ")"
+    -- Note: we can't use a spinner here as this function will prompt the user.
     verifyHostKey (deployDir </> "backend_known_hosts") localKey hostname
-  when hasConfigDir $ do
-    callProcessAndLogOutput (Notice, Error) $ proc "cp"
-      [ "-r"
-      , "-T"
-      , configDir
-      , deployDir </> "config"
-      ]
-  liftIO $ createThunk (deployDir </> "src") thunkPtr
-  liftIO $ setupObeliskImpl deployDir
-  initGit deployDir
+  when hasConfigDir $ withSpinner "Importing project configuration" $ do
+    callProcessAndLogOutput (Notice, Error) $
+      proc "cp" [ "-r" , "-T" , configDir , deployDir </> "config"]
+  withSpinner "Writing deployment configuration" $ do
+    writeDeployConfig deployDir "backend_hosts" $ unlines hostnames
+    writeDeployConfig deployDir "enable_https" $ show enableHttps
+    writeDeployConfig deployDir "admin_email" adminEmail
+    writeDeployConfig deployDir ("config" </> "common" </> "route") $ route
+  withSpinner "Creating source thunk (./src)" $ liftIO $ do
+    createThunk (deployDir </> "src") thunkPtr
+    setupObeliskImpl deployDir
+  withSpinner ("Initializing git repository (" <> T.pack deployDir <> ")") $
+    initGit deployDir
 
 setupObeliskImpl :: FilePath -> IO ()
 setupObeliskImpl deployDir = do
@@ -59,8 +83,11 @@ setupObeliskImpl deployDir = do
 
 deployPush :: MonadObelisk m => FilePath -> m [String] -> m ()
 deployPush deployPath getNixBuilders = do
-  let backendHosts = deployPath </> "backend_hosts"
-  host <- liftIO $ fmap (T.unpack . T.strip) $ T.readFile backendHosts
+  host <- readDeployConfig deployPath "backend_hosts"
+  adminEmail <- readDeployConfig deployPath "admin_email"
+  enableHttps <- read <$> readDeployConfig deployPath "enable_https"
+  route <- readDeployConfig deployPath $ "config" </> "common" </> "route"
+  routeHost <- getHostFromRoute enableHttps route
   let srcPath = deployPath </> "src"
       build = do
         builders <- getNixBuilders
@@ -70,7 +97,12 @@ deployPush deployPath getNixBuilders = do
             , _target_attr = Just "server"
             }
           , _nixBuildConfig_outLink = OutLink_None
-          , _nixBuildConfig_args = pure $ Arg "hostName" host
+          , _nixBuildConfig_args =
+            [ strArg "hostName" host
+            , strArg "adminEmail" adminEmail
+            , strArg "routeHost" routeHost
+            , boolArg "enableHttps" enableHttps
+            ]
           , _nixBuildConfig_builders = builders
           }
         return $ listToMaybe $ lines buildOutput
@@ -114,6 +146,7 @@ deployPush deployPath getNixBuilders = do
           ["-C", deployPath, "add", "."]
         callProcessAndLogOutput (Debug, Error) $ proc "git"
           ["-C", deployPath, "commit", "-m", "New deployment"]
+    putLog Notice $ "Deployed => " <> T.pack route
   where
     callProcess' envMap cmd args = do
       processEnv <- Map.toList . (envMap <>) . Map.fromList <$> liftIO getEnvironment
@@ -131,6 +164,14 @@ deployMobile platform mobileArgs = withProjectRoot "." $ \root -> do
   result <- nixBuildAttrWithCache srcDir $ platform <> ".frontend"
   callProcessAndLogOutput (Notice, Error) $ proc (result </> "bin" </> "deploy") mobileArgs
 
+-- | Simplified deployment configuration mechanism. At one point we may revisit this.
+writeDeployConfig :: MonadObelisk m => FilePath -> FilePath -> String -> m ()
+writeDeployConfig deployDir fname = liftIO . writeFile (deployDir </> fname)
+
+readDeployConfig :: MonadObelisk m => FilePath -> FilePath -> m String
+readDeployConfig deployDir fname = liftIO $ do
+  fmap (T.unpack . T.strip) $ T.readFile $ deployDir </> fname
+
 verifyHostKey :: MonadObelisk m => FilePath -> FilePath -> String -> m ()
 verifyHostKey knownHostsPath keyPath hostName =
   callProcessAndLogOutput (Notice, Warning) $ proc "ssh" $
@@ -145,3 +186,59 @@ sshArgs knownHostsPath keyPath askHostKeyCheck =
   , "-o", "StrictHostKeyChecking=" <> if askHostKeyCheck then "ask" else "yes"
   , "-i", keyPath
   ]
+
+-- common/route validation
+-- TODO: move these to executable-config once the typed-config stuff is done.
+
+data InvalidRoute
+  = InvalidRoute_NotHttps URI
+  | InvalidRoute_MissingScheme URI
+  | InvalidRoute_MissingHost URI
+  | InvalidRoute_HasPort URI
+  | InvalidRoute_HasPath URI
+  deriving Show
+
+instance Exception InvalidRoute where
+  displayException = \case
+    InvalidRoute_MissingScheme uri -> route uri "must have an URI scheme"
+    InvalidRoute_NotHttps uri -> route uri "must be HTTPS"
+    InvalidRoute_MissingHost uri -> route uri "must contain a hostname"
+    InvalidRoute_HasPort uri -> route uri "cannot specify port"
+    InvalidRoute_HasPath uri -> route uri "cannot contain path"
+    where
+      route uri err = T.unpack $ "Route (" <> URI.render uri <> ") " <> err
+
+-- | Get the hostname from a https route
+--
+-- Fail if the route is invalid (i.e, no host present or scheme is not https)
+getHostFromRoute
+  :: MonadObelisk m
+  => Bool  -- ^ Ensure https?
+  -> String
+  -> m String
+getHostFromRoute mustBeHttps route = do
+  result :: Either InvalidRoute String <- try $ do
+    validateCommonRouteAndGetHost mustBeHttps =<< URI.mkURI (T.strip $ T.pack route)
+  either (failWith . T.pack . displayException) pure result
+
+validateCommonRouteAndGetHost
+  :: (MonadThrow m, MonadObelisk m)
+  => Bool -- ^ Ensure https?
+  -> URI
+  -> m String
+validateCommonRouteAndGetHost mustBeHttps uri = do
+  case uri ^? uriScheme of
+    Just (Just (URI.unRText -> s)) -> case (mustBeHttps, s) of
+      (False, _) -> pure ()
+      (True, "https") -> pure ()
+      _ -> throwM $ InvalidRoute_NotHttps uri
+    _ -> throwM $ InvalidRoute_MissingScheme uri
+  case uri ^. uriPath of
+    [] -> pure ()
+    _path -> throwM $ InvalidRoute_HasPath uri
+  case uri ^? uriAuthority . _Right . authPort of
+    Just (Just _port) -> throwM $ InvalidRoute_HasPort uri
+    _ -> pure ()
+  case uri ^? uriAuthority . _Right . authHost of
+    Nothing -> throwM $ InvalidRoute_MissingHost uri
+    Just sslHost -> return $ T.unpack $ URI.unRText sslHost

--- a/lib/https/default.nix
+++ b/lib/https/default.nix
@@ -1,7 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-import ((import <nixpkgs> {}).fetchFromGitHub (
-  let json = builtins.fromJSON (builtins.readFile ./github.json);
-  in { inherit (json) owner repo rev sha256;
-       private = json.private or false;
-     }
-))

--- a/lib/https/github.json
+++ b/lib/https/github.json
@@ -1,6 +1,0 @@
-{
-  "owner": "obsidiansystems",
-  "repo": "obelisk-https",
-  "rev": "5bc5cd81b669a0ea1b4415a1be8fd8c5a0680f0b",
-  "sha256": "105n7pxykz02n8ilgjznssmxa8hszclg21nqiyqdr64bcrxjyxf4"
-}

--- a/migration/6a18939264224d6ce24c7426249edfea-e66afc8befac4d76b5780a960f768c31/obelisk-upgrade
+++ b/migration/6a18939264224d6ce24c7426249edfea-e66afc8befac4d76b5780a960f768c31/obelisk-upgrade
@@ -1,0 +1,15 @@
+# ob deploy: HTTPs support
+
+Obelisk deployments now support HTTPs. You must upgrade the deployment repo
+associated with the obelisk project as follows:
+
+```
+cd /your/project's/deployment/repo
+echo True > enable_https
+echo admin@yoursite.com > admin_email
+echo https://yoursite.com/ > config/common/route
+git add ... && git commit ...
+ob deploy push
+```
+
+If you do not wish to enable HTTPs, write `False` to `enable_https` instead.


### PR DESCRIPTION
Replaced `obelisk-https` with upstream (nixos) letsencrypt support.

## todo
- [x] verify CI fails for `ob upgrade` (no migrations yet)
- [x] add migration