### PR TITLE
Fix more ob run stuff...

### DIFF
--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -315,10 +315,15 @@ runGhcid root chdirToRoot dotGhci packages mcmd =
     opts =
       [ "-W"
       , "--command='ghci -ignore-dot-ghci " <> makeBaseGhciOptions dotGhci <> "' "
-      , "--reload=config"
       , "--outputfile=ghcid-output.txt"
-      ] <> testCmd
+      ] <> map (\x -> "--reload='" <> x <> "'") reloadFiles
+        <> map (\x -> "--restart='" <> x <> "'") restartFiles
+        <> testCmd
     testCmd = maybeToList (flip fmap mcmd $ \cmd -> "--test='" <> cmd <> "'") -- TODO: Shell escape
+
+    adjustRoot x = if chdirToRoot then makeRelative root x else x
+    reloadFiles = map adjustRoot [root </> "config"]
+    restartFiles = map (adjustRoot . _cabalPackageInfo_packageFile) packages
 
 makeBaseGhciOptions :: FilePath -> String
 makeBaseGhciOptions dotGhci =

--- a/skeleton/backend/src/Backend.hs
+++ b/skeleton/backend/src/Backend.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeFamilies #-}
 module Backend where
 
 import Common.Route


### PR DESCRIPTION
Cleans up skeleton a bit.
Improves sensitivity of 'ob run' by detecting changes to config correctly and also adding restarts whet cabal/hpack files change.
I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
