### PR TITLE
Fix: 'ob init' crashes when LANG is unset

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -303,14 +303,16 @@ in rec {
                     ${if android == null then null else frontendName} = {
                       executableName = "frontend";
                       ${if builtins.pathExists staticFiles then "assets" else null} =
-                        nixpkgs.obeliskExecutableConfig.platforms.android.inject (injectableConfig configPath) processedStatic.symlinked;
+                        (if configPath == null then lib.id else  nixpkgs.obeliskExecutableConfig.platforms.android.inject (injectableConfig configPath))
+                         processedStatic.symlinked;
                     } // android;
                   };
                   __ios = configPath: {
                     ${if ios == null then null else frontendName} = {
                       executableName = "frontend";
                       ${if builtins.pathExists staticFiles then "staticSrc" else null} =
-                        nixpkgs.obeliskExecutableConfig.platforms.ios.inject (injectableConfig configPath) processedStatic.symlinked;
+                         (if configPath == null then lib.id else nixpkgs.obeliskExecutableConfig.platforms.ios.inject (injectableConfig configPath))
+                         processedStatic.symlinked;
                     } // ios;
                   };
               in {

--- a/lib/cliapp/src/Obelisk/CliApp/Logging.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Logging.hs
@@ -47,7 +47,7 @@ import System.Console.ANSI (Color (Red, Yellow), ColorIntensity (Vivid),
                             ConsoleIntensity (FaintIntensity), ConsoleLayer (Foreground),
                             SGR (SetColor, SetConsoleIntensity), clearLine)
 import System.Exit (ExitCode (..))
-import System.IO (BufferMode (NoBuffering), hFlush, hReady, hSetBuffering, stderr, stdin, stdout)
+import System.IO (BufferMode (NoBuffering), hFlush, hReady, hSetBuffering, stderr, stdin, stdout, hGetEncoding)
 
 import qualified Obelisk.CliApp.TerminalString as TS
 import Obelisk.CliApp.Types
@@ -63,7 +63,8 @@ newCliConfig sev noColor noSpinner errorLogExitCode = do
   lock <- newMVar False
   tipDisplayed <- newIORef False
   stack <- newIORef ([], [])
-  return $ CliConfig level noColor noSpinner lock tipDisplayed stack errorLogExitCode
+  textEncoding <- hGetEncoding stdout
+  return $ CliConfig level noColor noSpinner lock tipDisplayed stack errorLogExitCode textEncoding
 
 runCli :: MonadIO m => CliConfig e -> CliT e m a -> m a
 runCli c =

--- a/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
@@ -72,11 +72,11 @@ withSpinner' msg mkTrail action = do
       logMessage Output_ClearLine
       logsM <- modifyStack $ popSpinner $ case resultM of
         Nothing ->
-          ( TerminalString_Colorized Red "✖"
+          ( TerminalString_Colorized Red "FAILED"
           , Just msg  -- Always display final message if there was an exception.
           )
         Just result ->
-          ( TerminalString_Colorized Green "✔"
+          ( TerminalString_Colorized Green "DONE"
           , mkTrail <*> pure result
           )
       -- Last message, finish off with newline.
@@ -102,7 +102,7 @@ withSpinner' msg mkTrail action = do
       =<< fmap _cliConfig_spinnerStack getCliConfig
     modifyStack f = liftIO . flip atomicModifyIORef' f
       =<< fmap _cliConfig_spinnerStack getCliConfig
-    spinner = coloredSpinner defaultSpinnerTheme
+    spinner = coloredSpinner minimalSpinnerTheme
 
 -- | How nested spinner logs should be displayed
 renderSpinnerStack
@@ -114,7 +114,7 @@ renderSpinnerStack mark = L.intersperse space . go . L.reverse
     go [] = []
     go (x:[]) = mark : [x]
     go (x:xs) = arrow : x : go xs
-    arrow = TerminalString_Colorized Blue "⇾"
+    arrow = TerminalString_Colorized Blue "->"
     space = TerminalString_Normal " "
 
 -- | A spinner is simply an infinite list of strings that supplant each other in a delayed loop, creating the
@@ -133,14 +133,14 @@ runSpinner spinner f = forM_ spinner $ f >=> const delay
 type SpinnerTheme = [Text]
 
 -- Find more spinners at https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
-_spinnerCircleHalves :: SpinnerTheme
-_spinnerCircleHalves = ["◐", "◓", "◑", "◒"]
+_spinnerSticks :: SpinnerTheme
+_spinnerSticks = ["|", "/", "-", "\\"]
 
-spinnerMoon :: SpinnerTheme
-spinnerMoon = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"]
+spinnerStick :: SpinnerTheme
+spinnerStick = ["|", "/", "-", "\\"]
 
-defaultSpinnerTheme :: SpinnerTheme
-defaultSpinnerTheme = spinnerMoon
+minimalSpinnerTheme :: SpinnerTheme
+minimalSpinnerTheme = spinnerStick
 
 -- | Like `bracket` but the `release` function can know whether an exception was raised
 bracket' :: MonadMask m => m a -> (a -> Maybe c -> m b) -> (a -> m c) -> m c

--- a/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
@@ -94,10 +94,10 @@ withSpinner' msg mkTrail action = do
       )
       where
         isTemporary = isNothing mkTrail
-    popSpinner mTextEncoding (mark, trailMsgM) (flag, old) =
+    popSpinner theme (mark, trailMsgM) (flag, old) =
       ( (newFlag, new)
       -- With final trail spinner message to render
-      , renderSpinnerStack mTextEncoding mark . (: new) . TerminalString_Normal <$> (
+      , renderSpinnerStack theme mark . (: new) . TerminalString_Normal <$> (
           if inTemporarySpinner then Nothing else trailMsgM
           )
       )

--- a/lib/cliapp/src/Obelisk/CliApp/Types.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Types.hs
@@ -20,6 +20,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans (MonadTrans, lift)
 import Data.IORef (IORef)
 import Data.Text (Text)
+import System.IO (TextEncoding)
 import System.Exit (ExitCode (..), exitWith)
 
 import Obelisk.CliApp.TerminalString (TerminalString)
@@ -88,6 +89,8 @@ data CliConfig e = CliConfig
     _cliConfig_spinnerStack :: IORef ([Bool], [TerminalString])
   , -- | Failure handler. How to log error and what exit status to use.
     _cliConfig_errorLogExitCode :: e -> (Text, Int)
+  , -- | Type of encoding allowed
+    _cliConfig_textEncoding :: Maybe TextEncoding
   }
 
 class Monad m => HasCliConfig e m | m -> e where


### PR DESCRIPTION
Remove use of Unicode chars during logging of ob commands