### PR TITLE
Experimental ghcide support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Obelisk provides an easy way to develop and deploy your [Reflex](https://github.
   - [Running over HTTPS](#running-over-https)
   - [IDE Support](#ide-support)
     - [Terminal-based feedback](#terminal-based-feedback)
-    - [**Experimental** `ghcide` support](#experimental-ghcide-support)
+    - [Experimental `ghcide` support](#experimental-ghcide-support)
 - [Deploying](#deploying)
   - [Locally](#locally)
   - [Default EC2 Deployment](#default-ec2-deployment)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Obelisk provides an easy way to develop and deploy your [Reflex](https://github.
 - [Developing an Obelisk project](#developing-an-obelisk-project)
   - [Adding Packages](#adding-packages)
   - [Adding Package Overrides](#adding-package-overrides)
-  - [Running over https](#running-over-https)
+  - [Running over HTTPS](#running-over-https)
 - [Deploying](#deploying)
   - [Locally](#locally)
   - [Default EC2 Deployment](#default-ec2-deployment)
@@ -169,9 +169,10 @@ project ./. ({ pkgs, ... }: {
 
 ### Running over HTTPS
 
-To run your app locally over https, update the protocol in `config/common/route` to `https`, and then use `ob run` as normal.
+To run your app locally over HTTPS, update the protocol in `config/common/route` to `https`, and then use `ob run` as normal.
 
-Since Obelisk generates a self-signed certificate for running https, the browser will issue a warning about using an invalid certificate. On Chrome, you can go to `chrome://flags/#allow-insecure-localhost` to enable invalid certificates for localhost.
+Since Obelisk generates a self-signed certificate for running HTTPS, the browser will issue a warning about using an invalid certificate. On Chrome, you can go to `chrome://flags/#allow-insecure-localhost` to enable invalid certificates for localhost.
+
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Obelisk provides an easy way to develop and deploy your [Reflex](https://github.
   - [Adding Packages](#adding-packages)
   - [Adding Package Overrides](#adding-package-overrides)
   - [Running over HTTPS](#running-over-https)
+  - [IDE Support](#ide-support)
+    - [Terminal-based feedback](#terminal-based-feedback)
+    - [**Experimental** `ghcide` support](#experimental-ghcide-support)
 - [Deploying](#deploying)
   - [Locally](#locally)
   - [Default EC2 Deployment](#default-ec2-deployment)
@@ -173,6 +176,42 @@ To run your app locally over HTTPS, update the protocol in `config/common/route`
 
 Since Obelisk generates a self-signed certificate for running HTTPS, the browser will issue a warning about using an invalid certificate. On Chrome, you can go to `chrome://flags/#allow-insecure-localhost` to enable invalid certificates for localhost.
 
+### IDE Support
+
+#### Terminal-based feedback
+
+Obelisk officially supports terminal-based feedback (akin to [`ghcid`](https://github.com/ndmitchell/ghcid)) in `ob run` and `ob watch`.
+
+#### **Experimental** `ghcide` support
+
+> **NOTE:** `ghcide` support is strictly **experimental** and **not officially supported**. There is no guarantee that it will work for you or that this support will be maintained over time.
+
+To try out the **experimental** [`ghcide`](https://github.com/digital-asset/ghcide) support:
+
+  * Install a `ghcide` plugin for your editor.
+  * Add `__withGhcide = true;` to your Obelisk project's `default.nix` (inside the call to `project`). With this setting, `ob shell` will provide `ghcide` as well.
+  * Add `hie-bios.sh` to the root of your project:
+      ```shell
+      cat > hie-bios.sh <<'EOF'
+      #!/usr/bin/env bash
+      source "$HOME/.bash_profile"; # NOTE: Some editors need help finding 'ob' and this assumes that `ob` is made available on your `$PATH` in `.bash_profile`
+      ob internal export-ghci-configuration > "$HIE_BIOS_OUTPUT"
+      EOF
+      chmod +x hie-bios.sh
+      ```
+  * Add `hie.yaml` to the root of your project:
+      ```shell
+      echo 'cradle: { bios: { program: hie-bios.sh } }' > hie.yaml
+      ```
+  * Test the configuration with `ob shell ghcide`. Assuming your project compiles and works with `ghcide` otherwise, this should succeed.
+  * Start your editor in a way that it can access the appropriate `ghcide`:
+      * This can sometimes be achieved with `ob shell 'start my editor'`.
+      * If you can't easily start your editor in a way that it inherits your shell, you may need to customize how your `ghcide` plugin finds `ghcide` or create a custom `ghcide` replacement script that you install globally. For example, for Visual Studio Code on macOS adding a script called `ghcide` to your `PATH` like the one below will cause `ghcide` from each project's `ob shell` to be used:
+          ```shell
+          #!/usr/bin/env bash
+          source "$HOME/.bash_profile"  # NOTE: This assumes that `ob` is made available on your `$PATH` in `.bash_profile`
+          ob shell "ghcide $@"
+          ```
 
 ## Deploying
 

--- a/all-builds.nix
+++ b/all-builds.nix
@@ -53,19 +53,28 @@ let
         obelisk.haskellPackageSets.ghcjs
         obeliskPackagesCommon;
       command = obelisk.command;
-      skeleton = import ./skeleton { inherit obelisk; };
-      serverSkeletonExe = skeleton.exe;
+
+      withSkeletonOptions = skel: options: (skel.passthru.__unstable__.self.extend (self: super: {
+        userSettings = super.userSettings // options;
+      })).project;
+      rawSkeleton = import ./skeleton { inherit obelisk; };
+      skeleton = withSkeletonOptions rawSkeleton {
+        withHoogle = true;  # cache the Hoogle database for the skeleton
+        __withGhcide = true; # cache the ghcide build for the skeleton
+      };
+
+      serverSkeletonExe = rawSkeleton.exe;
       # TODO fix nixpkgs so it doesn't try to run the result of haskell shells as setup hooks.
       serverSkeletonShell = local-self.nixpkgs.runCommand "shell-safe-for-dep" {} ''
         touch "$out"
         echo "return" >> "$out"
         cat "${skeleton.shells.ghc}" >> "$out"
       '';
-      androidSkeleton = (import ./skeleton { inherit obelisk; }).android.frontend;
-      iosSkeleton = (import ./skeleton { inherit obelisk; }).ios.frontend;
+      androidSkeleton = skeleton.android.frontend;
+      iosSkeleton = skeleton.ios.frontend;
       nameSuffix = if profiling then "profiled" else "unprofiled";
       packages = {
-        skeletonProfiledObRun = skeleton.__unstable__.profiledObRun;
+        skeletonProfiledObRun = rawSkeleton.__unstable__.profiledObRun;
         inherit
           command
           serverSkeletonShell

--- a/haskell-overlays/ghcide.nix
+++ b/haskell-overlays/ghcide.nix
@@ -1,0 +1,34 @@
+self: super:
+  let
+    pkgs = self.callPackage ({ pkgs }: pkgs) {};
+    inherit (pkgs.haskell.lib) dontCheck;
+  in {
+  ghcide = pkgs.haskell.lib.justStaticExecutables (dontCheck ((self.override {
+    overrides = self: super: {
+      ghc-check = self.callHackageDirect {
+        pkg = "ghc-check";
+        ver = "0.1.0.3";
+        sha256 = "038llbvryk5y27jbdpbshp0zw5lw1j6m7qk7vx1n96ykqdzkh649";
+      } {};
+      lsp-test = dontCheck (self.callHackage "lsp-test" "0.6.1.0" {});
+      haddock-library = dontCheck (self.callHackage "haddock-library" "1.8.0" {});
+      haskell-lsp = dontCheck (self.callHackage "haskell-lsp" "0.19.0.0" {});
+      haskell-lsp-types = dontCheck (self.callHackage "haskell-lsp-types" "0.19.0.0" {});
+      regex-posix = dontCheck (self.callHackage "regex-posix" "0.96.0.0" {});
+      test-framework = dontCheck (self.callHackage "test-framework" "0.8.2.0" {});
+      regex-base = dontCheck (self.callHackage "regex-base" "0.94.0.0" {});
+      regex-tdfa = dontCheck (self.callHackage "regex-tdfa" "1.3.1.0" {});
+      shake = dontCheck (self.callHackage "shake" "0.18.4" {});
+      hie-bios = dontCheck (self.callHackageDirect {
+        pkg = "hie-bios";
+        ver = "0.4.0";
+        sha256 = "19lpg9ymd9656cy17vna8wr1hvzfal94gpm2d3xpnw1d5qr37z7x";
+      } {});
+    };
+  }).callCabal2nix "ghcide" (pkgs.fetchFromGitHub {
+    owner = "digital-asset";
+    repo = "ghcide";
+    rev = "v0.1.0";
+    sha256 = "1kf71iix46hvyxviimrcv7kvsj67hcnnqlpdsmazmlmybf7wbqbb";
+  }) {}));
+}


### PR DESCRIPTION
See #660 

To experiment:

```
cd skeleton
ob shell ghcide
```

For vscode, etc: `ob shell 'code .'`

Todo:

  - [x] Integrate nix to provide ghcide
  - [x] Add `ob shell --for-unpacked` to provide a nix-shell exactly like `ob run` uses
  - [x] Write wrapper script for `ghcide` that proxies to `ob shell --for-unpacked ghcide` so editors don't need to run inside a special shell

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
