### PR TITLE
Use IP address for nginx proxy pass

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -198,7 +198,7 @@ in rec {
           enableACME = enableHttps;
           forceSSL = enableHttps;
           locations.${baseUrl} = {
-            proxyPass = "http://localhost:" + toString internalPort;
+            proxyPass = "http://127.0.0.1:" + toString internalPort;
             proxyWebsockets = true;
           };
         };


### PR DESCRIPTION
Name resolutions fail intermittently with nginx's proxy pass, causing gateway errors. This switches the proxy pass from `localhost` to `127.0.0.1` to prevent this from happening.

From https://stackoverflow.com/a/52550758:

> For me, the issue was with my proxy_pass entry. I had
```
location / {
        ...
        proxy_pass    http://localhost:5001;
    }
```
> This caused the upstream request to use the IP4 localhost IP or the IP6 localhost IP, but every now and again, it would use the localhost DNS without the port number resulting in the upstream error as seen in the logs below. 
