### PR TITLE
Fix build with no assets

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -154,6 +154,7 @@ in rec {
   } ''
     set -euo pipefail
     touch "$out"
+    mkdir -p "$symlinked"
     obelisk-asset-manifest-generate "$src" "$haskellManifest" ${packageName} ${moduleName} "$symlinked"
   '';
 


### PR DESCRIPTION
If no assets exist, obelisk failing in asset-manifest for unclear
reasons. It looks like symlinked just needs to be created
automatically.