### PR TITLE
RFC: Add routeLinkAttr

### DIFF
--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -497,7 +497,7 @@ routeLink
   -> m a
 routeLink r w = routeLinkAttr r mempty w
   
--- | Link `routeLink` but allows setting attributes of the "a" element.
+-- | Like `routeLink` but allows setting attributes of the "a" element.
 routeLinkAttr
   :: forall t m a route.
      ( DomBuilder t m
@@ -516,7 +516,6 @@ routeLinkAttr r attr w = do
   (e, a) <- element "a" cfg w
   setRoute $ r <$ domEvent Click e
   return a
-
 
 -- On ios due to sandboxing when loading the page from a file adapt the
 -- path to be based on the hash.


### PR DESCRIPTION
Motivation: `routeLink` as it is makes it impossible to say add a class attribute (eg: for semantic-ui's menu tab) to the created `a` element . 

The solution this PR adapts is to extend the function to take in a custom `attr` parameter to set whatever element attributes we want; just as `elAttr` exists alongside `el`. 