### PR TITLE
read files strictly in "Obelisk.Migration".

### DIFF
--- a/lib/migration/src/Obelisk/Migration.hs
+++ b/lib/migration/src/Obelisk/Migration.hs
@@ -17,6 +17,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import System.Directory
 import System.FilePath
 
@@ -66,10 +67,10 @@ instance Exception MissingEdgeInActionMap
 instance Exception NonLinearGraph
 
 class Action action where
-  parseEdgeMeta :: String -> action
+  parseEdgeMeta :: Text -> action
 
 instance Action Text where
-  parseEdgeMeta = T.pack
+  parseEdgeMeta = id
 
 -- | Get the directed-acylic graph of migration
 -- TODO: Consider calling getDag only when reading the graph for efficiency.
@@ -95,7 +96,7 @@ readGraph root name = doesDirectoryExist root >>= \case
       let f = root </> (T.unpack $ v1 <> "-" <> v2) </> T.unpack graph
       doesFileExist f >>= \case
         True -> do
-          c <- readFile f >>= pure . parseEdgeMeta
+          c <- parseEdgeMeta <$> T.readFile f
           return $ Just c
         False -> do
           return Nothing


### PR DESCRIPTION
To avoid "too many open files" error.

This fixes #115 partly, I still get an error that is similar to the one on hydra:

```
No vertex found for HEAD (b0b562b83e8a198bb858deeb19d5868c)
✖ Checking existence of HEAD vertex
```