### PR TITLE
exe-config: Export getTextConfig

### DIFF
--- a/lib/executable-config/lookup/src/Obelisk/Configs.hs
+++ b/lib/executable-config/lookup/src/Obelisk/Configs.hs
@@ -15,6 +15,7 @@ module Obelisk.Configs
   , ConfigsT
   , runConfigsT
   , mapConfigsT
+  , getTextConfig
   ) where
 
 import Control.Applicative


### PR DESCRIPTION
This was added in https://github.com/obsidiansystems/obelisk/commit/59104db9b81ca0ea0cc4750f1e52fa05636e3a5c but not exported