### PR TITLE
Quickfix: Unused import

### DIFF
--- a/skeleton/backend/src/Backend.hs
+++ b/skeleton/backend/src/Backend.hs
@@ -1,6 +1,5 @@
 module Backend where
 
-import Common.Api
 import Frontend
 import qualified Obelisk.Backend as Ob
 


### PR DESCRIPTION
```[-Wunused-imports]
    The import of ‘Common.Api’ is redundant```