### PR TITLE
Generalize backend formulation and expose a snaplet

### DIFF
--- a/lib/backend/src/Obelisk/Backend.hs
+++ b/lib/backend/src/Obelisk/Backend.hs
@@ -16,7 +16,9 @@ module Obelisk.Backend
   , runSnapWithCommandLineArgs
   , serveDefaultObeliskApp
   , prettifyOutput
-  , runBackend
+  , serveBackend
+  , Obelisk
+  , snapletObelisk
   , staticRenderContentType
   , mkRouteToUrl
   ) where
@@ -41,15 +43,13 @@ import Obelisk.Frontend
 import Obelisk.Route
 import Obelisk.Snap.Extras (doNotCache, serveFileIfExistsAs)
 import Reflex.Dom
-import Snap (MonadSnap, Snap, commandLineConfig, defaultConfig, getsRequest, httpServe, modifyResponse
-            , rqPathInfo, rqQueryString, setContentType, writeBS, writeText
-            , rqCookies, Cookie(..))
+import Snap
 import Snap.Internal.Http.Server.Config (Config (accessLog, errorLog), ConfigLog (ConfigIoLog))
 import System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
 
-data Backend backendRoute frontendRoute = Backend
+data Backend backendRoute frontendRoute m = Backend
   { _backend_routeEncoder :: Encoder (Either Text) Identity (R (Sum backendRoute (ObeliskRoute frontendRoute))) PageName
-  , _backend_run :: ((R backendRoute -> Snap ()) -> IO ()) -> IO ()
+  , _backend_routes :: R backendRoute -> m ()
   }
 
 -- | The static assets provided must contain a compiled GHCJS app that corresponds exactly to the Frontend provided
@@ -62,10 +62,8 @@ data GhcjsApp route = GhcjsApp
 --TODO: The frontend should be provided together with the asset paths so that this isn't so easily breakable; that will probably make this function obsolete
 serveDefaultObeliskApp
   :: (MonadSnap m, HasCookies m)
-  => (R appRoute
-  -> Text)
-  -> ([Text]
-  -> m ())
+  => (R appRoute -> Text)
+  -> ([Text] -> m ())
   -> Frontend (R appRoute)
   -> R (ObeliskRoute appRoute)
   -> m ()
@@ -167,16 +165,34 @@ serveGhcjsApp urlEnc app = \case
     writeBS <=< renderGhcjsFrontend urlEnc (appRouteComponent :/ appRouteRest) $ _ghcjsApp_value app
   GhcjsAppRoute_Resource :=> Identity pathSegments -> serveStaticAssets (_ghcjsApp_compiled app) pathSegments
 
-runBackend :: Backend fullRoute frontendRoute -> Frontend (R frontendRoute) -> IO ()
-runBackend backend frontend = case checkEncoder $ _backend_routeEncoder backend of
+serveBackend
+  :: (MonadSnap m, HasCookies m)
+  => Backend fullRoute frontendRoute m
+  -> Frontend (R frontendRoute)
+  -> m ()
+serveBackend backend frontend = case checkEncoder $ _backend_routeEncoder backend of
   Left e -> fail $ "backend error:\n" <> T.unpack e
-  Right validFullEncoder -> _backend_run backend $ \serveRoute -> do
-    runSnapWithCommandLineArgs $ do
-      getRouteWith validFullEncoder >>= \case
-        Identity r -> case r of
-          InL backendRoute :=> Identity a -> serveRoute $ backendRoute :/ a
-          InR obeliskRoute :=> Identity a ->
-            serveDefaultObeliskApp (mkRouteToUrl validFullEncoder) (serveStaticAssets defaultStaticAssets) frontend $ obeliskRoute :/ a
+  Right validFullEncoder ->
+    getRouteWith validFullEncoder >>= \case
+      Identity r -> case r of
+        InL backendRoute :=> Identity a ->
+          _backend_routes backend (backendRoute :/ a)
+        InR obeliskRoute :=> Identity a ->
+          serveDefaultObeliskApp
+            (mkRouteToUrl validFullEncoder) (serveStaticAssets defaultStaticAssets)
+            frontend (obeliskRoute :/ a)
+
+data Obelisk = Obelisk
+
+snapletObelisk
+  :: HasCookies (Handler b Obelisk)
+  => Backend fullRoute frontendRoute (Handler b Obelisk)
+  -> Frontend (R frontendRoute)
+  -> SnapletInit b Obelisk
+snapletObelisk backend frontend = makeSnaplet "obelisk" "Obelisk snaplet" Nothing $ do
+  addRoutes [("", serveBackend backend frontend)]
+  return Obelisk
+
 
 mkRouteToUrl :: Encoder Identity parse (R (Sum f (ObeliskRoute r))) PageName -> R r -> Text
 mkRouteToUrl validFullEncoder =
@@ -189,11 +205,11 @@ renderGhcjsFrontend
   -> route
   -> Frontend route
   -> m ByteString
-renderGhcjsFrontend urlEnc route f = do
+renderGhcjsFrontend urlEnc r f = do
   let ghcjsPreload = elAttr "link" ("rel" =: "preload" <> "as" =: "script" <> "href" =: "ghcjs/all.js") blank
       ghcjsScript = elAttr "script" ("language" =: "javascript" <> "src" =: "ghcjs/all.js" <> "defer" =: "defer") blank
   cookies <- askCookies
-  renderFrontendHtml cookies urlEnc route
+  renderFrontendHtml cookies urlEnc r
     (_frontend_head f >> ghcjsPreload)
     (_frontend_body f >> ghcjsScript)
 

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -63,7 +63,7 @@ import Web.Cookie
 run
   :: Int -- ^ Port to run the backend
   -> ([Text] -> Snap ()) -- ^ Static asset handler
-  -> Backend fullRoute frontendRoute -- ^ Backend
+  -> Backend fullRoute frontendRoute Snap -- ^ Backend
   -> Frontend (R frontendRoute) -- ^ Frontend
   -> IO ()
 run port serveStaticAsset backend frontend = do
@@ -74,13 +74,7 @@ run port serveStaticAsset backend frontend = do
     Left e -> hPutStrLn stderr $ "backend error:\n" <> T.unpack e
     Right validFullEncoder -> do
       backendTid <- forkIO $ handle handleBackendErr $ withArgs ["--quiet", "--port", show port] $ do
-        _backend_run backend $ \serveRoute -> do
-          runSnapWithCommandLineArgs $ do
-            getRouteWith validFullEncoder >>= \case
-              Identity r -> case r of
-                InL backendRoute :=> Identity a -> serveRoute $ backendRoute :/ a
-                InR obeliskRoute :=> Identity a ->
-                  serveDefaultObeliskApp (mkRouteToUrl validFullEncoder) serveStaticAsset frontend $ obeliskRoute :/ a
+        runSnapWithCommandLineArgs $ serveBackend backend frontend
       let conf = defRunConfig { _runConfig_redirectPort = port }
       runWidget conf frontend validFullEncoder `finally` killThread backendTid
 

--- a/skeleton/backend/src/Backend.hs
+++ b/skeleton/backend/src/Backend.hs
@@ -10,6 +10,6 @@ import Obelisk.Backend
 
 backend :: Backend BackendRoute FrontendRoute
 backend = Backend
-  { _backend_run = \serve -> serve $ const $ return ()
-  , _backend_routeEncoder = backendRouteEncoder
+  { _backend_routeEncoder = backendRouteEncoder
+  , _backend_routes = const $ return ()
   }


### PR DESCRIPTION
Obelisk usually gets in the way of various things I want to do with the backend.  This explores how we might change it to be more general and work with existing snaplet infrastructure more easily.