### PR TITLE
Get ghcid with fix from ghcid#288

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@ This project's release branch is `master`. This log is written from the perspect
 * Use `--keep NIX_PATH` for all pure shells so references to `<nixpkgs>` continues to work.
 * Backport ACMEv2 support in obelisk server to regain LetsEncrypt account creation.
 * Enable https in `ob run`
+* `ob run` now handles ghci errors better, and includes a custom ghcid
+  version. As a result, you no longer need to have ghcid installed to
+  use `ob run`, as we provide one for you.
 
 ## v0.2.0.0 - 2019-8-17
 

--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ let
         });
         hnix-store-core = self.callHackage "hnix-store-core" "0.1.0.0" {};
 
-        ghcid = haskellLib.justStaticExecutables (self.callCabal2nix "ghcid" (hackGet ./dep/ghcid) {});
+        ghcid = self.callCabal2nix "ghcid" (hackGet ./dep/ghcid) {};
       })
 
       pkgs.obeliskExecutableConfig.haskellOverlay
@@ -55,7 +55,12 @@ let
         obelisk-asset-serve-snap = self.callCabal2nix "obelisk-asset-serve-snap" (cleanSource ./lib/asset/serve-snap) {};
         obelisk-backend = self.callCabal2nix "obelisk-backend" (cleanSource ./lib/backend) {};
         obelisk-cliapp = self.callCabal2nix "obelisk-cliapp" (cleanSource ./lib/cliapp) {};
-        obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}) { librarySystemDepends = [ pkgs.nix self.ghcid ]; };
+        obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}) {
+          librarySystemDepends = [
+            pkgs.nix
+            (haskellLib.justStaticExecutables self.ghcid)
+          ];
+        };
         obelisk-frontend = self.callCabal2nix "obelisk-frontend" (cleanSource ./lib/frontend) {};
         obelisk-run = self.callCabal2nix "obelisk-run" (cleanSource ./lib/run) {};
         obelisk-route = self.callCabal2nix "obelisk-route" (cleanSource ./lib/route) {};

--- a/default.nix
+++ b/default.nix
@@ -45,6 +45,8 @@ let
           doCheck = false;
         });
         hnix-store-core = self.callHackage "hnix-store-core" "0.1.0.0" {};
+
+        ghcid = haskellLib.justStaticExecutables (self.callCabal2nix "ghcid" (hackGet ./dep/ghcid) {});
       })
 
       pkgs.obeliskExecutableConfig.haskellOverlay
@@ -59,7 +61,7 @@ let
         obelisk-asset-serve-snap = self.callCabal2nix "obelisk-asset-serve-snap" (cleanSource ./lib/asset/serve-snap) {};
         obelisk-backend = self.callCabal2nix "obelisk-backend" (cleanSource ./lib/backend) {};
         obelisk-cliapp = self.callCabal2nix "obelisk-cliapp" (cleanSource ./lib/cliapp) {};
-        obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}) { librarySystemDepends = [ pkgs.nix ]; };
+        obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}) { librarySystemDepends = [ pkgs.nix self.ghcid ]; };
         obelisk-frontend = self.callCabal2nix "obelisk-frontend" (cleanSource ./lib/frontend) {};
         obelisk-run = self.callCabal2nix "obelisk-run" (cleanSource ./lib/run) {};
         obelisk-route = self.callCabal2nix "obelisk-route" (cleanSource ./lib/route) {};

--- a/dep/.gitignore
+++ b/dep/.gitignore
@@ -1,4 +1,5 @@
 *
+!*/
 !.gitignore
 !*/*.json
 !*/default.nix

--- a/dep/ghcid/default.nix
+++ b/dep/ghcid/default.nix
@@ -1,0 +1,7 @@
+# DO NOT HAND-EDIT THIS FILE
+import ((import <nixpkgs> {}).fetchFromGitHub (
+  let json = builtins.fromJSON (builtins.readFile ./github.json);
+  in { inherit (json) owner repo rev sha256;
+       private = json.private or false;
+     }
+))

--- a/dep/ghcid/github.json
+++ b/dep/ghcid/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "ghcid",
+  "branch": "show-unexpected-exit-msg",
+  "rev": "54e047560002711b30554a966d6fc511baf0eede",
+  "sha256": "18b86j078b9li3q3cvzf9i1l571k0ci8a3f8likzhc1p7bsb5b8d"
+}

--- a/dep/ghcid/github.json
+++ b/dep/ghcid/github.json
@@ -1,7 +1,7 @@
 {
-  "owner": "obsidiansystems",
+  "owner": "ndmitchell",
   "repo": "ghcid",
-  "branch": "show-unexpected-exit-msg",
-  "rev": "54e047560002711b30554a966d6fc511baf0eede",
-  "sha256": "18b86j078b9li3q3cvzf9i1l571k0ci8a3f8likzhc1p7bsb5b8d"
+  "branch": "master",
+  "rev": "f572318f32b1617f6054248e5888af68222f8e50",
+  "sha256": "1icg3r70lg2kmd9gdc024ih1n9nrja98yav74z9nvykqygvv5w0n"
 }

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -227,7 +227,7 @@ runGhcid
   => FilePath -- ^ Path to .ghci
   -> Maybe String -- ^ Optional command to run at every reload
   -> m ()
-runGhcid dotGhci mcmd = callCommand $ unwords $ "ghcid" : opts
+runGhcid dotGhci mcmd = callCommand $ unwords $ $(staticWhich "ghcid") : opts
   where
     opts =
       [ "-W"


### PR DESCRIPTION
This adds a custom ghcid pointing to
https://github.com/ndmitchell/ghcid/pull/288 for better error
messages. Also uses staticWhich to find ghcid for use in ob run. As a
result, we now include ghcid in Obelisk runtime.

Fixes #563
