### PR TITLE
Prevent impure path from polluting builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -152,7 +152,7 @@ in rec {
     set -euo pipefail
     touch "$out"
     mkdir -p "$symlinked"
-    obelisk-asset-manifest-generate "$src" "${builtins.toString src}" "$haskellManifest" ${packageName} ${moduleName} "$symlinked"
+    obelisk-asset-manifest-generate "$src" "$haskellManifest" ${packageName} ${moduleName} "$symlinked"
   '';
 
   compressedJs = frontend: optimizationLevel: pkgs.runCommand "compressedJs" { buildInputs = [ pkgs.closurecompiler ]; } ''
@@ -273,6 +273,7 @@ in rec {
                   backendName = "backend";
                   commonName = "common";
                   staticName = "obelisk-generated-static";
+                  staticFilesImpure = if lib.isDerivation staticFiles then staticFiles else toString staticFiles;
                   processedStatic = processAssets { src = staticFiles; };
                   # The packages whose names and roles are defined by this package
                   predefinedPackages = lib.filterAttrs (_: x: x != null) {
@@ -324,7 +325,7 @@ in rec {
                       nixpkgs.obeliskExecutableConfig.platforms.ios.inject injectableConfig processedStatic.symlinked;
                   } // ios;
                 };
-                passthru = { inherit android ios packages overrides tools shellToolOverrides withHoogle staticFiles __closureCompilerOptimizationLevel; };
+                passthru = { inherit android ios packages overrides tools shellToolOverrides withHoogle staticFiles staticFilesImpure __closureCompilerOptimizationLevel; };
               };
           in mkProject (projectDefinition args));
       serverOn = sys: config: version: serverExe

--- a/lib/asset/manifest/src-bin/generate.hs
+++ b/lib/asset/manifest/src-bin/generate.hs
@@ -7,11 +7,10 @@ import System.Environment
 main :: IO ()
 main = do
   --TODO: Usage
-  [root, rootLocalPath, haskellTarget, packageName, moduleName, fileTarget] <- getArgs
+  [root, haskellTarget, packageName, moduleName, fileTarget] <- getArgs
   paths <- gatherHashedPaths root
   writeStaticProject paths haskellTarget $ StaticConfig
     { _staticConfig_packageName = T.pack packageName
     , _staticConfig_moduleName = T.pack moduleName
-    , _staticConfig_rootPath = rootLocalPath
     }
   copyAndSymlink paths root fileTarget

--- a/lib/asset/manifest/src/Obelisk/Asset/Promoted.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/Promoted.hs
@@ -28,7 +28,6 @@ import qualified Data.Map as Map
 data StaticConfig = StaticConfig
   { _staticConfig_packageName :: Text --TODO: Better type
   , _staticConfig_moduleName :: Text --TODO: Better type
-  , _staticConfig_rootPath :: FilePath
   }
 
 writeStaticProject :: Map FilePath FilePath -> FilePath -> StaticConfig -> IO ()
@@ -41,14 +40,7 @@ writeStaticProject paths target cfg = do
         Just (name, parents) -> (name, target </> "src" </> T.unpack (T.intercalate "/" $ reverse parents))
   createDirectoryIfMissing True moduleDirPath
   modContents <- staticModuleFile modName paths
-  T.writeFile (moduleDirPath </> T.unpack modName' <.> "hs") $ appendRootPath (_staticConfig_rootPath cfg) modContents
-
-appendRootPath :: FilePath -> Text -> Text
-appendRootPath fp txt = T.unlines
-  [ txt
-  , "staticRootPath :: FilePath"
-  , "staticRootPath = \"" <> T.pack fp <> "\""
-  ]
+  T.writeFile (moduleDirPath </> T.unpack modName' <.> "hs") modContents
 
 staticCabalFile :: StaticConfig -> Text
 staticCabalFile cfg = T.unlines

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -145,7 +145,7 @@ findProjectRoot target = do
   (result, _) <- liftIO $ runStateT (walkToProjectRoot target targetStat myUid) []
   return result
 
-withProjectRoot :: MonadObelisk m => FilePath -> (FilePath -> m ()) -> m ()
+withProjectRoot :: MonadObelisk m => FilePath -> (FilePath -> m a) -> m a
 withProjectRoot target f = findProjectRoot target >>= \case
   Nothing -> failWith "Must be used inside of an Obelisk project"
   Just root -> f root


### PR DESCRIPTION
`obelisk-generated-static` will no longer contain `staticRootPath`. Instead `ob run` will pass that in to the interpreter. That way no builds are polluted.