### PR TITLE
Add missing changelog entry for obelisk 0.3 routes change

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,20 @@ This project's release branch is `master`. This log is written from the perspect
 
 ## v0.3.0.0 - 2019-12-20
 
+* Change the structure of Obelisk routes to use a designated
+  `FullRoute` type. This combines frontend and backend routes into one
+  structure. This is a **breaking** change which requires Obelisk apps
+  to take specific migrations. They are:
+    * Rewrite the implementation of `_backend_routeEncoder` in
+      `Backend` to use `mkFullRouteEncoder` instead of
+      `handleEncoder`. Specifically, the backend and frontend cases of
+      the top-level `pathComponentEncoder` become the second and third
+      arguments of `mkFullRouteEncoder` respectively, while the
+      missing route becomes the first argument. An example of how to
+      do this is available in [a reflex-examples
+      commit](https://github.com/reflex-frp/reflex-examples/commits/28f566c3e7dc615578dc74297b7c620c1f13683e).
+    * Replace type constructions of `InL` with `FullRoute_Backend` and
+      `InR` with `FullRoute_Frontend`.
 * Generalised `pathSegmentEncoder`, added `pathFieldEncoder`.
 * Added some `Prism`s to the encoder library for manipulating `DSum`s.
 * Add `ob doc` command, which lists paths to haddock documentation for specified packages.


### PR DESCRIPTION
In b6da186353c525aaf674e16933b48311dca5a1d3, we added a new FullRoute
structure that contains the frontend, backend, and missing routes.
This included changes to the skeleton, but was missing a note in the
changelog that previous apps based off of the skeleton (or really any
obelisk apps) needed to be updated.

This change adds the missing note to the changelog. Emphasis is made
that this is a breaking change that requires some changes on the
user’s part. Some idea of what the user needs to do is given as well.
I have also included an example for what I had to do in
reflex-examples to get it working with Obelisk routes.

[Provide a clear overview of your changes.]

I have:

  - [ ] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
