### PR TITLE
Bump reflex-platform pin to rp/master

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "develop",
+  "branch": "master",
   "private": false,
-  "rev": "156ebb7c391ec909d19e794e591f107462862543",
-  "sha256": "0rvbaimcvcica80538i6vxckv8si1gbd1ynvgxv7zr5jd1gk6vi5"
+  "rev": "41be4d952b75515a037318aa344dd6b13ad29cfe",
+  "sha256": "132yqzyzd3c5fjy7wwnwa5d6pjxv5ap2xz0swwbv3h5pwi8jwv0a"
 }


### PR DESCRIPTION
Update reflex-packages pin to `0.5.2.0` release.

I have:

  - [X] Based work on latest `develop` branch
  - [ ] ~Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)~ n/a
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [X] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
