### PR TITLE
exe-config: fix ghcjs config gathering

### DIFF
--- a/lib/executable-config/lookup/src-ghcjs/Obelisk/ExecutableConfig/Lookup.hs
+++ b/lib/executable-config/lookup/src-ghcjs/Obelisk/ExecutableConfig/Lookup.hs
@@ -30,7 +30,8 @@ getConfigs = do
       Just htmlE -> return htmlE
     dataset <- getDataset e
     (,)
-      <$> get dataset ("obelisk-executable-config-inject-key" :: Text)
+      -- the key is camelCased: https://html.spec.whatwg.org/multipage/dom.html#dom-dataset
+      <$> get dataset ("obeliskExecutableConfigInjectKey" :: Text)
       <*> (fmap decodeOrFail (getInnerHTML e))
   where
     collToList es = do


### PR DESCRIPTION
Previously the keys in the map would evaluate to `<undefined>`, leading to really weird behaviour: `getConfig` returning the same config no matter the path, and, it seems, hangs under some circumstances