### PR TITLE
Provide nix-shells with complete dev environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ Or to launch ghcid for `lib/command` project:
 nix-shell -A obelisk.obelisk-command.env --run "cd lib/command && ghcid -c 'cabal new-repl'"
 ```
 
+If you need a compatible `cabal-install` and `ghcid` installed in your `nix-shell` as well, use `obeliskDev` instead of `obelisk`, like so:
+
+```
+nix-shell -A obeliskDev.obelisk-command.env --run "cd lib/command && ghcid -c 'cabal new-repl'"
+```
+
+If you get an error like this one:
+
+```
+No files loaded, GHCi is not working properly.
+Command: cabal new-repl
+```
+
+Issue a cabal new-build first:
+
+```
+nix-shell -A obeliskDev.obelisk-command.env --run "cd lib/command && cabal new-build"
+```
+
+Now `ghcid` should work fine.
+
 ### Accessing private repositories
 To allow the Nix builder to access private git repositories, follow these steps:
 


### PR DESCRIPTION
The current `nix-shell` commands assumed that the user has `ghcid` and
`cabal-install` installed at the right versions. This commit provides
"dev" variants that include these tools.