### PR TITLE
Use --pure shells for ob run

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ This project's release branch is `master`. This log is written from the perspect
 * Bump reflex-platform so that obelisk now uses GHC 8.6.5 and the nixos-19.03 nixpkgs set
 * Add support in obelisk-route for single parameters in URL paths
 * Bump reflex-platform so that obelisk now uses reflex-dom 0.5.2.0
+* Use a `--pure` nix shell in `ob run` for parity with `ob repl` and more resilience against "works on my machine".
+* Use `--keep NIX_PATH` for all pure shells so references to `<nixpkgs>` continues to work.
 
 ## v0.2.0.0 - 2019-8-17
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -81,7 +81,7 @@ project's dependencies and,
 Assuming we are in a project created with `ob init`, `ob run` calls (see
 `lib/command/src/Obelisk/Command.hs`):
 
-    nix-shell -A shells.ghc --run 'ob --no-handoff internal run-static-io <real-run-function>'
+    nix-shell --pure --keep NIX_PATH -A shells.ghc --run 'ob --no-handoff internal run-static-io <real-run-function>'
 
 where
 
@@ -109,7 +109,7 @@ It is defined in `lib/run/src/Obelisk/Run.hs`:
     * or to `serveDefaultObeliskApp` (`lib/backend/src/Obelisk/Backend.hs`) to
       serve static assets.
 * Starts `runWidget`
-  which itself runs 
+  which itself runs
   [runSettingsSocket](https://hackage.haskell.org/package/warp-3.2.26/docs/Network-Wai-Handler-Warp.html#v:runSettingsSocket)
   (the *“TCP listen loop”*):
     * it binds to TCP socket, and

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -106,7 +106,7 @@ data ObInternal
 inNixShell' :: MonadObelisk m => StaticPtr (ObeliskT IO ()) -> m ()
 inNixShell' p = withProjectRoot "." $ \root -> do
   cmd <- liftIO $ unwords <$> mkCmd  -- TODO: shell escape instead of unwords
-  projectShell root False "ghc" (Just cmd)
+  projectShell root True "ghc" (Just cmd)
   where
     mkCmd = do
       argsCfg <- getArgsConfig

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -206,7 +206,9 @@ projectShell :: MonadObelisk m => FilePath -> Bool -> String -> Maybe String -> 
 projectShell root isPure shellName command = do
   (_, _, _, ph) <- createProcess_ "runNixShellAttr" $ setCtlc $ setCwd (Just root) $ proc "nix-shell" $
      [ "default.nix"] <>
-     [ "--pure" | isPure ] <>
+     -- Keep $NIX_PATH in the env for --pure shells so '<nixpkgs>' works in sub-commands
+     -- TODO: Don't use <nixpkgs> for anything!
+     (if isPure then [ "--pure", "--keep", "NIX_PATH" ] else []) <>
      [ "-A"
      , "shells." <> shellName
      ] <> case command of


### PR DESCRIPTION
`ob repl` already uses `--pure`. I ran into a situation where `ob run` would fail to build the app but `ob repl` worked fine. This makes them consistent and also more resilient to local configuration problems.