### PR TITLE
Warn when being forced to disambiguate packages in a session

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ This project's release branch is `master`. This log is written from the perspect
 ## Unreleased
 
 * Fix a bug in `Obelisk.Route.Frontend` where `routeLink`, `routeLinkDynAttr`, and `dynRouteLink` would not behave exactly like `<a href="...">` when run by JavaScript. These functions now scroll to the top of the page when the link is clicked. ([#540](https://github.com/obsidiansystems/obelisk/pull/540))
+* Fix a bug in `ob run`/`ob watch`/`ob repl` where nested Obelisk projects would also be loaded into the session. These are now ignored. ([#652](https://github.com/obsidiansystems/obelisk/pull/652))
+* Improve behavior of `ob run`/`ob watch`/`ob repl` when multiple packages with the same name are encountered. Obelisk now issues a warning and tells you which one it will use. ([#653](https://github.com/obsidiansystems/obelisk/pull/653))
 
 ## v0.5.0.0 - 2020-02-07
 

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -186,7 +186,7 @@ findProjectRoot target = do
   targetStat <- liftIO $ getFileStatus target
   umask <- liftIO getUmask
   (result, _) <- liftIO $ runStateT (walkToProjectRoot target targetStat umask myUid) []
-  return result
+  return $ makeRelative "." <$> result
 
 withProjectRoot :: MonadObelisk m => FilePath -> (FilePath -> m a) -> m a
 withProjectRoot target f = findProjectRoot target >>= \case

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -74,7 +74,6 @@ run :: MonadObelisk m => m ()
 run = withProjectRoot "." $ \root -> do
   pkgs <- fmap toList . parsePackagesOrFail =<< getLocalPkgs root
   withGhciScript pkgs root $ \dotGhciPath -> do
-    freePort <- getFreePort
     assets <- do
       isDerivation <- readProcessAndLogStderr Debug $ setCwd (Just root) $
         proc nixExePath
@@ -94,6 +93,7 @@ run = withProjectRoot "." $ \root -> do
         else readProcessAndLogStderr Debug $ setCwd (Just root) $
           proc nixExePath ["eval", "-f", ".", "passthru.staticFilesImpure", "--raw"]
     putLog Debug $ "Assets impurely loaded from: " <> assets
+    freePort <- getFreePort
     runGhcid root True dotGhciPath pkgs $ Just $ unwords
       [ "Obelisk.Run.run"
       , show freePort

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -129,7 +129,7 @@ getLocalPkgs root = do
   -- We do not want to find packages that are embedded inside other obelisk projects, unless that
   -- obelisk project is our own.
   let exclusions = filter (/= root) $ map takeDirectory obeliskPaths
-  runFind $
+  fmap (map (makeRelative ".")) $ runFind $
     ["-L", root, "(", "-name", "*.cabal", "-o", "-name", Hpack.packageConfig, ")", "-a", "-type", "f"]
     <> concat [["-not", "-path", p </> "*"] | p <- exclusions]
   where


### PR DESCRIPTION
I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
