### PR TITLE
don't cache app content

### DIFF
--- a/lib/backend/src/Obelisk/Backend.hs
+++ b/lib/backend/src/Obelisk/Backend.hs
@@ -46,7 +46,7 @@ import Obelisk.Snap.Extras (doNotCache, serveFileIfExistsAs)
 import Reflex.Dom
 import Snap (MonadSnap, Snap, commandLineConfig, defaultConfig, getsRequest, httpServe, modifyResponse
             , rqPathInfo, rqQueryString, setContentType, writeBS, writeText
-            , rqCookies, Cookie(..))
+            , rqCookies, Cookie(..) , setHeader)
 import Snap.Internal.Http.Server.Config (Config (accessLog, errorLog), ConfigLog (ConfigIoLog))
 import System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
 
@@ -166,6 +166,7 @@ serveGhcjsApp
 serveGhcjsApp urlEnc app config = \case
   GhcjsAppRoute_App appRouteComponent :=> Identity appRouteRest -> do
     modifyResponse $ setContentType staticRenderContentType
+    modifyResponse $ setHeader "Cache-Control" "no-store private"
     writeBS <=< renderGhcjsFrontend urlEnc (appRouteComponent :/ appRouteRest) config $ _ghcjsApp_value app
   GhcjsAppRoute_Resource :=> Identity pathSegments -> serveStaticAssets (_ghcjsApp_compiled app) pathSegments
 


### PR DESCRIPTION
Without this, obelisk apps produce no cache-control headers for dynamically generated content.  This change instructs http caches to never store the generated content, and further that the generated content is "private".

**Note** this does *not* actually add the `cache-control` header in the `ob run` case.  Only in proper builds.  This is probably fixable, but maybe not as important?