### PR TITLE
Bump reflex-platform to master

### DIFF
--- a/dep/reflex-platform/default.nix
+++ b/dep/reflex-platform/default.nix
@@ -1,7 +1,8 @@
 # DO NOT HAND-EDIT THIS FILE
-import ((import <nixpkgs> {}).fetchFromGitHub (
-  let json = builtins.fromJSON (builtins.readFile ./github.json);
-  in { inherit (json) owner repo rev sha256;
-       private = json.private or false;
-     }
-))
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,7 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "develop",
-  "rev": "90351bdb2c99d416ea95fd5b8b474e8f9fab2942",
-  "sha256": "0bbzz4ckdx0ilhhpd3drfbsc0zdb2rnhw2m3nls9villbs3lz3lh"
+  "branch": "master",
+  "private": false,
+  "rev": "5429278830e1555a577f2550e045ce7f7164aa65",
+  "sha256": "1lp86cgccmim573rarsjny5vh0ygkfp5afq7006li0k9w2sw2d4c"
 }


### PR DESCRIPTION
Bump reflex-platform

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
