### PR TITLE
ob deploy push: actually push the deploy config

### DIFF
--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -101,6 +101,7 @@ deployPush deployPath getNixBuilders = do
             , strArg "adminEmail" adminEmail
             , strArg "routeHost" routeHost
             , boolArg "enableHttps" enableHttps
+            , rawArg "config" $ deployPath </> "config"
             ]
           , _nixBuildConfig_builders = builders
           }

--- a/lib/command/src/Obelisk/Command/Nix.hs
+++ b/lib/command/src/Obelisk/Command/Nix.hs
@@ -11,6 +11,7 @@ module Obelisk.Command.Nix
   , OutLink (..)
   , Arg (..)
   , boolArg
+  , rawArg
   , strArg
   ) where
 
@@ -56,6 +57,9 @@ data Arg
 
 strArg :: String -> String -> Arg
 strArg k = Arg_Str k
+
+rawArg :: String -> String -> Arg
+rawArg k = Arg_Expr k
 
 boolArg :: String -> Bool -> Arg
 boolArg k = Arg_Expr k . bool "false" "true"


### PR DESCRIPTION
Previously only the project source config gets deployed, but this change overrides that with the config in the deploy repo.

Effectively then,
1. `ob run` uses config from local working copy (project source)
2. `ob deploy push`'ed instance will use the config from the deploy repository, which invariably is different to project config (eg: `common/route` is always different, but other config files can also vary).
