### PR TITLE
Hide PR template instructions from rendered version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-[Provide a clear overview of your changes.]
+<!-- Provide a clear overview of your changes. -->
 
 I have:
 


### PR DESCRIPTION
[Provide a clear overview of your changes.]

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
