### PR TITLE
fix: Update getConfig route to config/common/route

### DIFF
--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -95,7 +95,7 @@ runServeAsset :: FilePath -> [Text] -> Snap ()
 runServeAsset rootPath = Snap.serveAsset "" rootPath . T.unpack . T.intercalate "/"
 
 getConfigRoute :: Map Text Text -> IO (Maybe URI)
-getConfigRoute configs = case Map.lookup "common/route" configs of
+getConfigRoute configs = case Map.lookup "config/common/route" configs of
   Just r -> case URI.mkURI $ T.strip r of
     Just route -> pure $ Just route
     Nothing -> do


### PR DESCRIPTION
If you have an obelisk project with a obelisk version at 39dc7b4a1616bca1709f4f3d3a3e7469f16395a4 or greater, then it'll default to 127.0.0.1. If you are used to hitting it on localhost:8000 this gets
very confusing as you start getting weird jsaddle errors with the jsaddle endpoint saying "got a bad url" because obelisk is expecting to strip off 127.0.0.1 instead.

Just looks like it was slightly broken in https://github.com/obsidiansystems/obelisk/commit/39dc7b4a1616bca1709f4f3d3a3e7469f16395a4#diff-33d8ae62fc950d308753c1f76ab2a58dL87

Pinging @kmicklas since it was his PR in case it was intentional. I pointed my project at this branch and it fixed the issue for me, so I'm guessing that it was accidental. :slightly_smiling_face: 