### PR TITLE
Always specify 'default.nix' when using obelisk project nix shells

### DIFF
--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -275,7 +275,7 @@ instance ToJSON KeytoolConfig
 createKeystore :: MonadObelisk m => FilePath -> KeytoolConfig -> m ()
 createKeystore root config = do
   let expr = "with (import " <> toImplDir root <> ").reflex-platform.nixpkgs; pkgs.mkShell { buildInputs = [ pkgs.jdk ]; }"
-  callProcessAndLogOutput (Notice,Notice) $ (proc "nix-shell" ["-E" , expr, "--run" , keytoolCmd]) { cwd = Just root }
+  callProcessAndLogOutput (Notice,Notice) $ (proc "nix-shell" ["default.nix", "-E" , expr, "--run" , keytoolCmd]) { cwd = Just root }
   where
     keytoolCmd = processToShellString "keytool"
       [ "-genkeypair", "-noprompt"

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -205,6 +205,7 @@ inImpureProjectShell shellName command = withProjectRoot "." $ \root ->
 projectShell :: MonadObelisk m => FilePath -> Bool -> String -> Maybe String -> m ()
 projectShell root isPure shellName command = do
   (_, _, _, ph) <- createProcess_ "runNixShellAttr" $ setCtlc $ setCwd (Just root) $ proc "nix-shell" $
+     [ "default.nix"] <>
      [ "--pure" | isPure ] <>
      [ "-A"
      , "shells." <> shellName

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -162,7 +162,7 @@ main = do
         forM_ ["ghc", "ghcjs"] $ \compiler -> do
           let
             shell = "shells." <> compiler
-            inShell cmd' = run "nix-shell" ["-A", fromString shell, "--run", cmd']
+            inShell cmd' = run "nix-shell" ["default.nix", "-A", fromString shell, "--run", cmd']
           it ("can enter "    <> shell) $ inTmpObInit $ \_ -> inShell "exit"
           it ("can build in " <> shell) $ inTmpObInit $ \_ -> inShell $ "cabal new-build --" <> fromString compiler <> " all"
 

--- a/skeleton/shell.nix
+++ b/skeleton/shell.nix
@@ -1,0 +1,1 @@
+(import ./. {}).shells.ghc


### PR DESCRIPTION
Currently, adding a `shell.nix` file to an obelisk project can break several commands - e.g. `ob run/repl/watch` expect to find `shells.ghc`.