### PR TITLE
Downgrade spinners

### DIFF
--- a/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
@@ -133,14 +133,8 @@ runSpinner spinner f = forM_ spinner $ f >=> const delay
 type SpinnerTheme = [Text]
 
 -- Find more spinners at https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
-_spinnerCircleHalves :: SpinnerTheme
-_spinnerCircleHalves = ["◐", "◓", "◑", "◒"]
-
-spinnerMoon :: SpinnerTheme
-spinnerMoon = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"]
-
 defaultSpinnerTheme :: SpinnerTheme
-defaultSpinnerTheme = spinnerMoon
+defaultSpinnerTheme = ["◐", "◓", "◑", "◒"]
 
 -- | Like `bracket` but the `release` function can know whether an exception was raised
 bracket' :: MonadMask m => m a -> (a -> Maybe c -> m b) -> (a -> m c) -> m c


### PR DESCRIPTION
The moon spinner does not render properly in urxvt, and presumably other terminals.

Longer-term, we should really see if we can detect whether unicode is allowed at all, and fallback to something like `/-\|` if not.