### PR TITLE
Bump reflex-platform

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -2,6 +2,6 @@
   "owner": "reflex-frp",
   "repo": "reflex-platform",
   "branch": "develop",
-  "rev": "a4d679629b52f80ecae857864591d79d902a5c5d",
-  "sha256": "1p34qc3ryar81jh01g4jm0svr05yri83vlswm2jbxiabigy47652"
+  "rev": "3fae704d4790a2b918f3feb0a16293f4adc42e00",
+  "sha256": "0xgkw7q4racc18xcvvgbd9k6ikgfy1nfsls75xx6gi04kbj4z52l"
 }


### PR DESCRIPTION
Fixes `lens-family-th` not building on ghcjs mentioned in #197 