### PR TITLE
Serve range requests correctly for static files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,6 +39,8 @@ let
         hnix-store-core = self.callHackage "hnix-store-core" "0.1.0.0" {};
 
         ghcid = self.callCabal2nix "ghcid" (hackGet ./dep/ghcid) {};
+        # Exports more internals
+        snap-core = haskellLib.dontCheck (self.callCabal2nix "snap-core" (hackGet ./dep/snap-core) {});
       })
 
       pkgs.obeliskExecutableConfig.haskellOverlay

--- a/dep/snap-core/default.nix
+++ b/dep/snap-core/default.nix
@@ -1,0 +1,8 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))

--- a/dep/snap-core/github.json
+++ b/dep/snap-core/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "snap-core",
+  "branch": "ts-expose-fileserve-internals",
+  "private": false,
+  "rev": "e015fc484e38dd9389c58b277b1884395e553bdf",
+  "sha256": "1793x1h4lw9vnrii5akhfxx1x9yrgxf3052jf6bs8f1mhaic6mxx"
+}

--- a/lib/asset/serve-snap/src/Obelisk/Asset/Serve/Snap.hs
+++ b/lib/asset/serve-snap/src/Obelisk/Asset/Serve/Snap.hs
@@ -95,8 +95,8 @@ serveAsset' doRedirect base fallback p = do
           let finalFilename = base </> p </> "encodings" </> T.unpack (decodeUtf8 e)
           stat <- liftIO $ getFileStatus finalFilename
           modifyResponse $ setHeader "Last-Modified" "Thu, 1 Jan 1970 00:00:00 GMT"
-          modifyResponse $ setHeader "Accept-Ranges" "bytes"
-          modifyResponse $ setContentType (fileType defaultMimeTypes p)
+            . setHeader "Accept-Ranges" "bytes"
+            . setContentType (fileType defaultMimeTypes p)
           let size = fromIntegral $ fileSize stat
           -- Check if this is a range request
           req <- getRequest

--- a/lib/asset/serve-snap/src/Obelisk/Asset/Serve/Snap.hs
+++ b/lib/asset/serve-snap/src/Obelisk/Asset/Serve/Snap.hs
@@ -98,8 +98,10 @@ serveAsset' doRedirect base fallback p = do
             . setHeader "Accept-Ranges" "bytes"
             . setContentType (fileType defaultMimeTypes p)
           let size = fromIntegral $ fileSize stat
-          -- Check if this is a range request
           req <- getRequest
+          -- Despite the name, this function actually does all of the work for
+          -- responding to range requests. We only need to handle *none* range
+          -- requests ourselves.
           wasRange <- checkRangeReq req finalFilename size
           unless wasRange $ do
             modifyResponse $ setResponseCode 200 . setContentLength size


### PR DESCRIPTION
Without this, Safari will refuse to play video files from /static.

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
