### PR TITLE
Fix ob deploy test

### DIFF
--- a/lib/command/src/Obelisk/Command/Nix.hs
+++ b/lib/command/src/Obelisk/Command/Nix.hs
@@ -24,6 +24,7 @@ module Obelisk.Command.Nix
   , nixShellConfig_common
   , nixShellConfig_pure
   , nixShellConfig_run
+  , setNixShellExpr
   , OutLink (..)
   , Target (..)
   , target_attr
@@ -180,6 +181,13 @@ data NixCmd
 instance Default NixCmd where
   def = NixCmd_Build def
 
+-- | Configures a 'NixShellConfig' to use '-E' for a given expression along with any number of @--arg/--argstr@ argmuments.
+setNixShellExpr :: String -> [Arg] -> NixShellConfig -> NixShellConfig
+setNixShellExpr expr args x = x
+  & nixShellConfig_common . nixCmdConfig_target .~ (def & target_path .~ Nothing & target_expr ?~ expr)
+  & nixShellConfig_common . nixCmdConfig_args .~ args
+
+-- | Renders a 'NixShellConfig' to its list of arguments ready for forking a subprocess.
 runNixShellConfig :: NixShellConfig -> [String]
 runNixShellConfig cfg = mconcat
   [ runNixCommonConfig $ cfg ^. nixCommonConfig

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -44,6 +44,9 @@ nixExePath = $(staticWhich "nix")
 nixBuildExePath :: FilePath
 nixBuildExePath = $(staticWhich "nix-build")
 
+nixShellExePath :: FilePath
+nixShellExePath = $(staticWhich "nix-shell")
+
 -- Check whether the working directory is clean
 checkGitCleanStatus :: MonadObelisk m => FilePath -> Bool -> m Bool
 checkGitCleanStatus repo withIgnored = do


### PR DESCRIPTION
`ob deploy test android` was invoking `nix-shell` incorrectly. I created better defaults/combinators to help us get this right more often and used them in `ob deploy test`.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
