### PR TITLE
Add additional result-* links from nix-build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/.cabal-sandbox
 **/cabal.sandbox.config
 result
+result-*
 *.o
 *.hi
 TAGS

--- a/skeleton/.gitignore
+++ b/skeleton/.gitignore
@@ -1,5 +1,6 @@
 dist-newstyle
 result
+result-*
 result-android
 result-ios
 result-exe


### PR DESCRIPTION
If you `nix-build` an attribute set you get `result-2`, `result-3`, etc.