### PR TITLE
Decrease android certificate validity from 1b days to 1m

### DIFF
--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -281,7 +281,7 @@ createKeystore root config = do
       [ "-genkeypair", "-noprompt"
       , "-keystore", _keytoolConfig_keystore config
       , "-keyalg", "RSA", "-keysize", "2048"
-      , "-validity", "1000000000"
+      , "-validity", "1000000"
       , "-storepass", _keytoolConfig_storepass config
       , "-alias", _keytoolConfig_alias config
       , "-keypass", _keytoolConfig_keypass config


### PR DESCRIPTION
With 1,000,000,000 days, I get this error on ‘ob deploy test android’:

> com.android.ide.common.signing.KeytoolException: Failed to read key
obelisk from store
"/nix/store/4fa5z7arnfkaf6jipj18k062ydkwhzab-android_keystore.jks":
java.io.IOException: Parse Generalized time, invalid format

It looks like the number is too big to be parsed by Android / Java parsing. 10^9, 10^8, 10^7 all fail but 10^6 succeeds. This seems like a weird cut-off, roughly below 2^20. But, 10^6 is still valid for 2737 years.