### PR TITLE
Fix command runtime nix dep

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ let
     git
     gitAndTools.hub
     nix-prefetch-git
-    nixStable
+    nixUnstable
     openssh
   ];
 


### PR DESCRIPTION
ob requires at least nix 2.0, but it was being wrapped with an older
version. This gets rid of having to manually set NIX_REMOTE for systems
running on 2.0