### PR TITLE
Generalise mapRoutedT

### DIFF
--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -171,7 +171,7 @@ instance (Monad m, SetRoute t r m) => SetRoute t r (QueryT t q m) where
 runRoutedT :: RoutedT t r m a -> Dynamic t r -> m a
 runRoutedT = runReaderT . unRoutedT
 
-mapRoutedT :: (m a -> n a) -> RoutedT t r m a -> RoutedT t r n a
+mapRoutedT :: (m a -> n b) -> RoutedT t r m a -> RoutedT t r n b
 mapRoutedT f = RoutedT . mapReaderT f . unRoutedT
 
 withRoutedT :: (Dynamic t r -> Dynamic t r') -> RoutedT t r' m a -> RoutedT t r m a


### PR DESCRIPTION
So that we can write things like:

```haskell
mapRoutedT runEventWriterT :: RoutedT t r (EventWriterT t w m) a -> RoutedT t r m (a, Event t w)
```

Because otherwise we risk needing to expose an `unsafeRoutedT` or something that is potentially invariant breaking. This relaxation of mapRoutedT covers all cases that I have hit. See #378 for the discussion that prompted this. 