### PR TITLE
Make path optional on nix-* command

### DIFF
--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -99,7 +99,7 @@ deployPush deployPath getNixBuilders = do
   builders <- getNixBuilders
   buildOutput <- nixCmd $ NixCmd_Build $ def
     & nixCmdConfig_target .~Target
-      { _target_path = srcPath
+      { _target_path = Just srcPath
       , _target_attr = Just "server.system"
       }
     & nixBuildConfig_outLink .~ OutLink_None

--- a/lib/command/src/Obelisk/Command/Nix.hs
+++ b/lib/command/src/Obelisk/Command/Nix.hs
@@ -33,6 +33,7 @@ import Control.Lens
 import Data.Bool (bool)
 import Data.Default
 import Data.List (intercalate)
+import Data.Maybe
 import Data.Monoid ((<>))
 import qualified Data.Text as T
 import System.Process (proc)
@@ -42,14 +43,14 @@ import Obelisk.CliApp
 
 -- | What to build
 data Target = Target
-  { _target_path :: FilePath
+  { _target_path :: Maybe FilePath
   , _target_attr :: Maybe String
   }
 makeClassy ''Target
 
 instance Default Target where
   def = Target
-    { _target_path = "."
+    { _target_path = Just "."
     , _target_attr = Nothing
     }
 
@@ -83,7 +84,7 @@ instance Default NixCommonConfig where
   def = NixCommonConfig def mempty mempty
 
 runNixCommonConfig :: NixCommonConfig -> [FilePath]
-runNixCommonConfig cfg = mconcat [[path], attrArg, args, buildersArg]
+runNixCommonConfig cfg = mconcat [maybeToList path, attrArg, args, buildersArg]
   where
     path = _target_path $ _nixCmdConfig_target cfg
     attr = _target_attr $ _nixCmdConfig_target cfg
@@ -151,7 +152,7 @@ instance Default NixCmd where
   def = NixCmd_Build def
 
 nixCmd :: MonadObelisk m => NixCmd -> m FilePath
-nixCmd cmdCfg = withSpinner' ("Running " <> cmd <> " on " <> desc) (Just $ const $ "Built " <> desc) $ do
+nixCmd cmdCfg = withSpinner' ("Running " <> cmd <> desc) (Just $ const $ "Built " <> desc) $ do
   output <- readProcessAndLogStderr Debug $ proc (T.unpack cmd) $ options
   -- Remove final newline that Nix appends
   Just (outPath, '\n') <- pure $ T.unsnoc output
@@ -169,6 +170,7 @@ nixCmd cmdCfg = withSpinner' ("Running " <> cmd <> " on " <> desc) (Just $ const
         , cfg' ^. nixCommonConfig
         )
     path = commonCfg ^. nixCmdConfig_target . target_path
-    desc = T.pack $ path <> maybe ""
-      (\a -> " [" <> a <> "]")
-      (commonCfg ^. nixCmdConfig_target . target_attr)
+    desc = T.pack $ mconcat $ catMaybes
+      [ (" on " <>) <$> path
+      , (\a -> " [" <> a <> "]") <$> (commonCfg ^. nixCmdConfig_target . target_attr)
+      ]

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -505,7 +505,7 @@ nixBuildThunkAttrWithCache thunkDir attr = do
       _ <- nixCmd $ NixCmd_Build$ def
         Lens.& nixBuildConfig_outLink Lens..~ OutLink_IndirectRoot cachePath
         Lens.& nixCmdConfig_target Lens..~ Target
-          { _target_path = thunkDir
+          { _target_path = Just thunkDir
           , _target_attr = Just attr
           }
       return cachePath
@@ -526,7 +526,7 @@ nixBuildAttrWithCache exprPath attr = do
     _ -> nixCmd $ NixCmd_Build $ def
       Lens.& nixBuildConfig_outLink Lens..~ OutLink_None
       Lens.& nixCmdConfig_target Lens..~ Target
-        { _target_path = exprPath
+        { _target_path = Just exprPath
         , _target_attr = Just attr
         }
 


### PR DESCRIPTION
this would be necessary for `nix-build --expr` which it does not take a
path