### PR TITLE
Enable WebSockets through nginx configuration

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -206,6 +206,7 @@ in rec {
           forceSSL = enableHttps;
           locations.${baseUrl} = {
             proxyPass = "http://localhost:" + toString internalPort;
+            proxyWebsockets = true;
           };
         };
       };


### PR DESCRIPTION
Without this, connection attempts fail with "426 Upgrade Required". Resolves #352.