### PR TITLE
Add runBackendWithAssetsFromDirectory for custom asset directory

### DIFF
--- a/lib/backend/obelisk-backend.cabal
+++ b/lib/backend/obelisk-backend.cabal
@@ -13,6 +13,7 @@ library
                  data-default,
                  dependent-sum,
                  dependent-sum-template,
+                 filepath,
                  lens,
                  mtl,
                  obelisk-asset-serve-snap,


### PR DESCRIPTION
By default, we get assets from the current directory. This works well
for some use cases, but when packaging apps, it is nice to have these
directories separate.