### PR TITLE
Don't redirect the output of backend to files, let it go to syslog.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -210,7 +210,7 @@ in rec {
         script = ''
           ln -sft . '${exe}'/*
           mkdir -p log
-          exec ./backend ${backendArgs} >>backend.out 2>>backend.err </dev/null
+          exec ./backend ${backendArgs} </dev/null
         '';
         serviceConfig = {
           User = user;


### PR DESCRIPTION
This way you can check the logs via journalctl -e -u backend and the disk should not get filled constantly.