### PR TITLE
Revert "Get rid of ShowTag, EqTag, OrdTag; Use ArgDict"

### DIFF
--- a/lib/route/obelisk-route.cabal
+++ b/lib/route/obelisk-route.cabal
@@ -8,7 +8,6 @@ library
   build-depends: base,
                  categories,
                  constraints,
-                 constraints-extras,
                  containers,
                  dependent-map,
                  dependent-sum,

--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/lib/route/src/Obelisk/Route/TH.hs
+++ b/lib/route/src/Obelisk/Route/TH.hs
@@ -1,6 +1,5 @@
 module Obelisk.Route.TH (deriveRouteComponent) where
 
-import Data.Constraint.Extras.TH
 import Data.GADT.Show.TH
 import Data.GADT.Compare.TH
 import Data.Universe.TH
@@ -12,6 +11,8 @@ deriveRouteComponent x = concat <$> traverse ($ x)
   [ deriveGShow
   , deriveGEq
   , deriveGCompare
+  , deriveShowTagIdentity
+  , deriveEqTagIdentity
+  , deriveOrdTagIdentity
   , deriveSomeUniverse
-  , deriveArgDict
   ]


### PR DESCRIPTION
This reverts commit 8968e1357726f8b54cb7b2705cf96b86f7e9afd6.

Fixes issue introduced by https://github.com/obsidiansystems/obelisk/pull/357