### PR TITLE
Adding a combinator for handling with a non closed (non GADT) segment in a non leaf position of the route

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -41,7 +41,7 @@ module Obelisk.Route
   , checkEnum1EncoderFunc
   , unitEncoder
   , pathOnlyEncoder
-  , pathSegmentConsEncoder
+  , pathSegmentTupleEncoder
   , singletonListEncoder
   , unpackTextEncoder
   , prefixTextEncoder
@@ -413,7 +413,7 @@ pathComponentEncoderImpl :: forall check parse p. (Monad check, Monad parse)
 pathComponentEncoderImpl this rest =
   chainEncoder (lensEncoder (\(_, b) a -> (a, b)) Prelude.fst consEncoder) this rest
 
-pathSegmentConsEncoder
+pathSegmentTupleEncoder
   :: forall check parse a b.
      ( Monad check
      , Applicative parse
@@ -422,7 +422,7 @@ pathSegmentConsEncoder
   => Encoder check parse a Text
   -> Encoder check parse b PageName
   -> Encoder check parse (a, b) PageName
-pathSegmentConsEncoder this rest = Encoder $ do
+pathSegmentTupleEncoder this rest = Encoder $ do
   thisValid <- unEncoder this
   restValid <- unEncoder rest
   pure $ EncoderImpl

--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -33,6 +33,7 @@ module Obelisk.Route.Frontend
   , mapRoutedT
   , subRoute
   , subRoute_
+  , subDynamicPathRoute
   , maybeRoute
   , maybeRoute_
   , maybeRouted
@@ -184,6 +185,10 @@ subRoute_ f = factorRouted $ strictDynWidget_ $ \(c :=> r') -> do
 subRoute :: (MonadFix m, MonadHold t m, GEq r, Adjustable t m) => (forall a. r a -> RoutedT t a m b) -> RoutedT t (R r) m (Dynamic t b)
 subRoute f = factorRouted $ strictDynWidget $ \(c :=> r') -> do
   runRoutedT (f c) r'
+
+subDynamicPathRoute :: (Functor (Dynamic t)) => (Dynamic t a -> RoutedT t b m c) -> RoutedT t (a, b) m c
+subDynamicPathRoute f = RoutedT . ReaderT $ \tupleDyn -> 
+  runRoutedT (f (Prelude.fst <$> tupleDyn)) (Prelude.snd <$> tupleDyn) 
 
 maybeRoute_ :: (MonadFix m, MonadHold t m, Adjustable t m) => m () -> RoutedT t r m () -> RoutedT t (Maybe r) m ()
 maybeRoute_ n j = maybeRouted $ strictDynWidget_ $ \case

--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -33,7 +33,7 @@ module Obelisk.Route.Frontend
   , mapRoutedT
   , subRoute
   , subRoute_
-  , subDynamicPathRoute
+  , pathSegmentTupleRoute
   , maybeRoute
   , maybeRoute_
   , maybeRouted
@@ -186,8 +186,8 @@ subRoute :: (MonadFix m, MonadHold t m, GEq r, Adjustable t m) => (forall a. r a
 subRoute f = factorRouted $ strictDynWidget $ \(c :=> r') -> do
   runRoutedT (f c) r'
 
-subDynamicPathRoute :: (Functor (Dynamic t)) => (Dynamic t a -> RoutedT t b m c) -> RoutedT t (a, b) m c
-subDynamicPathRoute f = RoutedT . ReaderT $ \tupleDyn -> 
+pathSegmentTupleRoute :: (Functor (Dynamic t)) => (Dynamic t a -> RoutedT t b m c) -> RoutedT t (a, b) m c
+pathSegmentTupleRoute f = RoutedT . ReaderT $ \tupleDyn -> 
   runRoutedT (f (Prelude.fst <$> tupleDyn)) (Prelude.snd <$> tupleDyn) 
 
 maybeRoute_ :: (MonadFix m, MonadHold t m, Adjustable t m) => m () -> RoutedT t r m () -> RoutedT t (Maybe r) m ()


### PR DESCRIPTION
This was to address a limitation that I hit when trying to encode this route structure mentioned in issue #361 . Namely:

/profile/:username
/profile/:username/favourites

This is tested [here](https://github.com/qfpl/reflex-realworld-example/blob/master/common/src/Common/Route.hs#L69) (this project is pointing at obelisk from my fork). If I change the ProfileRoute_Favourites segment to be PathEnd (unitEncoder mempty) it correctly fails the overlapping check because it clashes with the /profile/:username route, which is awesome and feels like it isn't a broken combinator from my naive view! 

I'm not sold on the name of the function. I was hoping that you'd have a good name for it or to just crush this PR with letting me know the intended way of encoding this kind of route! :slightly_smiling_face: 