### PR TITLE
Fix description of encode

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -202,7 +202,7 @@ decode e x = runIdentity (tryDecode e x)
 tryDecode :: Encoder Identity parse decoded encoded -> encoded -> parse decoded
 tryDecode (Encoder (Identity impl)) x = _encoderImpl_decode impl x
 
--- | Similar to 'decode' above, once an encoder has been checked so that its check monad is Identity, it
+-- | Similar to 'decode', once an encoder has been checked so that its check monad is Identity, it
 -- can be used to actually encode by using this. Note that while there's no constraint on the parse monad here,
 -- one should usually be applying decode and encode to the same 'Encoder'
 encode :: Encoder Identity parse decoded encoded -> decoded -> encoded


### PR DESCRIPTION
Don't say above, which is incorrect due to the API ordering.
Fixes #496 