### PR TITLE
Remove default-extensions in skeleton

### DIFF
--- a/skeleton/common/common.cabal
+++ b/skeleton/common/common.cabal
@@ -9,9 +9,6 @@ library
                , obelisk-route
                , mtl
                , text
-  default-extensions:
-    TypeFamilies
-    PolyKinds
   exposed-modules:
     Common.Api
     Common.Route

--- a/skeleton/common/src/Common/Route.hs
+++ b/skeleton/common/src/Common/Route.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 module Common.Route where
 
 {- -- You will probably want these imports for composing Encoders.


### PR DESCRIPTION
While I'm a fan of `default-extensions`, the use of them here seems a bit random