### PR TITLE
obelisk-executable-config-inject: Use reflex-dom-core

### DIFF
--- a/lib/executable-config/inject/obelisk-executable-config-inject.cabal
+++ b/lib/executable-config/inject/obelisk-executable-config-inject.cabal
@@ -10,7 +10,7 @@ library
     base,
     bytestring,
     filepath,
-    reflex-dom,
+    reflex-dom-core,
     text
 
   exposed-modules: Obelisk.ExecutableConfig.Inject

--- a/lib/executable-config/inject/src/Obelisk/ExecutableConfig/Inject.hs
+++ b/lib/executable-config/inject/src/Obelisk/ExecutableConfig/Inject.hs
@@ -5,7 +5,7 @@ import Data.Semigroup ((<>))
 import Data.ByteString (ByteString)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import Reflex.Dom
+import Reflex.Dom.Core
 import System.FilePath ((</>))
 
 inject :: FilePath -> IO ByteString


### PR DESCRIPTION
This project doesn't need all of reflex-dom, just reflex-dom-core.

This makes the dependency closure much smaller.