### PR TITLE
Replace deprecated name for optparse completions

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -69,7 +69,7 @@ let
         # Dynamic linking with split objects dramatically increases startup time (about
         # 0.5 seconds on a decent machine with SSD), so we do `justStaticExecutables`.
         obelisk-command = haskellLib.overrideCabal
-          (haskellLib.addOptparseApplicativeCompletionScripts "ob"
+          (haskellLib.generateOptparseApplicativeCompletion "ob"
             (haskellLib.justStaticExecutables super.obelisk-command))
           (drv: {
             buildTools = (drv.buildTools or []) ++ [ pkgs.buildPackages.makeWrapper ];


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/754763ff4ba1dd03fe3fad3a0fea36d2e39f5860/pkgs/development/haskell-modules/lib.nix#L364