### PR TITLE
command: Don't test against git protocol when checking if repos are private

### DIFF
--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -937,7 +937,7 @@ guessGitRepoIsPrivate uri = flip fix urisToTry $ \loop -> \case
     urisToTry = nubOrd $
       -- Include the original URI if it isn't using SSH because SSH will certainly fail.
       [uri | fmap URI.unRText (URI.uriScheme (unGitUri uri)) /= Just "ssh"] <>
-      [changeScheme "https" uri, changeScheme "http" uri, changeScheme "git" uri]
+      [changeScheme "https" uri, changeScheme "http" uri]
     changeScheme scheme (GitUri u) = GitUri $ u
       { URI.uriScheme = URI.mkScheme scheme
       , URI.uriAuthority = (\x -> x { URI.authUserInfo = Nothing }) <$> URI.uriAuthority u


### PR DESCRIPTION
GitLab `git://` checks seem to hang... so this check is more annoying than helpful.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
