### PR TITLE
Expose events from the routeLink functions

### DIFF
--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -556,8 +556,7 @@ dynRouteLink
   -> m a
 dynRouteLink = routeLinkDynAttr mempty
 
-
--- | Like 'routeLinkDynAttr' but without custom attributes and also returns the events associatd with the link.
+-- | Like 'routeLinkDynAttr' but without custom attributes and also returns the events associated with the link.
 dynRouteLink'
   :: forall t m a route.
      ( DomBuilder t m


### PR DESCRIPTION
The reflex-frp.org marketing site needs access to some of these events;  this is one of the changes in `reflex-frp.org`'s current branch of obelisk that seems like a small improvement to me.