### PR TITLE
Fix <base> tag rendering.

### DIFF
--- a/lib/backend/obelisk-backend.cabal
+++ b/lib/backend/obelisk-backend.cabal
@@ -14,7 +14,6 @@ library
                  lens,
                  mtl,
                  obelisk-asset-serve-snap,
-                 obelisk-executable-config-inject,
                  obelisk-frontend,
                  obelisk-route,
                  obelisk-snap-extras,

--- a/lib/backend/src/Obelisk/Backend.hs
+++ b/lib/backend/src/Obelisk/Backend.hs
@@ -37,7 +37,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding
 import Obelisk.Asset.Serve.Snap (serveAsset)
-import Obelisk.ExecutableConfig.Inject (injectExecutableConfigs)
 import Obelisk.Frontend
 import Obelisk.Route
 import Obelisk.Snap.Extras (doNotCache, serveFileIfExistsAs)
@@ -167,9 +166,8 @@ mkRouteToUrl validFullEncoder =
 
 renderGhcjsFrontend :: MonadIO m => (route -> Text) -> route -> Frontend route -> m ByteString
 renderGhcjsFrontend urlEnc route f = do
-  let baseTag  = elAttr "base" ("href" =: "/") blank --TODO: Figure out the base URL from the routes
-      ghcjsPreload = elAttr "link" ("rel" =: "preload" <> "as" =: "script" <> "href" =: "ghcjs/all.js") blank
+  let ghcjsPreload = elAttr "link" ("rel" =: "preload" <> "as" =: "script" <> "href" =: "ghcjs/all.js") blank
       ghcjsScript = elAttr "script" ("language" =: "javascript" <> "src" =: "ghcjs/all.js" <> "defer" =: "defer") blank
   liftIO $ renderFrontendHtml urlEnc route
-    (baseTag >> _frontend_head f >> injectExecutableConfigs >> ghcjsPreload)
+    (_frontend_head f >> ghcjsPreload)
     (_frontend_body f >> ghcjsScript)

--- a/lib/backend/src/Obelisk/Backend.hs
+++ b/lib/backend/src/Obelisk/Backend.hs
@@ -171,5 +171,5 @@ renderGhcjsFrontend urlEnc route f = do
       ghcjsPreload = elAttr "link" ("rel" =: "preload" <> "as" =: "script" <> "href" =: "ghcjs/all.js") blank
       ghcjsScript = elAttr "script" ("language" =: "javascript" <> "src" =: "ghcjs/all.js" <> "defer" =: "defer") blank
   liftIO $ renderFrontendHtml urlEnc route
-    (_frontend_head f >> injectExecutableConfigs >> baseTag >> ghcjsPreload)
+    (baseTag >> _frontend_head f >> injectExecutableConfigs >> ghcjsPreload)
     (_frontend_body f >> ghcjsScript)

--- a/lib/frontend/obelisk-frontend.cabal
+++ b/lib/frontend/obelisk-frontend.cabal
@@ -11,6 +11,7 @@ library
                  ghcjs-dom,
                  jsaddle,
                  lens,
+                 obelisk-executable-config-inject,
                  obelisk-route,
                  primitive,
                  ref-tf,

--- a/lib/frontend/src/Obelisk/Frontend.hs
+++ b/lib/frontend/src/Obelisk/Frontend.hs
@@ -42,6 +42,7 @@ import Obelisk.Route.Frontend
 import Reflex.Dom.Core
 import Reflex.Host.Class
 import qualified Reflex.TriggerEvent.Base as TriggerEvent
+import Obelisk.ExecutableConfig.Inject (injectExecutableConfigs)
 
 makePrisms ''Sum
 
@@ -163,6 +164,9 @@ renderFrontendHtml urlEnc route headWidget bodyWidget = do
   --TODO: We should probably have a "NullEventWriterT" or a frozen reflex timeline
   html <- fmap snd $ renderStatic $ fmap fst $ flip runRouteToUrlT urlEnc $ runSetRouteT $ flip runRoutedT (pure route) $
     el "html" $ do
-      el "head" headWidget
+      el "head" $ do
+        let baseTag = elAttr "base" ("href" =: "/") blank --TODO: Figure out the base URL from the routes
+        -- The order here is important - baseTag has to be before headWidget!
+        baseTag >> injectExecutableConfigs >> headWidget
       el "body" bodyWidget
   return $ "<!DOCTYPE html>" <> html

--- a/lib/run/obelisk-run.cabal
+++ b/lib/run/obelisk-run.cabal
@@ -25,7 +25,6 @@ library
     , obelisk-asset-serve-snap
     , obelisk-backend
     , obelisk-executable-config
-    , obelisk-executable-config-inject
     , obelisk-frontend
     , obelisk-route
     , process

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -50,7 +50,6 @@ import Network.WebSockets (ConnectionOptions)
 import Network.WebSockets.Connection (defaultConnectionOptions)
 import qualified Obelisk.Asset.Serve.Snap as Snap
 import Obelisk.ExecutableConfig (get)
-import Obelisk.ExecutableConfig.Inject (injectExecutableConfigs)
 import Obelisk.Frontend
 import Obelisk.Route.Frontend
 import Reflex.Dom.Core
@@ -152,8 +151,7 @@ renderJsaddleFrontend :: (route -> Text) -> route -> Frontend route -> IO ByteSt
 renderJsaddleFrontend urlEnc r f =
   let jsaddleScript = elAttr "script" ("src" =: "/jsaddle/jsaddle.js") blank
       jsaddlePreload = elAttr "link" ("rel" =: "preload" <> "as" =: "script" <> "href" =: "/jsaddle/jsaddle.js") blank
-      baseTag  = elAttr "base" ("href" =: "/") blank --TODO: Figure out the base URL from the routes
-  in renderFrontendHtml urlEnc r (baseTag >> _frontend_head f >> injectExecutableConfigs >> jsaddlePreload) (_frontend_body f >> jsaddleScript)
+  in renderFrontendHtml urlEnc r (_frontend_head f >> jsaddlePreload) (_frontend_body f >> jsaddleScript)
 
 -- | like 'bindPortTCP' but reconnects on exception
 bindPortTCPRetry :: Settings

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -152,7 +152,8 @@ renderJsaddleFrontend :: (route -> Text) -> route -> Frontend route -> IO ByteSt
 renderJsaddleFrontend urlEnc r f =
   let jsaddleScript = elAttr "script" ("src" =: "/jsaddle/jsaddle.js") blank
       jsaddlePreload = elAttr "link" ("rel" =: "preload" <> "as" =: "script" <> "href" =: "/jsaddle/jsaddle.js") blank
-  in renderFrontendHtml urlEnc r (_frontend_head f >> injectExecutableConfigs >> jsaddlePreload) (_frontend_body f >> jsaddleScript)
+      baseTag  = elAttr "base" ("href" =: "/") blank --TODO: Figure out the base URL from the routes
+  in renderFrontendHtml urlEnc r (baseTag >> _frontend_head f >> injectExecutableConfigs >> jsaddlePreload) (_frontend_body f >> jsaddleScript)
 
 -- | like 'bindPortTCP' but reconnects on exception
 bindPortTCPRetry :: Settings


### PR DESCRIPTION
The generated uris for `static @` should really be absolute and not relative. In a project of mine, we now have some frontend uris which change the path to no longer being "/", without this change static resource loading is broken.