### PR TITLE
Fix ob command's autocompleter

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -88,7 +88,20 @@ let
     obelisk-asset-serve-snap = self.callCabal2nix "obelisk-asset-serve-snap" (hackGet ./lib/asset + "/serve-snap") {};
     obelisk-backend = self.callCabal2nix "obelisk-backend" (cleanSource ./lib/backend) {};
     obelisk-cliapp = self.callCabal2nix "obelisk-cliapp" (cleanSource ./lib/cliapp) {};
-    obelisk-command = (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {});
+    obelisk-command = (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}).overrideAttrs
+      (drv: {
+        buildInputs = drv.buildInputs ++ [ pkgs.makeWrapper ];
+        postInstall = ''
+          ${drv.postInstall or ""}
+          # Install migrations
+          cp -r ${./migration} $out/migration;
+        '';
+        postFixup = ''
+          ${drv.postFixup or ""}
+          # Make `ob` reference its runtime dependencies.
+          wrapProgram "$out"/bin/ob --prefix PATH : ${pkgs.lib.makeBinPath (commandRuntimeDeps pkgs)}
+        '';
+      });
     obelisk-executable-config = executableConfig.haskellPackage self;
     obelisk-executable-config-inject = executableConfig.platforms.web.inject self;
     obelisk-frontend = self.callCabal2nix "obelisk-frontend" (cleanSource ./lib/frontend) {};
@@ -111,15 +124,7 @@ rec {
   pathGit = ./.;  # Used in CI by the migration graph hash algorithm to correctly ignore files.
   path = reflex-platform.filterGit ./.;
   obelisk = ghcObelisk;
-  commandWithMigration = ghcObelisk.obelisk-command.overrideAttrs (drv: {
-    postInstall = (drv.postInstall or "") +
-                  ''cp -r ${./migration} $out/migration;'';
-  });
-  command = pkgs.runCommand commandWithMigration.name { nativeBuildInputs = [pkgs.makeWrapper]; } ''
-    mkdir -p "$out/bin"
-    ln -s '${commandWithMigration}/bin/ob' "$out/bin/ob"
-    wrapProgram "$out"/bin/ob --prefix PATH : ${pkgs.lib.makeBinPath (commandRuntimeDeps pkgs)}
-  '';
+  command = ghcObelisk.obelisk-command;
   shell = pinBuildInputs "obelisk-shell" ([command] ++ commandRuntimeDeps pkgs) [];
 
   selftest = pkgs.writeScript "selftest" ''

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -110,7 +110,7 @@ initProject source = withSystemTempDirectory "ob-init" $ \tmpDir -> do
 --TODO: Allow the user to ignore our security concerns
 -- | Find the Obelisk implementation for the project at the given path
 findProjectObeliskCommand :: MonadObelisk m => FilePath -> m (Maybe FilePath)
-findProjectObeliskCommand target = withSpinnerNoTrail "Locating project obelisk" $ do
+findProjectObeliskCommand target = do
   myUid <- liftIO getRealUserID
   targetStat <- liftIO $ getFileStatus target
   (result, insecurePaths) <- flip runStateT [] $ walkToProjectRoot target targetStat myUid >>= \case


### PR DESCRIPTION
The autocompleter was not being installed because of the way we were wrapping the `ob` binary to include its run-time dependencies. The change now puts all modifications to the derivation in a single override of the main derivation instead of creating a chain of derivations that depend on each other; this makes easier to figure out what the actual artifact installed for users is. As a result, the `ob` command is now wrapped in place and the rest of the build artifacts are left intact.

There was also an issue where the program was outputting debug information that polluted the completion template. This logging was removed for the time being; if it's desirable to re-add, the logging should happen on stderr or be disabled when the program is run in completion script generation mode.