### PR TITLE
Obelisk.Command.Deploy: use `--use-substitutes`

### DIFF
--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -136,7 +136,7 @@ deployPush deployPath getNixBuilders = do
   withSpinner "Uploading closures" $ ifor_ buildOutputByHost $ \host outputPath -> do
     callProcess'
       (Map.fromList [("NIX_SSHOPTS", unwords sshOpts)])
-      "nix-copy-closure" ["-v", "--to", "root@" <> host, "--gzip", outputPath]
+      "nix-copy-closure" ["-v", "--to", "--use-substitutes", "root@" <> host, "--gzip", outputPath]
   withSpinner "Uploading config" $ ifor_ buildOutputByHost $ \host _ -> do
     callProcessAndLogOutput (Notice, Warning) $
       proc "rsync"


### PR DESCRIPTION
From `man nix-copy-closure`:

--use-substitutes / -s
  Attempt to download missing paths on the target
  machine using Nix’s substitute mechanism. Any paths that cannot be
  substituted on the target are still copied normally from the source.
  This is useful, for instance, if the connection between the source and
  target machine is slow, but the connection between the target machine
  and nixos.org (the default binary cache server) is fast.