### PR TITLE
WIP: obelisk-command: Allow loading local packages into repl + override backend/frontend in 'run'

### DIFF
--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Obelisk.Command.Run where
 
@@ -9,11 +11,16 @@ import Control.Exception (bracket)
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (MonadIO)
+import Data.Aeson (ToJSON, FromJSON)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Lazy as LBS
 import Data.Either
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription)
 import Distribution.Parsec.ParseResult (runParseResult)
 import Distribution.Pretty
@@ -22,6 +29,7 @@ import Distribution.Types.CondTree
 import Distribution.Types.GenericPackageDescription
 import Distribution.Types.Library
 import Distribution.Utils.Generic
+import GHC.Generics (Generic)
 import Hpack.Config
 import Hpack.Render
 import Hpack.Yaml
@@ -50,11 +58,70 @@ data CabalPackageInfo = CabalPackageInfo
     -- ^ List of globally set languages of the library component
   }
 
+data ReplOpts = ReplOpts
+  { _replOpts_import :: [(String, String)]
+  -- ^ Modules to load (in addition to Frontend/Backend).
+  -- First argument is the library name, second is the module name.
+  -- For example, [(some-frontend, Some.Other.Frontend)]
+  } deriving (Generic, Show)
+instance ToJSON ReplOpts
+instance FromJSON ReplOpts
+
+data RunOpts = RunOpts
+  { _runOpts_replOpts :: ReplOpts
+  -- ^ Repl options
+  , _runOpts_frontend :: Maybe (String, String)
+  -- ^ Alternative frontend to load.
+  -- First argument is the module, second is the function in the module.
+  -- The module must be imported (see 'runOptsModulesToLoad').
+  -- For example, (Some.Other.Frontend, myFrontend)
+  , _runOpts_backend :: Maybe (String, String)
+  -- ^ Alternative backend to load.
+  -- First argument is the module, second is the function in the module.
+  -- The module must be imported (see 'runOptsModulesToLoad').
+  -- For example, (Some.Other.Backend, myBackend)
+  } deriving (Generic, Show)
+instance ToJSON RunOpts
+instance FromJSON RunOpts
+
+-- | Decode 'RunOpts' from a base 16 bytestring
+decodeRunOpts :: String -> Either String RunOpts
+decodeRunOpts = Aeson.eitherDecodeStrict . fst . B16.decode . T.encodeUtf8 . T.pack
+
+-- | Encode 'RunOpts' to a base 16 bytestring. This uses base 16 to avoid
+-- shell quoting issues with JSON
+encodeRunOpts :: RunOpts -> String
+encodeRunOpts = T.unpack . T.decodeUtf8 . B16.encode . LBS.toStrict . Aeson.encode
+
+-- | Get the fully qualified frontend to use.
+runOptsFrontend :: MonadObelisk m => RunOpts -> m (Maybe String)
+runOptsFrontend opts
+  | Just (m, fun) <- _runOpts_frontend opts
+  = if any (\(_, m') -> m' == m) (_replOpts_import $ _runOpts_replOpts opts)
+    then pure $ Just $ m <> "." <> fun
+    else putLog Warning "Ignoring alternate frontend: the module is not imported" >> pure Nothing
+  | otherwise = pure Nothing
+
+-- | Get the fully qualified backend to use.
+runOptsBackend :: MonadObelisk m => RunOpts -> m (Maybe String)
+runOptsBackend opts
+  | Just (m, fun) <- _runOpts_backend opts
+  = if any (\(_, m') -> m' == m) (_replOpts_import $ _runOpts_replOpts opts)
+    then pure $ Just $ m <> "." <> fun
+    else putLog Warning "Ignoring alternate backend: the module is not imported" >> pure Nothing
+  | otherwise = pure Nothing
+
+runOptsModulesToLoad :: RunOpts -> [String]
+runOptsModulesToLoad opts = mconcat
+  [ ["Frontend", "Backend"]
+  , snd <$> _replOpts_import (_runOpts_replOpts opts)
+  ]
+
 -- NOTE: `run` is not polymorphic like the rest because we use StaticPtr to invoke it.
-run :: ObeliskT IO ()
-run = do
-  pkgs <- getLocalPkgs
-  withGhciScript pkgs $ \dotGhciPath -> do
+run :: RunOpts -> ObeliskT IO ()
+run opts = do
+  pkgs <- getLocalPkgs opts
+  withGhciScript opts pkgs $ \dotGhciPath -> do
     freePort <- getFreePort
     assets <- withProjectRoot "." $ \root -> do
       let importableRoot = if "/" `isInfixOf` root
@@ -80,29 +147,34 @@ run = do
         else readProcessAndLogStderr Debug $
           proc "nix" ["eval", "-f", root, "passthru.staticFilesImpure", "--raw"]
     putLog Debug $ "Assets impurely loaded from: " <> assets
+    mFrontend <- runOptsFrontend opts
+    mBackend <- runOptsBackend opts
     runGhcid dotGhciPath $ Just $ unwords
       [ "Obelisk.Run.run"
       , show freePort
       , "(runServeAsset " ++ show assets ++ ")"
-      , "Backend.backend"
-      , "Frontend.frontend"
+      , fromMaybe "Backend.backend" mBackend
+      , fromMaybe "Frontend.frontend" mFrontend
       ]
 
-runRepl :: MonadObelisk m => m ()
-runRepl = do
-  pkgs <- getLocalPkgs
-  withGhciScript pkgs $ \dotGhciPath -> do
+runRepl :: MonadObelisk m => RunOpts -> m ()
+runRepl opts = do
+  pkgs <- getLocalPkgs opts
+  withGhciScript opts pkgs $ \dotGhciPath -> do
     runGhciRepl dotGhciPath
 
-runWatch :: MonadObelisk m => m ()
-runWatch = do
-  pkgs <- getLocalPkgs
-  withGhciScript pkgs $ \dotGhciPath -> runGhcid dotGhciPath Nothing
+runWatch :: MonadObelisk m => RunOpts -> m ()
+runWatch opts = do
+  pkgs <- getLocalPkgs opts
+  withGhciScript opts pkgs $ \dotGhciPath -> runGhcid dotGhciPath Nothing
 
 -- | Relative paths to local packages of an obelisk project
 -- TODO a way to query this
-getLocalPkgs :: Applicative f => f [FilePath]
-getLocalPkgs = pure ["backend", "common", "frontend"]
+getLocalPkgs :: Applicative f => RunOpts -> f [FilePath]
+getLocalPkgs opts = pure $ mconcat
+  [ ["backend", "common", "frontend"]
+  , fst <$> _replOpts_import (_runOpts_replOpts opts)
+  ]
 
 parseCabalPackage
   :: (MonadObelisk m)
@@ -157,10 +229,11 @@ withUTF8FileContentsM fp f = do
 -- | Create ghci configuration to load the given packages
 withGhciScript
   :: MonadObelisk m
-  => [FilePath] -- ^ List of packages to load into ghci
+  => RunOpts
+  -> [FilePath] -- ^ List of packages to load into ghci
   -> (FilePath -> m ()) -- ^ Action to run with the path to generated temporory .ghci
   -> m ()
-withGhciScript pkgs f = do
+withGhciScript opts pkgs f = do
   (pkgDirErrs, packageInfos) <- fmap partitionEithers $ forM pkgs $ \pkg -> do
     flip fmap (parseCabalPackage pkg) $ \case
       Nothing -> Left pkg
@@ -182,11 +255,9 @@ withGhciScript pkgs f = do
         [ ":set -i" <> intercalate ":" (packageInfos >>= rootedSourceDirs)
         , extensionsLine
         , ":set " <> intercalate " " (("-X" <>) . prettyShow <$> language)
-        , ":load Backend Frontend"
+        , ":load " <> intercalate " " (runOptsModulesToLoad opts)
         , "import Obelisk.Run"
-        , "import qualified Frontend"
-        , "import qualified Backend"
-        ]
+        ] ++ fmap ("import qualified " <>) (runOptsModulesToLoad opts)
   warnDifferentLanguages language
   withSystemTempDirectory "ob-ghci" $ \fp -> do
     let dotGhciPath = fp </> ".ghci"


### PR DESCRIPTION
This commit allows arguments to be passed to `ob run/watch/repl` to
load and import extra local packages and modules, plus allows overriding
the default 'Frontend.frontend' and 'Backend.backend' used in 'ob run'.

It assumes the packages follow the same convention as backend/frontend: that is, they are in a directory of the same name.

Now you can do things like:
```
ob watch --import desktop:Desktop
ob run --import desktop:Desktop --frontend Desktop.desktopFrontend
```