### PR TITLE
RFC/WIP: add dependency of `ob` on `obelisk-run`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -94,17 +94,21 @@ let
       in {
         # Dynamic linking with split objects dramatically increases startup time (about
         # 0.5 seconds on a decent machine with SSD), so we do `justStaticExecutables`.
-        obelisk-command = haskellLib.overrideCabal
-          (addOptparseApplicativeCompletionScripts "ob"
-            (haskellLib.justStaticExecutables super.obelisk-command))
-          (drv: {
-            buildTools = (drv.buildTools or []) ++ [ pkgs.buildPackages.makeWrapper ];
-            postFixup = ''
-              ${drv.postFixup or ""}
-              # Make `ob` reference its runtime dependencies.
-              wrapProgram "$out"/bin/ob --prefix PATH : ${pkgs.lib.makeBinPath (commandRuntimeDeps pkgs)}
-            '';
-          });
+        obelisk-command =
+          haskellLib.addBuildDepend
+            (haskellLib.overrideCabal
+              (addOptparseApplicativeCompletionScripts "ob"
+                 (haskellLib.justStaticExecutables super.obelisk-command))
+              (drv: {
+                buildTools = (drv.buildTools or []) ++ [ pkgs.buildPackages.makeWrapper ];
+                postFixup = ''
+                  ${drv.postFixup or ""}
+                  # Make `ob` reference its runtime dependencies.
+                  wrapProgram "$out"/bin/ob --prefix PATH : ${pkgs.lib.makeBinPath (commandRuntimeDeps pkgs)}
+                '';
+               }))
+            # Obelisk.Command.Run.run dynamically calls Obelisk.Run.run by running ghcid
+            self.obelisk-run;
         obelisk-selftest = haskellLib.justStaticExecutables super.obelisk-selftest;
       })
 


### PR DESCRIPTION
It is not a “build” dependency but any change to `Obelisk.Run.run`'s type should be reflected in `Obelisk.Command`.