### PR TITLE
Add renderBackendRoute

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -833,8 +833,8 @@ makePrisms ''ObeliskRoute
 deriveGEq ''Void1
 deriveGCompare ''Void1
 
--- | Given a backend route and the standard backend route encoder,
--- render the route (path and query string).
+-- | Given a backend route and a checked route encoder, render the route (path
+-- and query string). See 'checkEncoder' for how to produce a checked encoder.
 renderBackendRoute
   :: forall br a.
      Encoder Identity Identity (R (Sum br a)) PageName

--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -19,6 +19,7 @@
 module Obelisk.Route
   ( R
   , pattern (:/)
+  , hoistR
   , PageName
   , PathQuery
   , Encoder
@@ -148,6 +149,9 @@ pattern a :/ b = a :=> Identity b
 
 mapSome :: (forall a. f a -> g a) -> Some f -> Some g
 mapSome f (Some.This a) = Some.This $ f a
+
+hoistR :: (forall x. f x -> g x) -> R f -> R g
+hoistR f (x :=> Identity y) = f x :/ y
 
 --------------------------------------------------------------------------------
 -- Encoder fundamentals

--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -81,8 +81,6 @@ module Obelisk.Route
   , queryParametersTextEncoder
   , renderObeliskRoute
   , renderBackendRoute
-  , renderBackendUrl
-  , unsafeRenderBackendRoute
   , renderFrontendRoute
   ) where
 

--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -842,17 +842,6 @@ renderBackendRoute
   -> Text
 renderBackendRoute enc = renderObeliskRoute enc . hoistR InL
 
--- | Renders a backend route and assumes that the supplied encoder is valid.
--- If you have a valid (i.e., checked) encoder, you can use 'renderBackendRoute'
--- instead. See 'checkEncoder' for more information.
-unsafeRenderBackendRoute
-  :: Encoder (Either Text) Identity (R (Sum br a)) PageName
-  -> R br
-  -> Text
-unsafeRenderBackendRoute backendRouteEncoder =
-  let Right enc = checkEncoder backendRouteEncoder
-  in renderBackendRoute enc
-
 -- | Renders a full backend url, using the provided route prefix (typically the scheme and authority).
 -- This is typically retrived from the "route" configuration in Obelisk applications. The prefix is
 -- assumed not to have a trailing slash.

--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -842,16 +842,6 @@ renderBackendRoute
   -> Text
 renderBackendRoute enc = renderObeliskRoute enc . hoistR InL
 
--- | Renders a full backend url, using the provided route prefix (typically the scheme and authority).
--- This is typically retrived from the "route" configuration in Obelisk applications. The prefix is
--- assumed not to have a trailing slash.
-renderBackendUrl
-  :: Text -- ^ Base application route
-  -> Encoder Identity Identity (R (Sum br a)) PageName
-  -> R br
-  -> Text
-renderBackendUrl prefix enc = (prefix <>) . renderBackendRoute enc
-
 -- | Renders a frontend route with the supplied checked encoder
 renderFrontendRoute
   :: forall a fr.


### PR DESCRIPTION
Depends on #340 

Useful if you want to, e.g., generate a backend route on the frontend. 

This feels a bit dissimilar to the other things in this module - maybe that's a bad sign.