### PR TITLE
Put gitignoreSource under cleanSource

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ let
 
   inherit (import dep/gitignore.nix { inherit (nixpkgs) lib; }) gitignoreSource;
 
-  cleanSource = src: gitignoreSource (pkgs.lib.cleanSource src);
+  cleanSource = src: pkgs.lib.cleanSource (gitignoreSource src);
 
   commandRuntimeDeps = pkgs: with pkgs; [
     coreutils


### PR DESCRIPTION
When these two are the other way around, `ob run` (or any ghcid using
obelisk's repl) is much slower.

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
