### PR TITLE
Remove COMPLETE pragma on tuple due to GHC bug

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -219,7 +219,9 @@ hoistR f (x :=> Identity y) = f x :/ y
 infixr 5 :.
 type (:.) = (,)
 
-{-# COMPLETE (:.) #-}
+-- This is COMPLETE but triggers https://gitlab.haskell.org/ghc/ghc/issues/17729
+-- TODO: Re-enable once our GHC has the fix.
+-- {-# COMPLETE (:.) #-}
 pattern (:.) :: a -> b -> a :. b
 pattern a :. b = (a, b)
 


### PR DESCRIPTION
See https://gitlab.haskell.org/ghc/ghc/issues/17729

cc @tomsmalley who found the bug in GHC!

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
