### PR TITLE
Recognize loaderless thunk types in ob thunk

### DIFF
--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -236,7 +236,7 @@ attrCacheFileName :: FilePath
 attrCacheFileName = ".attr-cache"
 
 data ThunkType = ThunkType
-  { _thunkType_loader :: FilePath
+  { _thunkType_loader :: Maybe FilePath
   , _thunkType_json :: FilePath
   , _thunkType_optional :: Set FilePath
   , _thunkType_loaderVersions :: NonEmpty Text
@@ -245,7 +245,7 @@ data ThunkType = ThunkType
 
 gitHubThunkType :: ThunkType
 gitHubThunkType = ThunkType
-  { _thunkType_loader = "default.nix"
+  { _thunkType_loader = Just "default.nix"
   , _thunkType_json = "github.json"
   , _thunkType_optional = Set.fromList [attrCacheFileName]
   , _thunkType_loaderVersions = gitHubStandaloneLoaders
@@ -255,7 +255,26 @@ gitHubThunkType = ThunkType
 
 gitThunkType :: ThunkType
 gitThunkType = ThunkType
-  { _thunkType_loader = "default.nix"
+  { _thunkType_loader = Just "default.nix"
+  , _thunkType_json = "git.json"
+  , _thunkType_optional = Set.fromList [attrCacheFileName]
+  , _thunkType_loaderVersions = plainGitStandaloneLoaders
+  , _thunkType_parser = parseThunkPtr $ fmap ThunkSource_Git . parseGitSource
+  }
+
+gitHubLoaderlessThunkType :: ThunkType
+gitHubLoaderlessThunkType = ThunkType
+  { _thunkType_loader = Nothing
+  , _thunkType_json = "github.json"
+  , _thunkType_optional = Set.fromList [attrCacheFileName]
+  , _thunkType_loaderVersions = gitHubStandaloneLoaders
+  , _thunkType_parser = parseThunkPtr $ \v ->
+      ThunkSource_GitHub <$> parseGitHubSource v <|> ThunkSource_Git <$> parseGitSource v
+  }
+
+gitLoaderlessThunkType :: ThunkType
+gitLoaderlessThunkType = ThunkType
+  { _thunkType_loader = Nothing
   , _thunkType_json = "git.json"
   , _thunkType_optional = Set.fromList [attrCacheFileName]
   , _thunkType_loaderVersions = plainGitStandaloneLoaders
@@ -263,16 +282,14 @@ gitThunkType = ThunkType
   }
 
 thunkTypes :: [ThunkType]
-thunkTypes = [gitThunkType, gitHubThunkType]
+thunkTypes = [gitThunkType, gitLoaderlessThunkType, gitHubThunkType, gitHubLoaderlessThunkType]
 
 findThunkType :: [ThunkType] -> FilePath -> IO (Either ReadThunkError ThunkType)
 findThunkType types thunkDir = do
   matches <- fmap catMaybes $ forM types $ \thunkType -> do
     let
       expectedContents = Set.fromList $ (thunkDir </>) <$>
-        [ _thunkType_loader thunkType
-        , _thunkType_json thunkType
-        ]
+        maybeToList (_thunkType_loader thunkType) <> [ _thunkType_json thunkType ]
       optionalContents = Set.map (thunkDir </>) (_thunkType_optional thunkType)
 
     -- Ensure that there aren't any other files in the thunk
@@ -294,10 +311,14 @@ findThunkType types thunkDir = do
 readPackedThunk :: FilePath -> IO (Either ReadThunkError ThunkPtr)
 readPackedThunk thunkDir = runExceptT $ do
   thunkType <- ExceptT $ findThunkType thunkTypes thunkDir
-  -- Ensure that we recognize the thunk loader
-  loader <- liftIO $ T.readFile $ thunkDir </> _thunkType_loader thunkType
-  unless (loader `elem` _thunkType_loaderVersions thunkType) $ do
-    throwError $ ReadThunkError_UnrecognizedLoader loader
+
+  case _thunkType_loader thunkType of
+    Just loaderFile -> do
+      -- Ensure that we recognize the thunk loader
+      loader <- liftIO $ T.readFile $ thunkDir </> loaderFile
+      unless (loader `elem` _thunkType_loaderVersions thunkType) $ do
+        throwError $ ReadThunkError_UnrecognizedLoader loader
+    Nothing -> pure ()
 
   txt <- liftIO $ LBS.readFile $ thunkDir </> _thunkType_json thunkType
   case parseMaybe (_thunkType_parser thunkType) =<< Aeson.decode txt of

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -269,11 +269,11 @@ findThunkType :: [ThunkType] -> FilePath -> IO (Either ReadThunkError ThunkType)
 findThunkType types thunkDir = do
   matches <- fmap catMaybes $ forM types $ \thunkType -> do
     let
-      expectedContents = Set.fromList $ (thunkDir </>) <$>
-        [ _thunkType_loader thunkType
-        , _thunkType_json thunkType
-        ]
-      optionalContents = Set.map (thunkDir </>) (_thunkType_optional thunkType)
+      expectedContents = (thunkDir </>) <$>
+        Set.singleton (_thunkType_json thunkType)
+      optionalContents = (thunkDir </>) <$>
+        (_thunkType_optional thunkType) <>
+        (Set.singleton (_thunkType_loader thunkType))
 
     -- Ensure that there aren't any other files in the thunk
     -- NB: System.Directory.listDirectory returns the contents without the directory path


### PR DESCRIPTION
Some thunks like those in
reflex-platform/haskell-overlays/reflex-packages/dep/ don’t have a
default.nix loader. This is because the target repo doesn’t have a
default.nix, so import’ing doesn’t work. As a consequence, these
loaders only work with hackGet.

This makes ThunkType accept no loader, and not give an unrecognized
files error.

See https://github.com/reflex-frp/reflex-platform/tree/45a8885e2fe404060722cb5101297a30d308d88b/haskell-overlays/reflex-packages/dep/reflex

<!-- Provide a clear overview of your changes. -->

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
