### PR TITLE
Provide nix executable to ob run

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,7 +59,7 @@ let
         obelisk-asset-serve-snap = self.callCabal2nix "obelisk-asset-serve-snap" (cleanSource ./lib/asset/serve-snap) {};
         obelisk-backend = self.callCabal2nix "obelisk-backend" (cleanSource ./lib/backend) {};
         obelisk-cliapp = self.callCabal2nix "obelisk-cliapp" (cleanSource ./lib/cliapp) {};
-        obelisk-command = self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {};
+        obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}) { librarySystemDepends = [ pkgs.nix ]; };
         obelisk-frontend = self.callCabal2nix "obelisk-frontend" (cleanSource ./lib/frontend) {};
         obelisk-run = self.callCabal2nix "obelisk-run" (cleanSource ./lib/run) {};
         obelisk-route = self.callCabal2nix "obelisk-route" (cleanSource ./lib/route) {};

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -46,6 +46,7 @@ library
     , transformers
     , unix
     , unordered-containers
+    , which
     , yaml
   exposed-modules:
     Obelisk.App

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Obelisk.Command.Run where
 
 import Control.Exception (bracket)
@@ -32,6 +33,7 @@ import System.Directory
 import System.FilePath
 import System.Process (proc)
 import System.IO.Temp (withSystemTempDirectory)
+import System.Which (staticWhich)
 import Data.ByteString (ByteString)
 
 import Obelisk.App (MonadObelisk, ObeliskT)
@@ -56,6 +58,7 @@ data CabalPackageInfo = CabalPackageInfo
 -- NOTE: `run` is not polymorphic like the rest because we use StaticPtr to invoke it.
 run :: ObeliskT IO ()
 run = do
+  let nixPath = $(staticWhich "nix")
   pkgs <- getLocalPkgs
   withGhciScript pkgs $ \dotGhciPath -> do
     freePort <- getFreePort
@@ -64,7 +67,7 @@ run = do
             then root
             else "./" <> root
       isDerivation <- readProcessAndLogStderr Debug $
-        proc "nix"
+        proc nixPath
           [ "eval"
           , "-f"
           , root
@@ -76,12 +79,12 @@ run = do
       -- Check whether the impure static files are a derivation (and so must be built)
       if isDerivation == "1"
         then fmap T.strip $ readProcessAndLogStderr Debug $ -- Strip whitespace here because nix-build has no --raw option
-          proc "nix-build"
+          proc (nixPath <> "-build")
             [ "--no-out-link"
             , "-E", "(import " <> importableRoot <> "{}).passthru.staticFilesImpure"
             ]
         else readProcessAndLogStderr Debug $
-          proc "nix" ["eval", "-f", root, "passthru.staticFilesImpure", "--raw"]
+          proc nixPath ["eval", "-f", root, "passthru.staticFilesImpure", "--raw"]
     putLog Debug $ "Assets impurely loaded from: " <> assets
     runGhcid dotGhciPath $ Just $ unwords
       [ "Obelisk.Run.run"

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -59,6 +59,7 @@ data CabalPackageInfo = CabalPackageInfo
 run :: ObeliskT IO ()
 run = do
   let nixPath = $(staticWhich "nix")
+      nixBuildPath = $(staticWhich "nix-build")
   pkgs <- getLocalPkgs
   withGhciScript pkgs $ \dotGhciPath -> do
     freePort <- getFreePort
@@ -79,7 +80,7 @@ run = do
       -- Check whether the impure static files are a derivation (and so must be built)
       if isDerivation == "1"
         then fmap T.strip $ readProcessAndLogStderr Debug $ -- Strip whitespace here because nix-build has no --raw option
-          proc (nixPath <> "-build")
+          proc nixBuildPath
             [ "--no-out-link"
             , "-E", "(import " <> importableRoot <> "{}).passthru.staticFilesImpure"
             ]


### PR DESCRIPTION
#556 introduced a pure shell for `ob run`, which breaks the command if the project does not have already have `nix` in its environment. This ensures that nix is available as a runtime dependency by declaring it as a system dependency of `obelisk-command`, and uses `staticWhich` to obtain the `/nix/store` path.