### PR TITLE
Use -ignore-dot-ghci with ghcid

### DIFF
--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -173,7 +173,7 @@ runGhcid dotGhci mcmd = callCommand $ unwords $ "ghcid" : opts
     opts =
       [ "-W"
       --TODO: The decision of whether to use -fwarn-redundant-constraints should probably be made by the user
-      , "--command='ghci -Wall -fwarn-redundant-constraints -ghci-script " <> dotGhci <> "' "
+      , "--command='ghci -Wall -ignore-dot-ghci -fwarn-redundant-constraints -ghci-script " <> dotGhci <> "' "
       , "--reload=config"
       , "--outputfile=ghcid-output.txt"
       ] <> testCmd


### PR DESCRIPTION
Without it, ob run/watch will flash when `~/.ghci` contains `:set +t`


This only happens against the `reunification` branch, but that has vanished, so I rebased to `master`