### PR TITLE
Support non-EC2 targets with ob deploy

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -173,9 +173,9 @@ in rec {
   '';
 
   serverModules = {
-    mkBaseEc2 = { obeliskPkgs, ... }: {...}: {
+    mkBaseEc2 = {...}: { pkgs, ...}: {
       imports = [
-        (obeliskPkgs.path + /nixos/modules/virtualisation/amazon-image.nix)
+        (pkgs.path + /nixos/modules/virtualisation/amazon-image.nix)
       ];
       ec2.hvm = true;
     };
@@ -261,7 +261,7 @@ in rec {
       system = "x86_64-linux";
       configuration = {
         imports = [
-          (module (args // { obeliskPkgs = pkgs; }))
+          (module { inherit exe hostName adminEmail routeHost enableHttps version; })
           (serverModules.mkDefaultNetworking args)
           (serverModules.mkObeliskApp args)
         ];

--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,7 @@ let
         obelisk-cliapp = self.callCabal2nix "obelisk-cliapp" (cleanSource ./lib/cliapp) {};
         obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (cleanSource ./lib/command) {}) {
           librarySystemDepends = [
+            pkgs.jre
             pkgs.nix
             (haskellLib.justStaticExecutables self.ghcid)
           ];

--- a/default.nix
+++ b/default.nix
@@ -174,9 +174,9 @@ in rec {
   '';
 
   serverModules = {
-    mkBaseEc2 = {...}: { pkgs, ...}: {
+    mkBaseEc2 = { nixosPkgs, ... }: {...}: {
       imports = [
-        (pkgs.path + /nixos/modules/virtualisation/amazon-image.nix)
+        (nixosPkgs.path + /nixos/modules/virtualisation/amazon-image.nix)
       ];
       ec2.hvm = true;
     };
@@ -262,7 +262,7 @@ in rec {
       system = "x86_64-linux";
       configuration = {
         imports = [
-          (module { inherit exe hostName adminEmail routeHost enableHttps version; })
+          (module { inherit exe hostName adminEmail routeHost enableHttps version; nixosPkgs = pkgs; })
           (serverModules.mkDefaultNetworking args)
           (serverModules.mkObeliskApp args)
         ];

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -155,8 +155,8 @@ deployCommand cfg = hsubparser $ mconcat
 
 deployInitOpts :: Parser DeployInitOpts
 deployInitOpts = DeployInitOpts
-  <$> strArgument (action "directory" <> metavar "DEPLOYDIR" <> help "Path to a directory that it will create")
-  <*> strOption (long "ssh-key" <> action "file" <> metavar "SSHKEY" <> help "Path to an ssh key that it will symlink to")
+  <$> strArgument (action "directory" <> metavar "DEPLOYDIR" <> help "Path to a directory where the deployment repository will be initialized")
+  <*> strOption (long "ssh-key" <> action "file" <> metavar "SSHKEY" <> help "Path to an SSH key that will be *copied* to the deployment repository")
   <*> some (strOption (long "hostname" <> metavar "HOSTNAME" <> help "hostname of the deployment target"))
   <*> strOption (long "route" <> metavar "PUBLICROUTE" <> help "Publicly accessible URL of your app")
   <*> strOption (long "admin-email" <> metavar "ADMINEMAIL" <> help "Email address where administrative alerts will be sent")

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -72,12 +72,6 @@ deployInit thunkPtr deployDir sshKeyPath hostnames route adminEmail enableHttps 
   --accidentally create a production deployment that uses development
   --credentials to connect to some resources.  This could result in, e.g.,
   --production data backed up to a dev environment.
-  putLog Notice "Writing default module.nix"
-  writeDeployConfig deployDir "module.nix"
-    "{ obeliskPkgs, ... }: {...}: {\n\
-    \  imports = [(obeliskPkgs.path + /nixos/modules/virtualisation/amazon-image.nix)];\n\
-    \  ec2.hvm = true;\n\
-    \}"
   withSpinner "Creating project configuration directories" $ do
     callProcessAndLogOutput (Notice, Error) $
       proc "mkdir" [ "-p"
@@ -85,14 +79,20 @@ deployInit thunkPtr deployDir sshKeyPath hostnames route adminEmail enableHttps 
                    , deployDir </> "config" </> "common"
                    , deployDir </> "config" </> "frontend"
                    ]
+
+  let srcDir = deployDir </> "src"
+  withSpinner ("Creating source thunk (" <> T.pack srcDir <> ")") $ liftIO $ do
+    createThunk srcDir thunkPtr
+    setupObeliskImpl deployDir
+
   withSpinner "Writing deployment configuration" $ do
     writeDeployConfig deployDir "backend_hosts" $ unlines hostnames
     writeDeployConfig deployDir "enable_https" $ show enableHttps
     writeDeployConfig deployDir "admin_email" adminEmail
     writeDeployConfig deployDir ("config" </> "common" </> "route") route
-  withSpinner "Creating source thunk (./src)" $ liftIO $ do
-    createThunk (deployDir </> "src") thunkPtr
-    setupObeliskImpl deployDir
+    writeDeployConfig deployDir "module.nix" $
+      "(import " <> toNixPath srcDir <> " {}).obelisk.serverModules.mkBaseEc2"
+
   withSpinner ("Initializing git repository (" <> T.pack deployDir <> ")") $
     initGit deployDir
 

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -272,19 +272,16 @@ instance FromJSON KeytoolConfig
 instance ToJSON KeytoolConfig
 
 createKeystore :: MonadObelisk m => FilePath -> KeytoolConfig -> m ()
-createKeystore root config = do
-  let expr = "with (import " <> toImplDir root <> ").reflex-platform.nixpkgs; pkgs.mkShell { buildInputs = [ pkgs.jdk ]; }"
-  callProcessAndLogOutput (Notice,Notice) $ setCwd (Just root) $ proc "nix-shell" ["-E" , expr, "--run" , keytoolCmd]
-  where
-    keytoolCmd = processToShellString "keytool"
-      [ "-genkeypair", "-noprompt"
-      , "-keystore", _keytoolConfig_keystore config
-      , "-keyalg", "RSA", "-keysize", "2048"
-      , "-validity", "1000000"
-      , "-storepass", _keytoolConfig_storepass config
-      , "-alias", _keytoolConfig_alias config
-      , "-keypass", _keytoolConfig_keypass config
-      ]
+createKeystore root config =
+  callProcessAndLogOutput (Notice, Notice) $ setCwd (Just root) $ proc jreKeyToolPath
+    [ "-genkeypair", "-noprompt"
+    , "-keystore", _keytoolConfig_keystore config
+    , "-keyalg", "RSA", "-keysize", "2048"
+    , "-validity", "1000000"
+    , "-storepass", _keytoolConfig_storepass config
+    , "-alias", _keytoolConfig_alias config
+    , "-keypass", _keytoolConfig_keypass config
+    ]
 
 -- | Simplified deployment configuration mechanism. At one point we may revisit this.
 writeDeployConfig :: MonadObelisk m => FilePath -> FilePath -> String -> m ()

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -48,6 +48,7 @@ deployInit
   -> Bool -- ^ enable https
   -> m ()
 deployInit thunkPtr deployDir sshKeyPath hostnames route adminEmail enableHttps = do
+  liftIO $ createDirectoryIfMissing True deployDir
   localKey <- withSpinner ("Preparing " <> T.pack deployDir) $ do
     localKey <- liftIO (doesFileExist sshKeyPath) >>= \case
       False -> failWith $ T.pack $ "ob deploy init: file does not exist: " <> sshKeyPath

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -44,6 +44,9 @@ nixExePath = $(staticWhich "nix")
 nixBuildExePath :: FilePath
 nixBuildExePath = $(staticWhich "nix-build")
 
+jreKeyToolPath :: FilePath
+jreKeyToolPath = $(staticWhich "keytool")
+
 -- Check whether the working directory is clean
 checkGitCleanStatus :: MonadObelisk m => FilePath -> Bool -> m Bool
 checkGitCleanStatus repo withIgnored = do


### PR DESCRIPTION
I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
