### PR TITLE
Add spaces and unicode to SelfTest paths

### DIFF
--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -24,7 +24,6 @@ import Shelly
 import System.Directory (withCurrentDirectory, getDirectoryContents)
 import System.Environment
 import System.Exit (ExitCode (..))
-import System.Info
 import System.IO (Handle, hClose)
 import System.IO.Temp
 import System.Process (readProcessWithExitCode, CreateProcess(cwd), readCreateProcessWithExitCode, proc)
@@ -81,7 +80,7 @@ main = do
   obeliskImpl <- fromString <$> getEnv "OBELISK_IMPL"
   httpManager <- HTTP.newManager HTTP.defaultManagerSettings
   [p0, p1, p2, p3] <- liftIO $ getFreePorts 4
-  withSystemTempDirectory "initCache" $ \initCache -> do
+  withSystemTempDirectory "init Cache λ" $ \initCache -> do
     -- Setup the ob init cache
     void . shellyOb verbosity $ chdir (fromString initCache) $ do
       run_ "ob" ["init"]
@@ -92,7 +91,7 @@ main = do
           inTmp :: (Shelly.FilePath -> Sh a) -> IO ()
           inTmp f = withTmp (chdir <*> f)
 
-          withTmp f = shelly_ . withSystemTempDirectory "test" $ f . fromString
+          withTmp f = shelly_ . withSystemTempDirectory "test λ" $ f . fromString
 
           inTmpObInit f = inTmp $ \dir -> do
             run_ "cp" ["-a", fromString $ initCache <> "/.", toTextIgnore dir]
@@ -119,7 +118,7 @@ main = do
         it "works with default impl"       $ inTmp $ \_ -> run "ob" ["init"]
         it "works with master branch impl" $ inTmp $ \_ -> run "ob" ["init", "--branch", "master"]
         it "works with symlink"            $ inTmp $ \_ -> run "ob" ["init", "--symlink", obeliskImpl]
-        it "doesn't silently overwrite existing files" $ withSystemTempDirectory "ob-init" $ \dir -> do
+        it "doesn't silently overwrite existing files" $ withSystemTempDirectory "ob-init λ" $ \dir -> do
           let p force = (proc "ob" $ "--no-handoff" : "init" : ["--force"|force]) { cwd = Just dir }
           (ExitSuccess, _, _) <- readCreateProcessWithExitCode (p False) ""
           (ExitFailure _, _, _) <- readCreateProcessWithExitCode (p False) ""

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -44,9 +44,6 @@ data ObRunState
 doubleQuotes :: (IsString a, Semigroup a) => a -> a
 doubleQuotes s = "\"" <> s <> "\""
 
-routeFile :: IsString a => a
-routeFile = "config/common/route"
-
 commit :: Text -> Sh ()
 commit msg = void $ run "git"
   [ "commit"
@@ -151,16 +148,16 @@ main = do
         it "can build ghc.backend" $ inTmpObInit $ \_ -> nixBuild ["-A", "ghc.backend"]
         it "can build ghcjs.frontend" $ inTmpObInit $ \_ -> nixBuild ["-A", "ghcjs.frontend"]
 
-        -- if os == "darwin"
-        --   then it "can build ios" $ inTmpObInit $ \_ -> nixBuild ["-A", "ios.frontend"]
-        --   else it "can build android after accepting license" $ inTmpObInit $ \dir -> do
-        --     let defaultNixPath = dir </> ("default.nix" :: Shelly.FilePath)
-        --     writefile defaultNixPath
-        --       =<< T.replace
-        --         "# config.android_sdk.accept_license = false;"
-        --         "config.android_sdk.accept_license = true;"
-        --       <$> readfile defaultNixPath
-        --     nixBuild ["-A", "android.frontend"]
+        if os == "darwin"
+          then it "can build ios" $ inTmpObInit $ \_ -> nixBuild ["-A", "ios.frontend"]
+          else it "can build android after accepting license" $ inTmpObInit $ \dir -> do
+            let defaultNixPath = dir </> ("default.nix" :: Shelly.FilePath)
+            writefile defaultNixPath
+              =<< T.replace
+                "# config.android_sdk.accept_license = false;"
+                "config.android_sdk.accept_license = true;"
+              <$> readfile defaultNixPath
+            nixBuild ["-A", "android.frontend"]
 
         forM_ ["ghc", "ghcjs"] $ \compiler -> do
           let
@@ -238,7 +235,7 @@ main = do
 testObRunInDir :: Socket.PortNumber -> Socket.PortNumber -> Maybe Shelly.FilePath -> HTTP.Manager -> Sh ()
 testObRunInDir p0 p1 mdir httpManager = handle_sh (\case ExitSuccess -> pure (); e -> throw e) $ do
   let uri p = "http://localhost:" <> T.pack (show p) <> "/" -- trailing slash required for comparison
-  writefile routeFile $ uri p0
+  writefile "config/common/route" $ uri p0
   maybe id chdir mdir $ runHandle "ob" ["run"] $ \stdout -> do
     firstUri <- handleObRunStdout httpManager stdout
     let newUri = uri p1
@@ -283,10 +280,10 @@ hGetLineSkipBlanks h = liftIO $ fix $ \loop -> T.hGetLine h >>= \case
 -- | Alters the route file and waits for `ob run` to reload
 alterRouteTo :: Text -> Handle -> Sh ()
 alterRouteTo uri stdout = do
-  writefile routeFile uri
+  writefile "config/common/route" uri
   hGetLineSkipBlanks stdout >>= \t -> when (t /= "Reloading...") $ errorExit $
     "Reloading failed: " <> T.pack (show t)
-  hGetLineSkipBlanks stdout >>= \t -> when (t /= "  " <> routeFile) $ errorExit $
+  hGetLineSkipBlanks stdout >>= \t -> when (t /= "  config/common/route") $ errorExit $
     "Reloading failed: " <> T.pack (show t)
   hGetLineSkipBlanks stdout >>= \t -> when (t /= "Interrupted.") $ errorExit $
     "Reloading failed: " <> T.pack (show t)

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -24,6 +24,7 @@ import Shelly
 import System.Directory (withCurrentDirectory, getDirectoryContents)
 import System.Environment
 import System.Exit (ExitCode (..))
+import qualified System.Info
 import System.IO (Handle, hClose)
 import System.IO.Temp
 import System.Process (readProcessWithExitCode, CreateProcess(cwd), readCreateProcessWithExitCode, proc)
@@ -148,7 +149,7 @@ main = do
         it "can build ghc.backend" $ inTmpObInit $ \_ -> nixBuild ["-A", "ghc.backend"]
         it "can build ghcjs.frontend" $ inTmpObInit $ \_ -> nixBuild ["-A", "ghcjs.frontend"]
 
-        if os == "darwin"
+        if System.Info.os == "darwin"
           then it "can build ios" $ inTmpObInit $ \_ -> nixBuild ["-A", "ios.frontend"]
           else it "can build android after accepting license" $ inTmpObInit $ \dir -> do
             let defaultNixPath = dir </> ("default.nix" :: Shelly.FilePath)

--- a/out
+++ b/out
@@ -1,0 +1,4 @@
+Tests may take longer to run if there are unbuilt derivations: use -v for verbose output
+
+ob init
+

--- a/out
+++ b/out
@@ -1,4 +1,0 @@
-Tests may take longer to run if there are unbuilt derivations: use -v for verbose output
-
-ob init
-


### PR DESCRIPTION
Adds spaces and lambdas to paths, to ensure we're quoting correctly, especially during obelisk handoff