### PR TITLE
Don't copy the dev config into the deployment when using `ob deploy i…

### DIFF
--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -330,8 +330,7 @@ ob = \case
           route = _deployInitOpts_route deployOpts
           adminEmail = _deployInitOpts_adminEmail deployOpts
           enableHttps = _deployInitOpts_enableHttps deployOpts
-      deployInit thunkPtr (root </> "config") deployDir
-        sshKeyPath hostname route adminEmail enableHttps
+      deployInit thunkPtr deployDir sshKeyPath hostname route adminEmail enableHttps
     DeployCommand_Push remoteBuilder -> do
       deployPath <- liftIO $ canonicalizePath "."
       deployPush deployPath $ case remoteBuilder of

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -47,33 +47,38 @@ deployInit
   => ThunkPtr
   -> FilePath
   -> FilePath
-  -> FilePath
   -> [String] -- ^ hostnames
   -> String -- ^ route
   -> String -- ^ admin email
   -> Bool -- ^ enable https
   -> m ()
-deployInit thunkPtr configDir deployDir sshKeyPath hostnames route adminEmail enableHttps = do
-  (hasConfigDir, localKey) <- withSpinner ("Preparing " <> T.pack deployDir) $ do
-    hasConfigDir <- liftIO $ do
-      createDirectoryIfMissing True deployDir
-      doesDirectoryExist configDir
+deployInit thunkPtr deployDir sshKeyPath hostnames route adminEmail enableHttps = do
+  localKey <- withSpinner ("Preparing " <> T.pack deployDir) $ do
     localKey <- liftIO (doesFileExist sshKeyPath) >>= \case
       False -> failWith $ T.pack $ "ob deploy init: file does not exist: " <> sshKeyPath
       True -> pure $ deployDir </> "ssh_key"
     callProcessAndLogOutput (Notice, Error) $
       proc "cp" [sshKeyPath, localKey]
     liftIO $ setFileMode localKey $ ownerReadMode .|. ownerWriteMode
-    return $ (hasConfigDir, localKey)
+    return localKey
   withSpinner "Validating configuration" $ do
     void $ getHostFromRoute enableHttps route -- make sure that hostname is present
   forM_ hostnames $ \hostname -> do
     putLog Notice $ "Verifying host keys (" <> T.pack hostname <> ")"
     -- Note: we can't use a spinner here as this function will prompt the user.
     verifyHostKey (deployDir </> "backend_known_hosts") localKey hostname
-  when hasConfigDir $ withSpinner "Importing project configuration" $ do
+  --IMPORTANT: We cannot copy config directory from the development project to
+  --the deployment directory.  If we do, it's very likely someone will
+  --accidentally create a production deployment that uses development
+  --credentials to connect to some resources.  This could result in, e.g.,
+  --production data backed up to a dev environment.
+  withSpinner "Creating project configuration directories" $ do
     callProcessAndLogOutput (Notice, Error) $
-      proc "cp" [ "-r" , "-T" , configDir , deployDir </> "config"]
+      proc "mkdir" [ "-p"
+                   , deployDir </> "config" </> "backend"
+                   , deployDir </> "config" </> "common"
+                   , deployDir </> "config" </> "frontend"
+                   ]
   withSpinner "Writing deployment configuration" $ do
     writeDeployConfig deployDir "backend_hosts" $ unlines hostnames
     writeDeployConfig deployDir "enable_https" $ show enableHttps


### PR DESCRIPTION
…nit`

This is important for security