### PR TITLE
WIP: Use reflex-ghci

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,7 +1,7 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "develop",
-  "rev": "90351bdb2c99d416ea95fd5b8b474e8f9fab2942",
-  "sha256": "0bbzz4ckdx0ilhhpd3drfbsc0zdb2rnhw2m3nls9villbs3lz3lh"
+  "branch": "aa-reflex-ghci",
+  "rev": "c6ec0def1a70cd4f83e4bb854f1a100381bb177b",
+  "sha256": "09a8izfwfq9v8qsy8fxvc0irfv8xggr5vp0w1dibdlp9yiciyvqd"
 }

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -39,6 +39,10 @@ library
     , optparse-applicative
     , placeholders
     , process
+    , reflex
+    , reflex-ghci
+    , reflex-process
+    , reflex-vty
     , temporary
     , terminal-size
     , text
@@ -46,6 +50,7 @@ library
     , transformers
     , unix
     , unordered-containers
+    , vty
     , which
     , yaml
   exposed-modules:

--- a/skeleton/frontend/src/Frontend.hs
+++ b/skeleton/frontend/src/Frontend.hs
@@ -19,7 +19,6 @@ import Reflex.Dom.Core
 import Common.Api
 import Common.Route
 
-
 -- This runs in a monad that can be run on the client or the server.
 -- To run code in a pure client or pure server context, use one of the
 -- `prerender` functions.


### PR DESCRIPTION
Use reflex-ghci. Module loading output is now separated from backend/frontend output. 

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found in code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
