### PR TITLE
ob hoogle

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ This project's release branch is `master`. This log is written from the perspect
 
 * Add `Obelisk.Route.(?/)`, a convenience function for constructing routes nested in `Maybe`. ([#457](https://github.com/obsidiansystems/obelisk/pull/457))
 * Add local packages from the Nix `project { packages }` option to the GHCi config, so that they are auto-reloaded with `ob run`. ([#489](https://github.com/obsidiansystems/obelisk/pull/489))
+* Add `ob hoogle` command to start a local [Hoogle](https://hoogle.haskell.org/) server for the project. ([#628](https://github.com/obsidiansystems/obelisk/pull/628))
 
 ## v0.4.0.0 - 2020-01-10
 

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -290,10 +290,27 @@ main = do
           void $ errExit False $ runOb ["thunk", "update", toTextIgnore dir, "--branch", "dumble-palooza"]
           checkDir dir >>= liftIO . assertEqual "" startingContents
 
+      describe "ob hoogle" $ {- NOT parallel -} do
+        it "starts a hoogle server on the given port" $ inTmpObInit $ \_ -> do
+          [p0] <- liftIO $ getFreePorts 1
+          maskExitSuccess $ runHandle "ob" ["hoogle", "--port", T.pack (show p0)] $ \stdout -> fix $ \loop -> do
+            ln <- liftIO $ T.hGetLine stdout
+            echo ln
+            let search = "Server starting on port " <> T.pack (show p0)
+            case search `T.isInfixOf` ln of
+              False -> loop -- keep waiting
+              True -> do
+                let req uri = liftIO $ HTTP.parseRequest uri >>= flip HTTP.httpLbs httpManager
+                req ("http://127.0.0.1:" <> show p0) >>= \r -> case HTTP.responseStatus r == HTTP.ok200 of
+                  False -> errorExit $ "Request to hoogle server failed: " <> T.pack (show r)
+                  True -> exit 0
+
+maskExitSuccess :: Sh () -> Sh ()
+maskExitSuccess = handle_sh (\case ExitSuccess -> pure (); e -> throw e)
 
 -- | Run `ob run` in the given directory (maximum of one level deep)
 testObRunInDir :: String -> [Text] -> Maybe FilePath -> HTTP.Manager -> Sh ()
-testObRunInDir executable extraArgs mdir httpManager = handle_sh (\case ExitSuccess -> pure (); e -> throw e) $ do
+testObRunInDir executable extraArgs mdir httpManager = maskExitSuccess $ do
   [p0, p1] <- liftIO $ getFreePorts 2
   let uri p = "http://localhost:" <> T.pack (show p) <> "/" -- trailing slash required for comparison
   writefile "config/common/route" $ uri p0


### PR DESCRIPTION
Add `ob hoogle` command for starting a local hoogle server for the project's dependency tree. It supports both `ghc` and `ghcjs` shells with a CLI arg. Port is also configurable via CLI.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
