### PR TITLE
Add new loader for GitHub, utilizing fetchTarball

### DIFF
--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -416,8 +416,8 @@ setThunk target gs branch = do
 gitHubStandaloneLoaders :: NonEmpty Text
 gitHubStandaloneLoaders =
   gitHubStandaloneLoaderV4 :|
-  [ gitHubStandaloneLoaderV2
-  , gitHubStandaloneLoaderV3
+  [ gitHubStandaloneLoaderV3
+  , gitHubStandaloneLoaderV2
   , gitHubStandaloneLoaderV1
   ]
 

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -470,16 +470,10 @@ gitHubStandaloneLoaderV4 = T.unlines
   , "      url = \"https://github.com/${owner}/${repo}/archive/${rev}.tar.gz\";"
   , "      inherit sha256; })"
   , "    else (import <nixpkgs> {}).fetchFromGitHub;"
-  , "  fetchFromGitHubPrivate ="
-  , "    { owner, repo, rev, branch ? null, name ? null, sha256 ? null"
-  , "    , private ? false, fetchSubmodules ? false"
-  , "    , githubBase ? \"github.com\", ...}: assert !fetchSubmodules;"
-  , "      builtins.fetchGit ({"
-  , "        url = \"ssh://git@${githubBase}/${owner}/${repo}.git\";"
-  , "        inherit rev;"
-  , "      } // (if branch == null then {} else { ref = branch; })"
-  , "        // (if name == null then {} else { inherit name; }));"
- , "in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))"
+  , "  fetchFromGitHubPrivate = { owner, repo, rev, sha256, ... }:"
+  , "    (import <nixpkgs> {}).fetchFromGitHub"
+  , "      { inherit owner repo rev sha256; private = true; }"
+  , "in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))"
   ]
 
 plainGitStandaloneLoaders :: NonEmpty Text

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -415,8 +415,9 @@ setThunk target gs branch = do
 -- This tool will only ever produce the newest one when it writes a thunk.
 gitHubStandaloneLoaders :: NonEmpty Text
 gitHubStandaloneLoaders =
-  gitHubStandaloneLoaderV2 :|
-  [ gitHubStandaloneLoaderV3
+  gitHubStandaloneLoaderV4 :|
+  [ gitHubStandaloneLoaderV2
+  , gitHubStandaloneLoaderV3
   , gitHubStandaloneLoaderV1
   ]
 
@@ -454,6 +455,31 @@ gitHubStandaloneLoaderV3 = T.unlines
   , "      // (if branch == null then {} else { ref = branch; })"
   , "      // (if name == null then {} else { inherit name; }));"
   , "in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))"
+  ]
+
+gitHubStandaloneLoaderV4 :: Text
+gitHubStandaloneLoaderV4 = T.unlines
+  [ "# DO NOT HAND-EDIT THIS FILE"
+  , "let"
+  , "  fetch = { private ? false, ... }@args:"
+  , "    if private && builtins.hasAttr \"fetchGit\" builtins"
+  , "    then fetchFromGitHubPrivate args"
+  , "    else fetchFromGitHub (builtins.removeAttrs args [\"branch\"]);"
+  , "  fetchFromGitHub = if builtins.hasAttr \"fetchTarball\" builtins then"
+  , "    ({ owner, repo, rev, sha256, ... }: builtins.fetchTarball {"
+  , "      url = \"https://github.com/${owner}/${repo}/archive/${rev}.tar.gz\";"
+  , "      inherit sha256; })"
+  , "    else (import <nixpkgs> {}).fetchFromGitHub;"
+  , "  fetchFromGitHubPrivate ="
+  , "    { owner, repo, rev, branch ? null, name ? null, sha256 ? null"
+  , "    , private ? false, fetchSubmodules ? false"
+  , "    , githubBase ? \"github.com\", ...}: assert !fetchSubmodules;"
+  , "      builtins.fetchGit ({"
+  , "        url = \"ssh://git@${githubBase}/${owner}/${repo}.git\";"
+  , "        inherit rev;"
+  , "      } // (if branch == null then {} else { ref = branch; })"
+  , "        // (if name == null then {} else { inherit name; }));"
+ , "in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))"
   ]
 
 plainGitStandaloneLoaders :: NonEmpty Text


### PR DESCRIPTION
This can use Nix 2.0’s builtins.fetchTarball if it is available. If
not, it will fall back on old behavior.

The benefit of builtins.fetchTarball is that we don't need to
import Nixpkgs just for fetchTarball. This means that we
should use less memory for each evaluation.