### PR TITLE
Add RouteToUrl

### DIFF
--- a/lib/backend/src/Obelisk/Backend.hs
+++ b/lib/backend/src/Obelisk/Backend.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Obelisk.Backend
   ( Backend (..)
@@ -17,6 +18,7 @@ module Obelisk.Backend
   , prettifyOutput
   , runBackend
   , staticRenderContentType
+  , mkRouteToUrl
   ) where
 
 import Prelude hiding (id, (.))
@@ -57,8 +59,8 @@ data GhcjsApp route = GhcjsApp
 
 -- | Serve a frontend, which must be the same frontend that Obelisk has built and placed in the default location
 --TODO: The frontend should be provided together with the asset paths so that this isn't so easily breakable; that will probably make this function obsolete
-serveDefaultObeliskApp :: MonadSnap m => ([Text] -> m ()) -> Frontend (R appRoute) -> R (ObeliskRoute appRoute) -> m ()
-serveDefaultObeliskApp serveStaticAsset frontend = serveObeliskApp serveStaticAsset frontendApp
+serveDefaultObeliskApp :: MonadSnap m => (R appRoute -> Text) -> ([Text] -> m ()) -> Frontend (R appRoute) -> R (ObeliskRoute appRoute) -> m ()
+serveDefaultObeliskApp urlEnc serveStaticAsset frontend = serveObeliskApp urlEnc serveStaticAsset frontendApp
   where frontendApp = GhcjsApp
           { _ghcjsApp_compiled = defaultFrontendGhcjsAssets
           , _ghcjsApp_value = frontend
@@ -109,12 +111,12 @@ getRouteWith e = do
   pageName <- getPageName
   return $ tryDecode e pageName
 
-serveObeliskApp :: MonadSnap m => ([Text] -> m ()) -> GhcjsApp (R appRoute) -> R (ObeliskRoute appRoute) -> m ()
-serveObeliskApp serveStaticAsset frontendApp = \case
-  ObeliskRoute_App appRouteComponent :=> Identity appRouteRest -> serveGhcjsApp frontendApp $ GhcjsAppRoute_App appRouteComponent :/ appRouteRest
+serveObeliskApp :: MonadSnap m => (R appRoute -> Text) -> ([Text] -> m ()) -> GhcjsApp (R appRoute) -> R (ObeliskRoute appRoute) -> m ()
+serveObeliskApp urlEnc serveStaticAsset frontendApp = \case
+  ObeliskRoute_App appRouteComponent :=> Identity appRouteRest -> serveGhcjsApp urlEnc frontendApp $ GhcjsAppRoute_App appRouteComponent :/ appRouteRest
   ObeliskRoute_Resource resComponent :=> Identity resRest -> case resComponent :=> Identity resRest of
     ResourceRoute_Static :=> Identity pathSegments -> serveStaticAsset pathSegments
-    ResourceRoute_Ghcjs :=> Identity pathSegments -> serveGhcjsApp frontendApp $ GhcjsAppRoute_Resource :/ pathSegments
+    ResourceRoute_Ghcjs :=> Identity pathSegments -> serveGhcjsApp urlEnc frontendApp $ GhcjsAppRoute_Resource :/ pathSegments
     ResourceRoute_JSaddleWarp :=> Identity _ -> do
       let msg = "Error: Obelisk.Backend received jsaddle request"
       liftIO $ putStrLn $ T.unpack msg
@@ -137,11 +139,11 @@ staticRenderContentType :: ByteString
 staticRenderContentType = "text/html; charset=utf-8"
 
 --TODO: Don't assume we're being served at "/"
-serveGhcjsApp :: MonadSnap m => GhcjsApp (R appRouteComponent) -> R (GhcjsAppRoute appRouteComponent) -> m ()
-serveGhcjsApp app = \case
+serveGhcjsApp :: MonadSnap m => (R appRouteComponent -> Text) -> GhcjsApp (R appRouteComponent) -> R (GhcjsAppRoute appRouteComponent) -> m ()
+serveGhcjsApp urlEnc app = \case
   GhcjsAppRoute_App appRouteComponent :=> Identity appRouteRest -> do
     modifyResponse $ setContentType staticRenderContentType
-    writeBS <=< liftIO $ renderGhcjsFrontend (appRouteComponent :/ appRouteRest) $ _ghcjsApp_value app
+    writeBS <=< liftIO $ renderGhcjsFrontend urlEnc (appRouteComponent :/ appRouteRest) $ _ghcjsApp_value app
   GhcjsAppRoute_Resource :=> Identity pathSegments -> serveStaticAssets (_ghcjsApp_compiled app) pathSegments
 
 runBackend :: Backend fullRoute frontendRoute -> Frontend (R frontendRoute) -> IO ()
@@ -152,10 +154,17 @@ runBackend backend frontend = case checkEncoder $ _backend_routeEncoder backend 
       getRouteWith validFullEncoder >>= \case
         Identity r -> case r of
           InL backendRoute :=> Identity a -> serveRoute $ backendRoute :/ a
-          InR obeliskRoute :=> Identity a -> serveDefaultObeliskApp (serveStaticAssets defaultStaticAssets) frontend $ obeliskRoute :/ a
+          InR obeliskRoute :=> Identity a ->
+            serveDefaultObeliskApp (mkRouteToUrl validFullEncoder) (serveStaticAssets defaultStaticAssets) frontend $ obeliskRoute :/ a
 
-renderGhcjsFrontend :: route -> Frontend route -> IO ByteString
-renderGhcjsFrontend route f = do
+mkRouteToUrl :: Encoder Identity parse (R (Sum f (ObeliskRoute r))) PageName -> R r -> Text
+mkRouteToUrl validFullEncoder =
+  let pageNameEncoder' :: Encoder Identity (Either Text) PageName PathQuery = pageNameEncoder
+  in \(k :/ v) -> T.pack . uncurry (<>) . encode pageNameEncoder' . encode validFullEncoder $ (InR $ ObeliskRoute_App k) :/ v
+
+
+renderGhcjsFrontend :: MonadIO m => (route -> Text) -> route -> Frontend route -> m ByteString
+renderGhcjsFrontend urlEnc route f = do
   let baseTag  = elAttr "base" ("href" =: "/") blank --TODO: Figure out the base URL from the routes
       ghcjsScript = elAttr "script" ("language" =: "javascript" <> "src" =: "ghcjs/all.js" <> "defer" =: "defer") blank
-  renderFrontendHtml route (_frontend_head f >> injectExecutableConfigs >> baseTag) (_frontend_body f >> ghcjsScript)
+  liftIO $ renderFrontendHtml urlEnc route (_frontend_head f >> injectExecutableConfigs >> baseTag) (_frontend_body f >> ghcjsScript)

--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -41,6 +41,11 @@ module Obelisk.Route.Frontend
   , SetRoute(..)
   , runSetRouteT
   , mapSetRouteT
+  , RouteToUrl(..)
+  , RouteToUrlT(..)
+  , runRouteToUrlT
+  , mapRouteToUrlT
+  , routeLink
   ) where
 
 import Prelude hiding ((.), id)
@@ -61,6 +66,8 @@ import Data.Constraint (Dict (..))
 import Data.Dependent.Sum (DSum (..))
 import Data.GADT.Compare
 import Data.Monoid
+import Data.Proxy
+import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Functor.Compose
 import Reflex.Class
@@ -290,6 +297,85 @@ instance (Monad m, MonadQuery t vs m) => MonadQuery t vs (SetRouteT t r m) where
   askQueryResult = lift askQueryResult
   queryIncremental = lift . queryIncremental
 
+class RouteToUrl r m | m -> r where
+  askRouteToUrl :: m (r -> Text)
+
+newtype RouteToUrlT r m a = RouteToUrlT { unRouteToUrlT :: ReaderT (r -> Text) m a }
+  deriving (Functor, Applicative, Monad, MonadFix, MonadTrans, NotReady t, MonadHold t, MonadSample t, PostBuild t, TriggerEvent t, MonadIO, MonadReflexCreateTrigger t, HasDocument)
+
+runRouteToUrlT
+  :: RouteToUrlT r m a
+  -> (r -> Text)
+  -> m a
+runRouteToUrlT a = runReaderT (unRouteToUrlT a)
+
+mapRouteToUrlT :: (forall x. m x -> n x) -> RouteToUrlT r m a -> RouteToUrlT r n a
+mapRouteToUrlT f (RouteToUrlT m) = RouteToUrlT $ mapReaderT f m
+
+instance Monad m => RouteToUrl r (RouteToUrlT r m) where
+  askRouteToUrl = RouteToUrlT ask
+
+instance (Monad m, RouteToUrl r m) => RouteToUrl r (SetRouteT t r' m) where
+  askRouteToUrl = lift askRouteToUrl
+
+instance (Monad m, RouteToUrl r m) => RouteToUrl r (RoutedT t r' m) where
+  askRouteToUrl = lift askRouteToUrl
+
+instance HasJSContext m => HasJSContext (RouteToUrlT r m) where
+  type JSContextPhantom (RouteToUrlT r m) = JSContextPhantom m
+  askJSContext = lift askJSContext
+
+instance Prerender js m => Prerender js (RouteToUrlT r m) where
+  prerenderClientDict = fmap (\Dict -> Dict) (prerenderClientDict :: Maybe (Dict (PrerenderClientConstraint js m)))
+
+instance Requester t m => Requester t (RouteToUrlT r m) where
+  type Request (RouteToUrlT r m) = Request m
+  type Response (RouteToUrlT r m) = Response m
+  requesting = RouteToUrlT . requesting
+  requesting_ = RouteToUrlT . requesting_
+
+#ifndef ghcjs_HOST_OS
+deriving instance MonadJSM m => MonadJSM (RouteToUrlT r m)
+#endif
+
+instance PerformEvent t m => PerformEvent t (RouteToUrlT r m) where
+  type Performable (RouteToUrlT r m) = Performable m
+  performEvent = lift . performEvent
+  performEvent_ = lift . performEvent_
+
+instance MonadRef m => MonadRef (RouteToUrlT r m) where
+  type Ref (RouteToUrlT r m) = Ref m
+  newRef = lift . newRef
+  readRef = lift . readRef
+  writeRef r = lift . writeRef r
+
+instance HasJS x m => HasJS x (RouteToUrlT r m) where
+  type JSX (RouteToUrlT r m) = JSX m
+  liftJS = lift . liftJS
+
+instance MonadTransControl (RouteToUrlT r) where
+  type StT (RouteToUrlT r) a = StT (ReaderT (r -> Text)) a
+  liftWith = defaultLiftWith RouteToUrlT unRouteToUrlT
+  restoreT = defaultRestoreT RouteToUrlT
+
+instance PrimMonad m => PrimMonad (RouteToUrlT r m ) where
+  type PrimState (RouteToUrlT r m) = PrimState m
+  primitive = lift . primitive
+
+instance DomBuilder t m => DomBuilder t (RouteToUrlT r m) where
+  type DomBuilderSpace (RouteToUrlT r m) = DomBuilderSpace m
+
+instance Adjustable t m => Adjustable t (RouteToUrlT r m) where
+  runWithReplace a0 a' = RouteToUrlT $ runWithReplace (coerce a0) $ coerceEvent a'
+  traverseIntMapWithKeyWithAdjust f a0 a' = RouteToUrlT $ traverseIntMapWithKeyWithAdjust (coerce f) (coerce a0) $ coerce a'
+  traverseDMapWithKeyWithAdjust f a0 a' = RouteToUrlT $ traverseDMapWithKeyWithAdjust (\k v -> coerce $ f k v) (coerce a0) $ coerce a'
+  traverseDMapWithKeyWithAdjustWithMove f a0 a' = RouteToUrlT $ traverseDMapWithKeyWithAdjustWithMove (\k v -> coerce $ f k v) (coerce a0) $ coerce a'
+
+instance (Monad m, MonadQuery t vs m) => MonadQuery t vs (RouteToUrlT r m) where
+  tellQueryIncremental = lift . tellQueryIncremental
+  askQueryResult = lift askQueryResult
+  queryIncremental = lift . queryIncremental
+
 runRouteViewT
   :: forall t m r a.
      ( TriggerEvent t m
@@ -300,7 +386,7 @@ runRouteViewT
      , MonadFix m
      )
   => (Encoder Identity Identity r PageName)
-  -> RoutedT t r (SetRouteT t r m) a
+  -> RoutedT t r (SetRouteT t r (RouteToUrlT r m)) a
   -> m a
 runRouteViewT routeEncoder a = do
   rec historyState <- manageHistory $ HistoryCommand_PushState <$> setState
@@ -313,7 +399,7 @@ runRouteViewT routeEncoder a = do
             where
               errorLeft (Left e) = error (T.unpack e)
               errorLeft (Right x) = x
-      (result, changeState) <- runSetRouteT $ runRoutedT a route
+      (result, changeState) <- runRouteToUrlT (runSetRouteT $ runRoutedT a route) $ (\(p, q) -> T.pack $ p <> q) . encode theEncoder
       let f (currentHistoryState, oldRoute) change =
             let newRoute = appEndo change oldRoute
                 (newPath, newQuery) = encode theEncoder newRoute
@@ -336,6 +422,24 @@ runRouteViewT routeEncoder a = do
                }
           setState = attachWith f ((,) <$> current historyState <*> current route) changeState
   return result
+
+routeLink
+  :: forall t m a route.
+     ( DomBuilder t m
+     , RouteToUrl (R route) m
+     , SetRoute t (R route) m
+     )
+  => R route -- ^ Target route
+  -> m a -- ^ Child widget
+  -> m a
+routeLink r w = do
+  enc <- askRouteToUrl
+  let cfg = (def :: ElementConfig EventResult t (DomBuilderSpace m))
+        & elementConfig_eventSpec %~ addEventSpecFlags (Proxy :: Proxy (DomBuilderSpace m)) Click (\_ -> preventDefault)
+        & elementConfig_initialAttributes .~ "href" =: enc r
+  (e, a) <- element "a" cfg w
+  setRoute $ r <$ domEvent Click e
+  return a
 
 -- On ios due to sandboxing when loading the page from a file adapt the
 -- path to be based on the hash.

--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -423,6 +423,8 @@ runRouteViewT routeEncoder a = do
           setState = attachWith f ((,) <$> current historyState <*> current route) changeState
   return result
 
+-- | A link widget that, when clicked, sets the route to the provided route. In non-javascript
+-- contexts, this widget falls back to using @href@s to control navigation
 routeLink
   :: forall t m a route.
      ( DomBuilder t m

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -143,7 +143,7 @@ obeliskApp opts frontend validFullEncoder uri backend = do
           }
       InR (ObeliskRoute_App appRouteComponent) :=> Identity appRouteRest -> do
         html <- renderJsaddleFrontend (appRouteComponent :/ appRouteRest) frontend
-        sendResponse $ W.responseLBS H.status200 [("Content-Type", "text/html")] $ BSLC.fromStrict html
+        sendResponse $ W.responseLBS H.status200 [("Content-Type", staticRenderContentType)] $ BSLC.fromStrict html
       _ -> backend req sendResponse
 
 renderJsaddleFrontend :: route -> Frontend route -> IO ByteString


### PR DESCRIPTION
Depends on #282 

Some machinery to support `routeLink`, a link widget that, when clicked, sets the route to the provided route. In non-javascript contexts, this widget falls back to using `href`s to control navigation.