### PR TITLE
Fix git loader to pass ref to fetchGit

### DIFF
--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -513,9 +513,10 @@ gitHubStandaloneLoaderV4 = T.unlines
 
 plainGitStandaloneLoaders :: NonEmpty Text
 plainGitStandaloneLoaders =
-  plainGitStandaloneLoaderV3 :|
+  plainGitStandaloneLoaderV4 :|
   [ plainGitStandaloneLoaderV1
   , plainGitStandaloneLoaderV2
+  , plainGitStandaloneLoaderV3
   ]
 
 plainGitStandaloneLoaderV1 :: Text
@@ -536,6 +537,8 @@ plainGitStandaloneLoaderV2 = T.unlines
   , "in import (fetchGit (builtins.fromJSON (builtins.readFile ./git.json)))"
   ]
 
+-- This loader has a bug because @builtins.fetchGit@ is not given a @ref@
+-- and will fail to find commits without this because it does shallow clones.
 plainGitStandaloneLoaderV3 :: Text
 plainGitStandaloneLoaderV3 = T.unlines
   [ "# DO NOT HAND-EDIT THIS FILE"
@@ -546,6 +549,23 @@ plainGitStandaloneLoaderV3 = T.unlines
   , "    else url;"
   , "  in if !fetchSubmodules && private then builtins.fetchGit {"
   , "    url = realUrl; inherit rev;"
+  , "  } else (import <nixpkgs> {}).fetchgit {"
+  , "    url = realUrl; inherit rev sha256;"
+  , "  };"
+  , "in import (fetch (builtins.fromJSON (builtins.readFile ./git.json)))"
+  ]
+
+plainGitStandaloneLoaderV4 :: Text
+plainGitStandaloneLoaderV4 = T.unlines
+  [ "# DO NOT HAND-EDIT THIS FILE"
+  , "let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:"
+  , "  let realUrl = let firstChar = builtins.substring 0 1 url; in"
+  , "    if firstChar == \"/\" then /. + url"
+  , "    else if firstChar == \".\" then ./. + url"
+  , "    else url;"
+  , "  in if !fetchSubmodules && private then builtins.fetchGit {"
+  , "    url = realUrl; inherit rev;"
+  , "    ${if branch == null then null else \"ref\"} = branch;"
   , "  } else (import <nixpkgs> {}).fetchgit {"
   , "    url = realUrl; inherit rev sha256;"
   , "  };"


### PR DESCRIPTION
The new git loader uses `builtins.fetchGit` for private repos. Now that v0.5 actually marks repos private (whereas it this was always disabled before), we're getting more test coverage of this loader. We've found that it gets stuck when downloading a rev that it's never seen before and is also not in the history of the default branch. You end up getting an error like

```
fatal: not a tree object: 3f00db4a6e211d6e648f236c15eaf68c2dc8385e
error: program 'git' failed with exit code 128
```

It turns out that `builtins.fetchGit` does a shallow clone on the given ref and then searches for the given rev. So you must make sure that your ref contains the rev, and passing no ref assumes the default branch.

This fix adds a new git loader to fix this issue by passing `branch` as `ref` to `builtins.fetchGit`.

I have:

  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
