### PR TITLE
Use --no-out-link with nix-build

### DIFF
--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -73,7 +73,10 @@ run = do
       -- Check whether the impure static files are a derivation (and so must be built)
       if isDerivation == "1"
         then fmap T.strip $ readProcessAndLogStderr Debug $ -- Strip whitespace here because nix-build has no --raw option
-          proc "nix-build" ["-E", "(import " <> importableRoot <> "{}).passthru.staticFilesImpure"]
+          proc "nix-build"
+            [ "--no-out-link"
+            , "-E", "(import " <> importableRoot <> "{}).passthru.staticFilesImpure"
+            ]
         else readProcessAndLogStderr Debug $
           proc "nix" ["eval", "-f", root, "passthru.staticFilesImpure", "--raw"]
     putLog Debug $ "Assets impurely loaded from: " <> assets

--- a/lib/command/src/Obelisk/Command/VmBuilder.hs
+++ b/lib/command/src/Obelisk/Command/VmBuilder.hs
@@ -156,7 +156,8 @@ testLinuxBuild stateDir
   | System.Info.os == "linux" = failWith "Using the docker builder is not necessary on linux."
   | otherwise = do
     (exitCode, _stdout, stderr) <- readCreateProcessWithExitCode $ proc "nix-build"
-      [ "-E", "(import <nixpkgs> { system = \"x86_64-linux\"; }).writeText \"test\" builtins.currentTime"
+      [ "--no-out-link"
+      , "-E", "(import <nixpkgs> { system = \"x86_64-linux\"; }).writeText \"test\" builtins.currentTime"
       , "--builders", nixBuildersArgString stateDir
       ]
     unless (exitCode == ExitSuccess) $ do

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -75,6 +75,7 @@ main = do
   unless isVerbose $
     putStrLn "Tests may take longer to run if there are unbuilt derivations: use -v for verbose output"
   let verbosity = bool silently verbosely isVerbose
+      nixBuild args = run "nix-build" ("--no-out-link" : args)
   obeliskImpl <- fromString <$> getEnv "OBELISK_IMPL"
   httpManager <- HTTP.newManager HTTP.defaultManagerSettings
   [p0, p1, p2, p3] <- liftIO $ getFreePorts 4
@@ -141,22 +142,22 @@ main = do
           testObRunInDir p2 p3 (Just "frontend") httpManager
 
       describe "obelisk project" $ parallel $ do
-        it "can build obelisk command"  $ inTmpObInit $ \_ -> run "nix-build" ["-A", "command" , obeliskImpl]
-        it "can build obelisk skeleton" $ inTmpObInit $ \_ -> run "nix-build" ["-A", "skeleton", obeliskImpl]
-        it "can build obelisk shell"    $ inTmpObInit $ \_ -> run "nix-build" ["-A", "shell",    obeliskImpl]
+        it "can build obelisk command"  $ inTmpObInit $ \_ -> nixBuild ["-A", "command" , obeliskImpl]
+        it "can build obelisk skeleton" $ inTmpObInit $ \_ -> nixBuild ["-A", "skeleton", obeliskImpl]
+        it "can build obelisk shell"    $ inTmpObInit $ \_ -> nixBuild ["-A", "shell",    obeliskImpl]
         -- See https://github.com/obsidiansystems/obelisk/issues/101
-        -- it "can build everything"       $ shelly_ $ run "nix-build" [obeliskImpl]
+        -- it "can build everything"       $ shelly_ $ nixBuild [obeliskImpl]
 
       describe "blank initialized project" $ parallel $ do
 
         it "can build ghc.backend" $ inTmpObInit $ \_ -> do
-          run "nix-build" ["--no-out-link", "-A", "ghc.backend"]
+          nixBuild ["-A", "ghc.backend"]
         it "can build ghcjs.frontend" $ inTmpObInit $ \_ -> do
-          run "nix-build" ["--no-out-link", "-A", "ghcjs.frontend"]
+          nixBuild ["-A", "ghcjs.frontend"]
 
         if os == "darwin"
-          then it "can build ios"     $ inTmpObInit $ \_ -> run "nix-build" ["--no-out-link", "-A", "ios.frontend"    ]
-          else it "can build android" $ inTmpObInit $ \_ -> run "nix-build" ["--no-out-link", "-A", "android.frontend"]
+          then it "can build ios"     $ inTmpObInit $ \_ -> nixBuild ["-A", "ios.frontend"]
+          else it "can build android" $ inTmpObInit $ \_ -> nixBuild ["-A", "android.frontend"]
 
         forM_ ["ghc", "ghcjs"] $ \compiler -> do
           let
@@ -166,7 +167,7 @@ main = do
           it ("can build in " <> shell) $ inTmpObInit $ \_ -> inShell $ "cabal new-build --" <> fromString compiler <> " all"
 
         it "can build reflex project" $ inTmpObInit $ \_ -> do
-          run "nix-build" []
+          nixBuild []
 
         it "has idempotent thunk update" $ inTmpObInit $ \_ -> do
           u  <- update


### PR DESCRIPTION
Alternate title: Stop leaving spam `result` folders in my working directory when using `ob run`.