### PR TITLE
Better source filtering

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,13 +9,9 @@ let
   inherit (reflex-platform) hackGet nixpkgs;
   pkgs = nixpkgs;
 
-  cleanSource = src: pkgs.lib.cleanSourceWith {
-    filter = name: _: let baseName = builtins.baseNameOf name; in !(
-      builtins.match "^\\.ghc\\.environment.*" baseName != null ||
-      baseName == "cabal.project.local"
-    );
-    src = pkgs.lib.cleanSource src;
-  };
+  inherit (import dep/gitignore.nix { inherit (nixpkgs) lib; }) gitignoreSource;
+
+  cleanSource = src: gitignoreSource (pkgs.lib.cleanSource src);
 
   commandRuntimeDeps = pkgs: with pkgs; [
     coreutils

--- a/default.nix
+++ b/default.nix
@@ -5,10 +5,17 @@
 , reflex-platform-func ? import ./dep/reflex-platform
 }:
 let
-  cleanSource = builtins.filterSource (name: _: let baseName = builtins.baseNameOf name; in !(
-    builtins.match "^\\.ghc\\.environment.*" baseName != null ||
-    baseName == "cabal.project.local"
-  ));
+  reflex-platform = getReflexPlatform system;
+  inherit (reflex-platform) hackGet nixpkgs;
+  pkgs = nixpkgs;
+
+  cleanSource = src: pkgs.lib.cleanSourceWith {
+    filter = name: _: let baseName = builtins.baseNameOf name; in !(
+      builtins.match "^\\.ghc\\.environment.*" baseName != null ||
+      baseName == "cabal.project.local"
+    );
+    src = pkgs.lib.cleanSource src;
+  };
 
   commandRuntimeDeps = pkgs: with pkgs; [
     coreutils
@@ -101,10 +108,6 @@ let
 
     ];
   };
-
-  reflex-platform = getReflexPlatform system;
-  inherit (reflex-platform) hackGet nixpkgs;
-  pkgs = nixpkgs;
 
   # The haskell environment used to build Obelisk itself, e.g. the 'ob' command
   ghcObelisk = reflex-platform.ghc;

--- a/dep/gitignore.nix/default.nix
+++ b/dep/gitignore.nix/default.nix
@@ -1,0 +1,8 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))

--- a/dep/gitignore.nix/github.json
+++ b/dep/gitignore.nix/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "hercules-ci",
+  "repo": "gitignore.nix",
+  "branch": "master",
+  "private": false,
+  "rev": "7415c4feb127845553943a3856cbc5cb967ee5e0",
+  "sha256": "1zd1ylgkndbb5szji32ivfhwh04mr1sbgrnvbrqpmfb67g2g3r9i"
+}


### PR DESCRIPTION
I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
