### PR TITLE
Fix preprocessor integration

### DIFF
--- a/lib/command/src/Obelisk/Command/Preprocessor.hs
+++ b/lib/command/src/Obelisk/Command/Preprocessor.hs
@@ -86,7 +86,10 @@ generateHeader origPath packageInfo =
         <> mconcat (intersperse (TL.fromText " ") optList)
         <> TL.fromText " #-}\n"
       else mempty
-    optList = map TL.fromString $ fromMaybe [] $ lookup GHC (_cabalPackageInfo_compilerOptions packageInfo)
+    optList = map TL.fromString
+                $ filter (\x -> not (isPrefixOf "-O" x))
+                $ fromMaybe []
+                $ lookup GHC (_cabalPackageInfo_compilerOptions packageInfo)
 
 lineNumberPragma :: FilePath -> TL.Builder
 lineNumberPragma origPath =

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -269,7 +269,7 @@ withGhciScript packageInfos pathBase f = do
       ]
     dotGhci = unlines
       -- TODO: Shell escape
-      [ ":set -pgmF " <> selfExe <> " -optF " <> preprocessorIdentifier <> " " <> unwords (map (("-optF " <>) . _cabalPackageInfo_packageRoot) packageInfos)
+      [ ":set -F -pgmF " <> selfExe <> " -optF " <> preprocessorIdentifier <> " " <> unwords (map (("-optF " <>) . makeRelative pathBase . _cabalPackageInfo_packageFile) packageInfos)
       , ":set -i" <> intercalate ":" (packageInfos >>= rootedSourceDirs)
       , if null modulesToLoad then "" else ":load " <> unwords modulesToLoad
       , "import qualified Obelisk.Run"
@@ -311,8 +311,7 @@ runGhcid root chdirToRoot dotGhci packages mcmd =
   where
     opts =
       [ "-W"
-      --TODO: The decision of whether to use -fwarn-redundant-constraints should probably be made by the user
-      , "--command='ghci -Wall -ignore-dot-ghci -fwarn-redundant-constraints " <> makeBaseGhciOptions dotGhci <> "' "
+      , "--command='ghci -ignore-dot-ghci " <> makeBaseGhciOptions dotGhci <> "' "
       , "--reload=config"
       , "--outputfile=ghcid-output.txt"
       ] <> testCmd


### PR DESCRIPTION
Fixes for ob run preprocessor

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
