### PR TITLE
Add obelisk profiling feature

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ This project's release branch is `master`. This log is written from the perspect
 * Fix `ob deploy test android` to work. ([#645](https://github.com/obsidiansystems/obelisk/pull/645))
 * Fix vulnerability where Android deployments would leave signing keys in the nix store which is world readable. ([#645](https://github.com/obsidiansystems/obelisk/pull/645)) (Thanks to [kmicklas](https://github.com/kmicklas) for the report.)
 * Add `Obelisk.Backend.runBackendWith` to allow customization of how GHCJS resources are loaded in the page. ([#668](https://github.com/obsidiansystems/obelisk/pull/668))
+* Add `ob profile` command to run Obelisk projects with profiling. `ob profile` works like `ob run`, but instead of using `ghci`, it builds an executable that is built with profiling enabled. ([#654](https://github.com/obsidiansystems/obelisk/pull/654))
 
 ## v0.6.0.0 - 2020-02-21
 
@@ -30,9 +31,6 @@ This project's release branch is `master`. This log is written from the perspect
 * `ob thunk pack` will now attempt to automatically detect if the thunk is a private or public repo. To avoid this detection, specify `--private` or `--public` manually. ([#607](https://github.com/obsidiansystems/obelisk/pull/607))
 * Fix a bug in the plain git thunk loader for thunks marked as 'private' when the revision is not in the default branch. ([#648](https://github.com/obsidiansystems/obelisk/pull/648))
 * Improve handling of runtime nix dependencies. This may fix some issues encountered particularly by users on systems other than NixOS.
-* Add `ob profile` command to run Obelisk project with profiling. `ob
-profile` works like ob run, but instead of using ghci, it builds an
-executable that is built with profiling enabled.
 
 ## v0.4.0.0 - 2020-01-10
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,9 @@ This project's release branch is `master`. This log is written from the perspect
 * Add local unpacked packages to the `ob run`, `ob watch`, and `ob repl` sessions. Any `.cabal` or hpack package inside the current obelisk project will be loaded into the session. For `ob run`/`ob watch` this means the session will automatically reload when you save a source file in any of those packages. For `ob repl` it means that `:r` will reload changes to any of those packages. There are some edge cases where this integration is still rough. Report any issues you encounter. ([#489](https://github.com/obsidiansystems/obelisk/pull/489))
 * Add `ob hoogle` command to start a local [Hoogle](https://hoogle.haskell.org/) server for the project. ([#628](https://github.com/obsidiansystems/obelisk/pull/628))
 * `ob thunk pack` will now attempt to automatically detect if the thunk is a private or public repo. To avoid this detection, specify `--private` or `--public` manually. ([#607](https://github.com/obsidiansystems/obelisk/pull/607))
+* Add `ob profile` command to run Obelisk project with profiling. `ob
+profile` works like ob run, but instead of using ghci, it builds an
+executable that is built with profiling enabled.
 
 ## v0.4.0.0 - 2020-01-10
 

--- a/all-builds.nix
+++ b/all-builds.nix
@@ -68,6 +68,7 @@ let
       iosSkeleton = (import ./skeleton { inherit obelisk; }).ios.frontend;
       nameSuffix = if profiling then "profiled" else "unprofiled";
       packages = {
+        skeletonProfiledObRun = skeleton.profiledObRun;
         inherit
           command
           serverSkeletonShell

--- a/all-builds.nix
+++ b/all-builds.nix
@@ -87,8 +87,7 @@ let
     in packages // {
       cache = reflex-platform.pinBuildInputs
         "obelisk-${system}-${nameSuffix}"
-        # skeletonProfiledObRun is a binary, so can’t be used in pinBuildInputs
-        (collect (builtins.removeAttrs ["skeletonProfiledObRun"] packages));
+        (collect packages);
     };
 
     perProfiling = {

--- a/all-builds.nix
+++ b/all-builds.nix
@@ -68,7 +68,7 @@ let
       iosSkeleton = (import ./skeleton { inherit obelisk; }).ios.frontend;
       nameSuffix = if profiling then "profiled" else "unprofiled";
       packages = {
-        skeletonProfiledObRun = skeleton.profiledObRun;
+        skeletonProfiledObRun = skeleton.__unstable__.profiledObRun;
         inherit
           command
           serverSkeletonShell

--- a/all-builds.nix
+++ b/all-builds.nix
@@ -87,7 +87,8 @@ let
     in packages // {
       cache = reflex-platform.pinBuildInputs
         "obelisk-${system}-${nameSuffix}"
-        (collect packages);
+        # skeletonProfiledObRun is a binary, so can’t be used in pinBuildInputs
+        (collect (builtins.removeAttrs ["skeletonProfiledObRun"] packages));
     };
 
     perProfiling = {

--- a/default.nix
+++ b/default.nix
@@ -399,7 +399,7 @@ in rec {
       in nixpkgs.runCommand "ob-run" {
            buildInputs = [ (profiled.ghc.ghcWithPackages (p: [ p.backend p.frontend])) ];
       } ''
-        mkdir -p $out/bin/ob-run
+        mkdir -p $out/bin/
         ghc -x hs -prof -fno-prof-auto -threaded ${exeSource} -o $out/bin/ob-run
       '';
 

--- a/default.nix
+++ b/default.nix
@@ -375,7 +375,7 @@ in rec {
       dummyVersion = "Version number is only available for deployments";
     in mainProjectOut // {
 
-      profiledObRun = let
+      __unstable__.profiledObRun = let
         profiled = projectOut { inherit system; enableLibraryProfiling = true; };
         exeSource = builtins.toFile "ob-run.hs" ''
           module Main where

--- a/default.nix
+++ b/default.nix
@@ -398,7 +398,10 @@ in rec {
         '';
       in nixpkgs.runCommand "ob-run" {
            buildInputs = [ (profiled.ghc.ghcWithPackages (p: [ p.backend p.frontend])) ];
-      } "ghc -x hs -prof -fno-prof-auto -threaded ${exeSource} -o $out";
+      } ''
+        mkdir -p $out/bin/ob-run
+        ghc -x hs -prof -fno-prof-auto -threaded ${exeSource} -o $out/bin/ob-run
+      '';
 
       linuxExeConfigurable = linuxExe;
       linuxExe = linuxExe dummyVersion;

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "master",
+  "branch": "bump-reflex-0-6-4-1",
   "private": false,
-  "rev": "5429278830e1555a577f2550e045ce7f7164aa65",
-  "sha256": "1lp86cgccmim573rarsjny5vh0ygkfp5afq7006li0k9w2sw2d4c"
+  "rev": "38060894cb377160d1217305334f7f11202042d4",
+  "sha256": "0n47fcwj9szy3aqip0smmxdsp9fr78985rdslpmx2zdlkswmm5r1"
 }

--- a/lib/cliapp/src/Obelisk/CliApp.hs
+++ b/lib/cliapp/src/Obelisk/CliApp.hs
@@ -51,6 +51,7 @@ module Obelisk.CliApp
   , setDelegateCtlc
   , setEnvOverride
   , shell
+  , waitForProcess
   ) where
 
 import Control.Monad.Log (Severity (..))

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -87,6 +87,7 @@ data ObCommand
    = ObCommand_Init InitSource Bool
    | ObCommand_Deploy DeployCommand
    | ObCommand_Run
+   | ObCommand_Profile
    | ObCommand_Thunk ThunkCommand
    | ObCommand_Repl
    | ObCommand_Watch
@@ -108,6 +109,7 @@ obCommand cfg = hsubparser
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
     , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
+    , command "profile" $ info (pure ObCommand_Profile) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (pure ObCommand_Watch) $ progDesc "Watch current project for errors and warnings"
@@ -365,7 +367,8 @@ ob = \case
         Just RemoteBuilder_ObeliskVM -> (:[]) <$> VmBuilder.getNixBuildersArg
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
-  ObCommand_Run -> run
+  ObCommand_Run -> run False
+  ObCommand_Profile -> run True
   ObCommand_Thunk tc -> case tc of
     ThunkCommand_Update thunks config -> for_ thunks (updateThunkToLatest config)
     ThunkCommand_Unpack thunks -> for_ thunks unpackThunk

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -112,7 +112,7 @@ obCommand cfg time root = hsubparser
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
     , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
-    , command "profile" $ info (ObCommand_Profile <$> option auto (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type." <> showDefault <> value ((fromMaybe "" root) </> "profile" </> formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" time) <> metavar "PATH")) $ progDesc "Run current project with profiling enabled"
+    , command "profile" $ info (ObCommand_Profile <$> option auto (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root." <> showDefault <> value ((fromMaybe "" root) </> "profile" </> formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" time) <> metavar "PATH")) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (pure ObCommand_Watch) $ progDesc "Watch current project for errors and warnings"

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -89,7 +89,7 @@ data ObCommand
    = ObCommand_Init InitSource Bool
    | ObCommand_Deploy DeployCommand
    | ObCommand_Run
-   | ObCommand_Profile (Maybe FilePath) (Maybe String)
+   | ObCommand_Profile (Maybe FilePath) String
    | ObCommand_Thunk ThunkCommand
    | ObCommand_Repl
    | ObCommand_Watch
@@ -111,7 +111,7 @@ obCommand cfg = hsubparser
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
     , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
-    , command "profile" $ info (ObCommand_Profile <$> (optional (strOption (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root." <> metavar "PATH"))) <*> (optional (strOption (long "rts-flags" <> help "RTS Flags to pass to the executable" <> metavar "FLAGS")))) $ progDesc "Run current project with profiling enabled"
+    , command "profile" $ info (ObCommand_Profile <$> (optional (strOption (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root." <> metavar "PATH"))) <*> (strOption (long "rts-flags" <> help "RTS Flags to pass to the executable." <> value "-p -hc" <> metavar "FLAGS" <> showDefault))) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (pure ObCommand_Watch) $ progDesc "Watch current project for errors and warnings"

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -87,7 +87,7 @@ data ObCommand
    = ObCommand_Init InitSource Bool
    | ObCommand_Deploy DeployCommand
    | ObCommand_Run
-   | ObCommand_Profile
+   | ObCommand_Profile (Maybe FilePath)
    | ObCommand_Thunk ThunkCommand
    | ObCommand_Repl
    | ObCommand_Watch
@@ -109,7 +109,7 @@ obCommand cfg = hsubparser
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
     , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
-    , command "profile" $ info (pure ObCommand_Profile) $ progDesc "Run current project with profiling enabled"
+    , command "profile" $ info (ObCommand_Profile <$> optional (strOption ( long "output" <> short 'o' <> metavar "BASEPATH" ))) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (pure ObCommand_Watch) $ progDesc "Watch current project for errors and warnings"
@@ -368,7 +368,7 @@ ob = \case
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
   ObCommand_Run -> run
-  ObCommand_Profile -> profile
+  ObCommand_Profile basePath -> profile basePath
   ObCommand_Thunk tc -> case tc of
     ThunkCommand_Update thunks config -> for_ thunks (updateThunkToLatest config)
     ThunkCommand_Unpack thunks -> for_ thunks unpackThunk

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -89,7 +89,7 @@ data ObCommand
    = ObCommand_Init InitSource Bool
    | ObCommand_Deploy DeployCommand
    | ObCommand_Run
-   | ObCommand_Profile (Maybe FilePath)
+   | ObCommand_Profile (Maybe FilePath) (Maybe String)
    | ObCommand_Thunk ThunkCommand
    | ObCommand_Repl
    | ObCommand_Watch
@@ -111,7 +111,7 @@ obCommand cfg = hsubparser
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
     , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
-    , command "profile" $ info (ObCommand_Profile <$> optional (strOption (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root." <> metavar "PATH"))) $ progDesc "Run current project with profiling enabled"
+    , command "profile" $ info (ObCommand_Profile <$> (optional (strOption (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root." <> metavar "PATH"))) <*> (optional (strOption (long "rts-flags" <> help "RTS Flags to pass to the executable" <> metavar "FLAGS")))) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (pure ObCommand_Watch) $ progDesc "Watch current project for errors and warnings"
@@ -370,13 +370,13 @@ ob = \case
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
   ObCommand_Run -> run
-  ObCommand_Profile mBasePath -> do
+  ObCommand_Profile mBasePath rtsFlags -> do
     basePath <- case mBasePath of
       Just path -> pure path
       Nothing -> do
         time <- liftIO $ getCurrentTime
         pure $ "profile" </> formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" time
-    profile basePath
+    profile basePath rtsFlags
   ObCommand_Thunk tc -> case tc of
     ThunkCommand_Update thunks config -> for_ thunks (updateThunkToLatest config)
     ThunkCommand_Unpack thunks -> for_ thunks unpackThunk

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -13,7 +13,6 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (for_)
 import Data.List
-import Data.Maybe
 import qualified Data.Text as T
 import Data.Text.Encoding
 import Data.Text.Encoding.Error (lenientDecode)
@@ -376,8 +375,7 @@ ob = \case
       Just path -> pure path
       Nothing -> do
         time <- liftIO $ getCurrentTime
-        root <- findProjectRoot "."
-        pure $ (fromMaybe "" root) </> "profile" </> formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" time
+        pure $ "profile" </> formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" time
     profile basePath
   ObCommand_Thunk tc -> case tc of
     ThunkCommand_Update thunks config -> for_ thunks (updateThunkToLatest config)

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -367,8 +367,8 @@ ob = \case
         Just RemoteBuilder_ObeliskVM -> (:[]) <$> VmBuilder.getNixBuildersArg
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
-  ObCommand_Run -> run False
-  ObCommand_Profile -> run True
+  ObCommand_Run -> run
+  ObCommand_Profile -> profile
   ObCommand_Thunk tc -> case tc of
     ThunkCommand_Update thunks config -> for_ thunks (updateThunkToLatest config)
     ThunkCommand_Unpack thunks -> for_ thunks unpackThunk

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -109,7 +109,7 @@ obCommand cfg = hsubparser
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
     , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
-    , command "profile" $ info (ObCommand_Profile <$> (strOption (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root." <> metavar "PATH" <> value "profile/%Y-%m-%dT%H:%M:%S" <> showDefault)) <*> (words <$> strOption (long "rts-flags" <> help "RTS Flags to pass to the executable." <> value "-p -hc" <> metavar "FLAGS" <> showDefault))) $ progDesc "Run current project with profiling enabled"
+    , command "profile" $ info (ObCommand_Profile <$> profileOutputFlag <*> profileRtsFlag) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (pure ObCommand_Watch) $ progDesc "Watch current project for errors and warnings"
@@ -223,6 +223,21 @@ thunkCommand = hsubparser $ mconcat
   , command "unpack" $ info (ThunkCommand_Unpack <$> some thunkDirectoryParser) $ progDesc "Unpack thunk into git checkout of revision it points to"
   , command "pack" $ info (ThunkCommand_Pack <$> some thunkDirectoryParser <*> thunkPackConfig) $ progDesc "Pack git checkout into thunk that points at the current branch's upstream"
   ]
+
+profileRtsFlag :: Parser [String]
+profileRtsFlag = words <$> strOption (   long "rts-flags"
+                                      <> help "RTS Flags to pass to the executable."
+                                      <> value "-p -hc"
+                                      <> metavar "FLAGS"
+                                      <> showDefault)
+
+profileOutputFlag :: Parser String
+profileOutputFlag = strOption (   long "output"
+                               <> short 'o'
+                               <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root."
+                               <> metavar "PATH"
+                               <> value "profile/%Y-%m-%dT%H:%M:%S"
+                               <> showDefault)
 
 data ShellOpts
   = ShellOpts

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -112,7 +112,7 @@ obCommand cfg = hsubparser
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
     , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
-    , command "profile" $ info (ObCommand_Profile <$> option auto (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root." <> metavar "PATH")) $ progDesc "Run current project with profiling enabled"
+    , command "profile" $ info (ObCommand_Profile <$> optional (strOption (long "output" <> short 'o' <> help "Base output to use for profiling output. Suffixes are added to this based on the profiling type. Defaults to a timestamped path in the profile/ directory in the project's root." <> metavar "PATH"))) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (pure ObCommand_Watch) $ progDesc "Watch current project for errors and warnings"

--- a/lib/command/src/Obelisk/Command/Nix.hs
+++ b/lib/command/src/Obelisk/Command/Nix.hs
@@ -32,6 +32,8 @@ module Obelisk.Command.Nix
 
   , boolArg
   , nixCmd
+  , nixCmdProc
+  , nixCmdProc'
   , rawArg
   , runNixShellConfig
   , strArg
@@ -188,27 +190,35 @@ runNixShellConfig cfg = mconcat
     ["--run", run] | run <- maybeToList $ cfg ^. nixShellConfig_run
   ]
 
-nixCmd :: MonadObelisk m => NixCmd -> m FilePath
-nixCmd cmdCfg = withSpinner' ("Running " <> cmd <> desc) (Just $ const $ "Built " <> desc) $ do
-  output <- readProcessAndLogStderr Debug $ proc (T.unpack cmd) options
-  -- Remove final newline that Nix appends
-  Just (outPath, '\n') <- pure $ T.unsnoc output
-  pure $ T.unpack outPath
+nixCmdProc :: NixCmd -> ProcessSpec
+nixCmdProc = fst . nixCmdProc'
+
+nixCmdProc' :: NixCmd -> (ProcessSpec, T.Text)
+nixCmdProc' cmdCfg = (proc (T.unpack cmd) options, cmd)
   where
-    (cmd, options, commonCfg) = case cmdCfg of
+    (cmd, options) = case cmdCfg of
       NixCmd_Build cfg' ->
         ( "nix-build"
         , runNixBuildConfig cfg'
-        , cfg' ^. nixCommonConfig
         )
       NixCmd_Instantiate cfg' ->
         ( "nix-instantiate"
         , runNixInstantiateConfig cfg'
-        , cfg' ^. nixCommonConfig
         )
+
+nixCmd :: MonadObelisk m => NixCmd -> m FilePath
+nixCmd cmdCfg = withSpinner' ("Running " <> cmd <> desc) (Just $ const $ "Built " <> desc) $ do
+  output <- readProcessAndLogStderr Debug cmdProc
+  -- Remove final newline that Nix appends
+  Just (outPath, '\n') <- pure $ T.unsnoc output
+  pure $ T.unpack outPath
+  where
+    (cmdProc, cmd) = nixCmdProc' cmdCfg
+    commonCfg = case cmdCfg of
+      NixCmd_Build cfg' -> cfg' ^. nixCommonConfig
+      NixCmd_Instantiate cfg' -> cfg' ^. nixCommonConfig
     path = commonCfg ^. nixCmdConfig_target . target_path
     desc = T.pack $ mconcat $ catMaybes
-      [ (" on " <>) <$> path
+      [ ("on " <>) <$> path
       , (\a -> " [" <> a <> "]") <$> (commonCfg ^. nixCmdConfig_target . target_attr)
       ]
-

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -42,7 +42,6 @@ import System.IO.Temp
 import System.IO.Unsafe (unsafePerformIO)
 import System.Posix (FileStatus, FileMode, CMode (..), UserID, deviceID, fileID, fileMode, fileOwner, getFileStatus, getRealUserID)
 import System.Posix.Files
-import System.Process (waitForProcess)
 
 import GitHub.Data.GitData (Branch)
 import GitHub.Data.Name (Name)
@@ -288,7 +287,7 @@ nixShellWithPkgs root isPure chdirToRoot packageNamesAndPaths command = do
         [ rawArg "root" $ toNixPath $ if chdirToRoot then "." else root
         , strArg "pkgs" (T.unpack $ decodeUtf8 $ BSL.toStrict $ Json.encode packageNamesAndAbsPaths)
         ]
-  void $ liftIO $ waitForProcess ph
+  void $ waitForProcess ph
 
 nixShellWithHoogle :: MonadObelisk m => FilePath -> Bool -> String -> Maybe String -> m ()
 nixShellWithHoogle root isPure shell' command = do
@@ -299,7 +298,7 @@ nixShellWithHoogle root isPure shell' command = do
           \userSettings = super.userSettings // { withHoogle = true; };\
         \})).project.shells.${shell}"
     & nixShellConfig_common . nixCmdConfig_args .~ [ strArg "shell" shell' ]
-  void $ liftIO $ waitForProcess ph
+  void $ waitForProcess ph
 
 projectShell :: MonadObelisk m => FilePath -> Bool -> String -> Maybe String -> m ()
 projectShell root isPure shellName command = do
@@ -307,7 +306,7 @@ projectShell root isPure shellName command = do
   (_, _, _, ph) <- createProcess_ "runNixShellAttr" $ setCwd (Just root) $ nixShellRunProc $ defShellConfig
     & nixShellConfig_common . nixCmdConfig_target . target_path ?~ "default.nix"
     & nixShellConfig_common . nixCmdConfig_target . target_attr ?~ ("shells." <> shellName)
-  void $ liftIO $ waitForProcess ph
+  void $ waitForProcess ph
 
 findProjectAssets :: MonadObelisk m => FilePath -> m Text
 findProjectAssets root = do

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -315,8 +315,6 @@ findProjectAssets root = do
   isDerivation <- readProcessAndLogStderr Debug $
     proc nixExePath
       [ "eval"
-      , "-f"
-      , root
       , "(let a = import " <> importableRoot <> " {}; in toString (a.reflex.nixpkgs.lib.isDerivation a.passthru.staticFilesImpure))"
       , "--raw"
       -- `--raw` is not available with old nix-instantiate. It drops quotation

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -104,20 +104,11 @@ run profiled = withProjectRoot "." $ \root -> do
       let exeSource =
             unlines $
               [ "module Main where"
-              , "import Control.Concurrent"
-              , "import Control.Monad.Fix"
+              , "import Control.Exception"
               , "import Reflex.Profiled" ]
               <> obRunImports <>
               [ "main :: IO ()"
-              , "main = do"
-              , "  forkIO $ fix $ \\rec -> do"
-                -- TODO: make this filename customizable
-              , "    writeProfilingData \"" <> profileBaseName <> ".rprof\""
-                -- write every .1 seconds.
-                -- TODO: perhaps it should only write once at the end of ecah run
-              , "    threadDelay 10000"
-              , "    rec"
-              , "  " <> obRunExpr]
+              , "main = " <> obRunExpr <> " `finally` writeProfilingData \"" <> profileBaseName <> ".rprof\"" ]
           -- Sane flags to enable by default, enable time profiling +
           -- closure heap profiling.
           rtsFlags = [ "+RTS", "-p", "-po" <> profileBaseName, "-hc", "-RTS" ]

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -108,7 +108,7 @@ run profiled = withProjectRoot "." $ \root -> do
               , "import Reflex.Profiled" ]
               <> obRunImports <>
               [ "main :: IO ()"
-              , "main = " <> obRunExpr <> " `finally` writeProfilingData \"" <> profileBaseName <> ".rprof\"" ]
+              , "main = (" <> obRunExpr <> ") `finally` writeProfilingData \"" <> profileBaseName <> ".rprof\"" ]
           -- Sane flags to enable by default, enable time profiling +
           -- closure heap profiling.
           rtsFlags = [ "+RTS", "-p", "-po" <> profileBaseName, "-hc", "-RTS" ]

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -91,7 +91,7 @@ profile profileBasePattern rtsFlags = withProjectRoot "." $ \root -> do
 
   putLog Debug $ T.pack $ "Storing profiled data under base name of " <> profileBaseName
 
-  liftIO $ createDirectoryIfMissing False $ takeDirectory profileBaseName
+  liftIO $ createDirectoryIfMissing True $ takeDirectory profileBaseName
 
   outPath <- nixCmd $ NixCmd_Build $ def
       & nixBuildConfig_outLink .~ OutLink_None

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -78,16 +78,12 @@ preprocessorIdentifier = "__preprocessor-apply-packages"
 profile
   :: MonadObelisk m
   => FilePath
-  -> Maybe String
+  -> String
   -> m ()
-profile profileBaseName mRtsFlags = withProjectRoot "." $ \root -> do
+profile profileBaseName rtsFlags = withProjectRoot "." $ \root -> do
   putLog Debug "Using profiled build of project."
   liftIO $ createDirectoryIfMissing False $ takeDirectory profileBaseName
-  let -- Sane flags to enable by default, enable time profiling +
-      -- closure heap profiling.
-      defaultRtsFlags = [ "-p", "-hc" ]
-      rtsFlags = maybe defaultRtsFlags words mRtsFlags
-      nixBuildExpr = [hereLit|
+  let nixBuildExpr = [hereLit|
 with (import ./. {});
 let
   exeSource = obelisk.nixpkgs.writeText "ob-run" ''
@@ -127,9 +123,9 @@ in obelisk.nixpkgs.runCommand "ob-run" {
     , T.unpack assets
     , profileBaseName
     , "+RTS"
-    , "-po" <> profileBaseName ]
-    <> rtsFlags
-    <> ["-RTS"]
+    , "-po" <> profileBaseName
+    ] <> words rtsFlags
+      <> [ "-RTS" ]
   _ <- liftIO $ waitForProcess ph
   pure ()
 

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -8,8 +8,7 @@ module Obelisk.Command.Run where
 
 import Control.Arrow ((&&&))
 import Control.Exception (Exception, bracket)
-import qualified Control.Lens as Lens
-import Control.Lens (ifor)
+import Control.Lens (ifor, (.~), (&))
 import Control.Monad (filterM, unless)
 import Control.Monad.Except (runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
@@ -109,8 +108,8 @@ profile profileBaseName = withProjectRoot "." $ \root -> do
         , "  buildInputs = [ (profiled.ghc.ghcWithPackages (p: [ p.backend p.frontend])) ];"
         , "} \"ghc -x hs -prof -fno-prof-auto ${exeSource} -o $out\")" ]
   exePath <- nixCmd $ NixCmd_Build $ def
-      Lens.& nixBuildConfig_outLink Lens..~ OutLink_None
-      Lens.& nixCmdConfig_target Lens..~ Target
+      & nixBuildConfig_outLink .~ OutLink_None
+      & nixCmdConfig_target .~ Target
         { _target_path = Nothing
         , _target_attr = Nothing
         , _target_expr = Just nixBuildExpr }

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -97,7 +97,7 @@ profile profileBasePattern rtsFlags = withProjectRoot "." $ \root -> do
       & nixBuildConfig_outLink .~ OutLink_None
       & nixCmdConfig_target .~ Target
         { _target_path = Just "."
-        , _target_attr = Just "profiledObRun"
+        , _target_attr = Just "__unstable__.profiledObRun"
         , _target_expr = Nothing }
   assets <- findProjectAssets root
   putLog Debug $ "Assets impurely loaded from: " <> assets

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -24,8 +24,6 @@ import Data.Maybe
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Time (getCurrentTime)
-import Data.Time.Format (formatTime, defaultTimeLocale)
 import Data.Traversable (for)
 import Debug.Trace (trace)
 import Distribution.Compiler (CompilerFlavor(..))
@@ -83,20 +81,14 @@ obRunImports = [ "import qualified Obelisk.Run"
 
 profile
   :: MonadObelisk m
-  => Maybe FilePath
+  => FilePath
   -> m ()
-profile mProfileBaseName = withProjectRoot "." $ \root -> do
+profile profileBaseName = withProjectRoot "." $ \root -> do
   freePort <- getFreePort
   assets <- findProjectAssets root
   putLog Debug $ "Assets impurely loaded from: " <> assets
   putLog Debug "Using profiled build of project."
-  time <- liftIO $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" <$> getCurrentTime
-  profileBaseName <- case mProfileBaseName of
-    Just baseName -> pure baseName
-    Nothing -> do
-      let profileDirectory = root </> "profile"
-      liftIO $ createDirectoryIfMissing False profileDirectory
-      pure $ profileDirectory </> time
+  liftIO $ createDirectoryIfMissing False $ takeDirectory profileBaseName
   let -- Sane flags to enable by default, enable time profiling +
       -- closure heap profiling.
       rtsFlags = [ "+RTS", "-p", "-po" <> profileBaseName, "-hc", "-RTS" ]

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -101,7 +101,7 @@ profile profileBasePattern rtsFlags = withProjectRoot "." $ \root -> do
 
   putLog Debug $ T.pack $ "Storing profiled data under base name of " <> profileBaseName
 
-  liftIO $ createDirectoryIfMissing True $ takeDirectory profileBaseName
+  liftIO $ createDirectoryIfMissing True $ takeDirectory $ root </> profileBaseName
 
   outPath <- withSpinner "Building profiled executable" $
     fmap (T.unpack . T.strip) $ readProcessAndLogStderr Debug $ setCwd (Just root) $ nixCmdProc $

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -118,7 +118,7 @@ run profiled = withProjectRoot "." $ \root -> do
       withSystemTempFile "ob-run-profiled.hs" $ \hsFname hsHandle -> withSystemTempFile "ob-run" $ \exeFname exeHandle -> do
         liftIO $ hPutStr hsHandle exeSource
         liftIO $ hFlush hsHandle
-        (_, _, _, ph1) <- createProcess_ "nixGhcWithProfiling" $ setCwd (Just root) $ proc "nix-shell" [ "-p", "((import ./. {}).profiled.ghc.ghcWithPackages (p: [ p.backend p.frontend]))", "--run", unwords [ "ghc", "-x", "hs", "-prof", "-fprof-auto", hsFname, "-o", exeFname ] ]
+        (_, _, _, ph1) <- createProcess_ "nixGhcWithProfiling" $ setCwd (Just root) $ proc "nix-shell" [ "-p", "((import ./. {}).profiled.ghc.ghcWithPackages (p: [ p.backend p.frontend]))", "--run", unwords [ "ghc", "-x", "hs", "-prof", "-fno-prof-auto", hsFname, "-o", exeFname ] ]
         code <- liftIO $ waitForProcess ph1
         case code of
           ExitSuccess -> do

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -82,8 +82,9 @@ obRunImports = [ "import qualified Obelisk.Run"
 
 profile
   :: MonadObelisk m
-  => m ()
-profile = withProjectRoot "." $ \root -> do
+  => Maybe FilePath
+  -> m ()
+profile mProfileBaseName = withProjectRoot "." $ \root -> do
   freePort <- getFreePort
   assets <- findProjectAssets root
   putLog Debug $ "Assets impurely loaded from: " <> assets
@@ -108,7 +109,7 @@ profile = withProjectRoot "." $ \root -> do
       -- closure heap profiling.
       rtsFlags = [ "+RTS", "-p", "-po" <> profileBaseName, "-hc", "-RTS" ]
       profileDirectory = root </> "profile"
-      profileBaseName = profileDirectory </> time
+      profileBaseName = fromMaybe (profileDirectory </> time) mProfileBaseName
   liftIO $ createDirectoryIfMissing False profileDirectory
   withSystemTempFile "ob-run-profiled.hs" $ \hsFname hsHandle -> withSystemTempFile "ob-run" $ \exeFname exeHandle -> do
     liftIO $ hPutStr hsHandle exeSource

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -109,7 +109,7 @@ main = do
   '';
 in obelisk.nixpkgs.runCommand "ob-run" {
      buildInputs = [ (profiled.ghc.ghcWithPackages (p: [ p.backend p.frontend])) ];
-} "ghc -x hs -prof -fno-prof-auto ${exeSource} -o $out"
+} "ghc -x hs -prof -fno-prof-auto -threaded ${exeSource} -o $out"
 |]
   exePath <- nixCmd $ NixCmd_Build $ def
       & nixBuildConfig_outLink .~ OutLink_None

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -93,7 +93,7 @@ profile profileBasePattern rtsFlags = withProjectRoot "." $ \root -> do
 
   liftIO $ createDirectoryIfMissing False $ takeDirectory profileBaseName
 
-  exePath <- nixCmd $ NixCmd_Build $ def
+  outPath <- nixCmd $ NixCmd_Build $ def
       & nixBuildConfig_outLink .~ OutLink_None
       & nixCmdConfig_target .~ Target
         { _target_path = Just "."
@@ -102,7 +102,7 @@ profile profileBasePattern rtsFlags = withProjectRoot "." $ \root -> do
   assets <- findProjectAssets root
   putLog Debug $ "Assets impurely loaded from: " <> assets
   freePort <- getFreePort
-  (_, _, _, ph) <- createProcess_ "runProfExe" $ setCwd (Just root) $ setDelegateCtlc True $ proc exePath $
+  (_, _, _, ph) <- createProcess_ "runProfExe" $ setCwd (Just root) $ setDelegateCtlc True $ proc (outPath </> "bin" </> "ob-run") $
     [ show freePort
     , T.unpack assets
     , profileBaseName

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -50,10 +50,11 @@ import System.Environment (getExecutablePath)
 import System.FilePath
 import qualified System.Info
 import System.IO.Temp (withSystemTempDirectory)
-import System.Process (waitForProcess)
 
 import Obelisk.App (MonadObelisk)
-import Obelisk.CliApp (Severity (..) , failWith, putLog, proc, readCreateProcessWithExitCode, setCwd, setDelegateCtlc, createProcess_)
+import Obelisk.CliApp (Severity (..),
+                       failWith, putLog, proc, readCreateProcessWithExitCode,
+                       setCwd, setDelegateCtlc, createProcess_, waitForProcess)
 import Obelisk.Command.Nix
 import Obelisk.Command.Project (nixShellWithPkgs, toImplDir, withProjectRoot, findProjectAssets)
 import Obelisk.Command.Thunk (attrCacheFileName)
@@ -136,7 +137,7 @@ in obelisk.nixpkgs.runCommand "ob-run" {
     , "-po" <> profileBaseName
     ] <> rtsFlags
       <> [ "-RTS" ]
-  _ <- liftIO $ waitForProcess ph
+  _ <- waitForProcess ph
   pure ()
 
 run

--- a/skeleton/.gitignore
+++ b/skeleton/.gitignore
@@ -6,3 +6,4 @@ result-ios
 result-exe
 .attr-cache
 ghcid-output.txt
+profile/


### PR DESCRIPTION
Adds obelisk profile command. This dumps some profiling information into the profile/ directory that can give you some idea of what your program is spending resources on. Currently outputs 3 profiles:

- Heap profiling (.hp)
- Time profiling (.prof)
- Reflex profiling (.rprof)

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
