### PR TITLE
New thunks to support hackGet

### DIFF
--- a/all-tests.nix
+++ b/all-tests.nix
@@ -100,14 +100,13 @@ in
               "cd ~/code/myapp && git remote add origin root@githost:/root/myorg/myapp.git"
           )
 
-
       with subtest("test pushing code to the remote"):
           client.succeed("cd ~/code/myapp && git push -u origin master")
           client.succeed("cd ~/code/myapp && git status")
 
       with subtest("test obelisk can pack"):
           client.succeed("ob -v thunk pack ~/code/myapp")
-          client.succeed("grep -qF 'git' ~/code/myapp/default.nix")
+          client.succeed("grep -qF 'git.json' ~/code/myapp/src.nix")
           client.succeed("grep -qF 'myorg' ~/code/myapp/git.json")
           client.succeed("ob -v thunk unpack ~/code/myapp")
 
@@ -123,19 +122,19 @@ in
           client.succeed("ob -v thunk unpack ~/code/myapp")
 
       with subtest("test building an invalid thunk fails"):
-          client.succeed("cd ~/code/myapp && git checkout -b bad")
+          client.succeed("cd ~/code/myapp/unpacked && git checkout -b bad")
           client.succeed(
-              "cp ${invalidThunkableSample} ~/code/myapp/default.nix"
+              "cp ${invalidThunkableSample} ~/code/myapp/unpacked/default.nix"
           )
-          client.succeed("cd ~/code/myapp && git add .")
+          client.succeed("cd ~/code/myapp/unpacked && git add .")
           client.succeed('git config --global user.email "you@example.com"')
           client.succeed('git config --global user.name "Your Name"')
-          client.succeed('cd ~/code/myapp && git commit -m "Bad commit"')
-          client.succeed("cd ~/code/myapp && git push -u origin bad")
+          client.succeed('cd ~/code/myapp/unpacked && git commit -m "Bad commit"')
+          client.succeed("cd ~/code/myapp/unpacked && git push -u origin bad")
           client.succeed("ob -v thunk pack ~/code/myapp --public")
           client.fail("nix-build  ~/code/myapp")
           client.succeed("ob -v thunk unpack ~/code/myapp")
-          client.succeed("cd ~/code/myapp && git checkout master")
+          client.succeed("cd ~/code/myapp/unpacked && git checkout master")
 
       with subtest("test obelisk can detect private repos"):
           client.succeed("ob -v thunk pack ~/code/myapp")

--- a/all-tests.nix
+++ b/all-tests.nix
@@ -109,7 +109,7 @@ in
 
       with subtest("obelisk can pack"):
           client.succeed("ob -v thunk pack ~/code/myapp")
-          client.succeed("grep -qF 'git.json' ~/code/myapp/src.nix")
+          client.succeed("grep -qF 'git.json' ~/code/myapp/thunk.nix")
           client.succeed("grep -qF 'myorg' ~/code/myapp/git.json")
           client.succeed("ob -v thunk unpack ~/code/myapp")
 
@@ -125,17 +125,17 @@ in
           client.succeed("ob -v thunk unpack ~/code/myapp")
 
       with subtest("building an invalid thunk fails"):
-          client.succeed("cd ~/code/myapp/unpacked && git checkout -b bad")
+          client.succeed("cd ~/code/myapp/local && git checkout -b bad")
           client.succeed(
-              "cp ${invalidThunkableSample} ~/code/myapp/unpacked/default.nix"
+              "cp ${invalidThunkableSample} ~/code/myapp/local/default.nix"
           )
-          client.succeed("cd ~/code/myapp/unpacked && git add .")
-          client.succeed('cd ~/code/myapp/unpacked && git commit -m "Bad commit"')
-          client.succeed("cd ~/code/myapp/unpacked && git push -u origin bad")
+          client.succeed("cd ~/code/myapp/local && git add .")
+          client.succeed('cd ~/code/myapp/local && git commit -m "Bad commit"')
+          client.succeed("cd ~/code/myapp/local && git push -u origin bad")
           client.succeed("ob -v thunk pack ~/code/myapp --public")
           client.fail("nix-build ~/code/myapp")
           client.succeed("ob -v thunk unpack ~/code/myapp")
-          client.succeed("cd ~/code/myapp/unpacked && git checkout master")
+          client.succeed("cd ~/code/myapp/local && git checkout master")
 
       with subtest("obelisk can detect private repos"):
           client.succeed("ob -v thunk pack ~/code/myapp")

--- a/default.nix
+++ b/default.nix
@@ -82,6 +82,7 @@ let
             pkgs.coreutils
             pkgs.git
             pkgs.nix
+            pkgs.nix-prefetch-git
             pkgs.rsync
           ];
         };

--- a/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 -- | Provides a simple CLI spinner that interoperates cleanly with the rest of the logging output.
 module Obelisk.CliApp.Spinner
   ( withSpinner

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -18,6 +18,7 @@ library
     , either
     , errors
     , exceptions
+    , extra
     , filepath
     , git
     , github

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -354,14 +354,9 @@ ob = \case
       when rootEqualsTarget $
         failWith $ "Deploy directory " <> T.pack deployDir <> " should not be the same as project root."
       thunkPtr <- readThunk root >>= \case
-        Left err -> failWith $ case err of
-          ReadThunkError_AmbiguousFiles ->
-            "Project root " <> T.pack r <> " is not a git repository or valid thunk"
-          ReadThunkError_UnrecognizedFiles ->
-            "Project root " <> T.pack r <> " is not a git repository or valid thunk"
-          _ -> "thunk read: " <> T.pack (show err)
-        Right (ThunkData_Packed ptr) -> return ptr
-        Right (ThunkData_Checkout (Just ptr)) -> return ptr
+        Left err -> failWith $ "Can't read thunk at: " <> T.pack root <> ": " <> T.pack (show err)
+        Right (ThunkData_Packed (_, ptr)) -> return ptr
+        Right (ThunkData_Checkout (Just (_, ptr))) -> return ptr
         Right (ThunkData_Checkout Nothing) ->
           getThunkPtr False root Nothing
       let sshKeyPath = _deployInitOpts_sshKey deployOpts

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -357,10 +357,8 @@ ob = \case
         failWith $ "Deploy directory " <> T.pack deployDir <> " should not be the same as project root."
       thunkPtr <- readThunk root >>= \case
         Left err -> failWith $ "Can't read thunk at: " <> T.pack root <> ": " <> T.pack (show err)
-        Right (ThunkData_Packed (_, ptr)) -> return ptr
-        Right (ThunkData_Checkout (Just (_, ptr))) -> return ptr
-        Right (ThunkData_Checkout Nothing) ->
-          getThunkPtr False root Nothing
+        Right (ThunkData_Packed _ ptr) -> return ptr
+        Right ThunkData_Checkout -> getThunkPtr False root Nothing
       let sshKeyPath = _deployInitOpts_sshKey deployOpts
           hostname = _deployInitOpts_hostname deployOpts
           route = _deployInitOpts_route deployOpts

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -9,7 +9,9 @@ import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.Bool (bool)
 import Data.Foldable (for_)
-import Data.List
+import Data.List (isInfixOf, isPrefixOf)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as T
 import Options.Applicative
 import Options.Applicative.Help.Pretty (text, (<$$>))
@@ -82,7 +84,7 @@ data ObCommand
    | ObCommand_Deploy DeployCommand
    | ObCommand_Run
    | ObCommand_Profile String [String]
-   | ObCommand_Thunk ThunkCommand
+   | ObCommand_Thunk ThunkOption
    | ObCommand_Repl
    | ObCommand_Watch
    | ObCommand_Shell ShellOpts
@@ -104,7 +106,7 @@ obCommand cfg = hsubparser
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
     , command "run" $ info (pure ObCommand_Run) $ progDesc "Run current project in development mode"
     , command "profile" $ info (uncurry ObCommand_Profile <$> profileCommand) $ progDesc "Run current project with profiling enabled"
-    , command "thunk" $ info (ObCommand_Thunk <$> thunkCommand) $ progDesc "Manipulate thunk directories"
+    , command "thunk" $ info (ObCommand_Thunk <$> thunkOption) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (pure ObCommand_Repl) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (pure ObCommand_Watch) $ progDesc "Watch current project for errors and warnings"
     , command "shell" $ info (ObCommand_Shell <$> shellOpts) $ progDesc "Enter a shell with project dependencies"
@@ -224,20 +226,27 @@ thunkPackConfig = ThunkPackConfig
   <$> switch (long "force" <> short 'f' <> help "Force packing thunks even if there are branches not pushed upstream, uncommitted changes, stashes. This will cause changes that have not been pushed upstream to be lost; use with care.")
   <*> thunkConfig
 
+data ThunkOption = ThunkOption
+  { _thunkOption_thunks :: NonEmpty FilePath
+  , _thunkOption_command :: ThunkCommand
+  } deriving Show
+
 data ThunkCommand
-  = ThunkCommand_Update [FilePath] ThunkUpdateConfig
-  | ThunkCommand_Unpack [FilePath]
-  | ThunkCommand_Pack   [FilePath] ThunkPackConfig
-  | ThunkCommand_Init   [FilePath]
+  = ThunkCommand_Update ThunkUpdateConfig
+  | ThunkCommand_Unpack
+  | ThunkCommand_Pack ThunkPackConfig
+  | ThunkCommand_Init
   deriving Show
 
-thunkCommand :: Parser ThunkCommand
-thunkCommand = hsubparser $ mconcat
-  [ command "update" $ info (ThunkCommand_Update <$> some thunkDirectoryParser <*> thunkUpdateConfig) $ progDesc "Update thunk to latest revision available"
-  , command "unpack" $ info (ThunkCommand_Unpack <$> some thunkDirectoryParser) $ progDesc "Unpack thunk into git checkout of revision it points to"
-  , command "pack" $ info (ThunkCommand_Pack <$> some thunkDirectoryParser <*> thunkPackConfig) $ progDesc "Pack git checkout into thunk that points at the current branch's upstream"
-  , command "init" $ info (ThunkCommand_Init <$> some thunkDirectoryParser) $ progDesc "Initialize a git checkout by converting it to an unpacked thunk"
+thunkOption :: Parser ThunkOption
+thunkOption = hsubparser $ mconcat
+  [ command "update" $ info (thunkOptionWith $ ThunkCommand_Update <$> thunkUpdateConfig) $ progDesc "Update thunk to latest revision available"
+  , command "unpack" $ info (thunkOptionWith $ pure ThunkCommand_Unpack) $ progDesc "Unpack thunk into git checkout of revision it points to"
+  , command "pack" $ info (thunkOptionWith $ ThunkCommand_Pack <$> thunkPackConfig) $ progDesc "Pack git checkout into thunk that points at the current branch's upstream"
+  , command "init" $ info (thunkOptionWith $ pure ThunkCommand_Init) $ progDesc "Initialize a git checkout by converting it to an unpacked thunk"
   ]
+  where
+    thunkOptionWith f = ThunkOption <$> NonEmpty.some1 thunkDirectoryParser <*> f
 
 data ShellOpts
   = ShellOpts
@@ -374,11 +383,13 @@ ob = \case
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
   ObCommand_Run -> run
   ObCommand_Profile basePath rtsFlags -> profile basePath rtsFlags
-  ObCommand_Thunk tc -> case tc of
-    ThunkCommand_Update thunks config -> for_ thunks (updateThunkToLatest config)
-    ThunkCommand_Unpack thunks -> for_ thunks unpackThunk
-    ThunkCommand_Pack thunks config -> for_ thunks (packThunk config)
-    ThunkCommand_Init thunks -> for_ thunks initThunk
+  ObCommand_Thunk to -> case _thunkOption_command to of
+    ThunkCommand_Update config -> for_ thunks (updateThunkToLatest config)
+    ThunkCommand_Unpack -> for_ thunks unpackThunk
+    ThunkCommand_Pack config -> for_ thunks (packThunk config)
+    ThunkCommand_Init -> for_ thunks initThunk
+    where
+      thunks = _thunkOption_thunks to
   ObCommand_Repl -> runRepl
   ObCommand_Watch -> runWatch
   ObCommand_Shell so -> withProjectRoot "." $ \root ->

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -225,9 +225,9 @@ thunkPackConfig = ThunkPackConfig
   <*> thunkConfig
 
 data ThunkCommand
-   = ThunkCommand_Update [FilePath] ThunkUpdateConfig
-   | ThunkCommand_Unpack [FilePath]
-   | ThunkCommand_Pack   [FilePath] ThunkPackConfig
+  = ThunkCommand_Update [FilePath] ThunkUpdateConfig
+  | ThunkCommand_Unpack [FilePath]
+  | ThunkCommand_Pack   [FilePath] ThunkPackConfig
   deriving Show
 
 thunkCommand :: Parser ThunkCommand

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -228,6 +228,7 @@ data ThunkCommand
   = ThunkCommand_Update [FilePath] ThunkUpdateConfig
   | ThunkCommand_Unpack [FilePath]
   | ThunkCommand_Pack   [FilePath] ThunkPackConfig
+  | ThunkCommand_Init   [FilePath]
   deriving Show
 
 thunkCommand :: Parser ThunkCommand
@@ -235,6 +236,7 @@ thunkCommand = hsubparser $ mconcat
   [ command "update" $ info (ThunkCommand_Update <$> some thunkDirectoryParser <*> thunkUpdateConfig) $ progDesc "Update thunk to latest revision available"
   , command "unpack" $ info (ThunkCommand_Unpack <$> some thunkDirectoryParser) $ progDesc "Unpack thunk into git checkout of revision it points to"
   , command "pack" $ info (ThunkCommand_Pack <$> some thunkDirectoryParser <*> thunkPackConfig) $ progDesc "Pack git checkout into thunk that points at the current branch's upstream"
+  , command "init" $ info (ThunkCommand_Init <$> some thunkDirectoryParser) $ progDesc "Initialize a git checkout by converting it to an unpacked thunk"
   ]
 
 data ShellOpts
@@ -378,6 +380,7 @@ ob = \case
     ThunkCommand_Update thunks config -> for_ thunks (updateThunkToLatest config)
     ThunkCommand_Unpack thunks -> for_ thunks unpackThunk
     ThunkCommand_Pack thunks config -> for_ thunks (packThunk config)
+    ThunkCommand_Init thunks -> for_ thunks initThunk
   ObCommand_Repl -> runRepl
   ObCommand_Watch -> runWatch
   ObCommand_Shell so -> withProjectRoot "." $ \root ->

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -78,7 +78,7 @@ deployInit thunkPtr deployDir sshKeyPath hostnames route adminEmail enableHttps 
 
   let srcDir = deployDir </> "src"
   withSpinner ("Creating source thunk (" <> T.pack (makeRelative deployDir srcDir) <> ")") $ do
-    createThunk True srcDir thunkPtr
+    createThunk srcDir $ Right thunkPtr
     setupObeliskImpl deployDir
 
   withSpinner "Writing deployment configuration" $ do

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -78,7 +78,7 @@ deployInit thunkPtr deployDir sshKeyPath hostnames route adminEmail enableHttps 
 
   let srcDir = deployDir </> "src"
   withSpinner ("Creating source thunk (" <> T.pack (makeRelative deployDir srcDir) <> ")") $ do
-    createThunk srcDir thunkPtr
+    createThunk True srcDir thunkPtr
     setupObeliskImpl deployDir
 
   withSpinner "Writing deployment configuration" $ do
@@ -109,8 +109,8 @@ deployPush deployPath getNixBuilders = do
   routeHost <- getHostFromRoute enableHttps route
   let srcPath = deployPath </> "src"
   thunkPtr <- readThunk srcPath >>= \case
-    Right (ThunkData_Packed (_, ptr)) -> return ptr
-    Right (ThunkData_Checkout _) -> do
+    Right (ThunkData_Packed _ ptr) -> return ptr
+    Right ThunkData_Checkout -> do
       checkGitCleanStatus srcPath True >>= \case
         True -> packThunk (ThunkPackConfig False (ThunkConfig Nothing)) srcPath
         False -> failWith $ T.pack $ "ob deploy push: ensure " <> srcPath <> " has no pending changes and latest is pushed upstream."

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -9,7 +9,7 @@ module Obelisk.Command.Deploy where
 import Control.Lens
 import Control.Monad
 import Control.Monad.Catch (Exception (displayException), MonadThrow, bracket, throwM, try)
-import Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson (FromJSON, ToJSON, encode, eitherDecode)
 import Data.Bits
 import qualified Data.ByteString.Lazy as BSL
@@ -77,7 +77,7 @@ deployInit thunkPtr deployDir sshKeyPath hostnames route adminEmail enableHttps 
                    ]
 
   let srcDir = deployDir </> "src"
-  withSpinner ("Creating source thunk (" <> T.pack (makeRelative deployDir srcDir) <> ")") $ liftIO $ do
+  withSpinner ("Creating source thunk (" <> T.pack (makeRelative deployDir srcDir) <> ")") $ do
     createThunk srcDir thunkPtr
     setupObeliskImpl deployDir
 
@@ -92,8 +92,8 @@ deployInit thunkPtr deployDir sshKeyPath hostnames route adminEmail enableHttps 
   withSpinner ("Initializing git repository (" <> T.pack deployDir <> ")") $
     initGit deployDir
 
-setupObeliskImpl :: FilePath -> IO ()
-setupObeliskImpl deployDir = do
+setupObeliskImpl :: MonadIO m => FilePath -> m ()
+setupObeliskImpl deployDir = liftIO $ do
   let
     implDir = toImplDir deployDir
     goBackUp = foldr (</>) "" $ (".." <$) $ splitPath $ makeRelative deployDir implDir
@@ -109,7 +109,7 @@ deployPush deployPath getNixBuilders = do
   routeHost <- getHostFromRoute enableHttps route
   let srcPath = deployPath </> "src"
   thunkPtr <- readThunk srcPath >>= \case
-    Right (ThunkData_Packed ptr) -> return ptr
+    Right (ThunkData_Packed (_, ptr)) -> return ptr
     Right (ThunkData_Checkout _) -> do
       checkGitCleanStatus srcPath True >>= \case
         True -> packThunk (ThunkPackConfig False (ThunkConfig Nothing)) srcPath

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -14,7 +14,6 @@ module Obelisk.Command.Project
   , obeliskDirName
   , projectShell
   , toImplDir
-  , toNixPath
   , toObeliskDir
   , withProjectRoot
   ) where
@@ -29,7 +28,6 @@ import Data.Bits
 import qualified Data.ByteString.Lazy as BSL
 import Data.Default (def)
 import Data.Function ((&), on)
-import Data.List (isInfixOf)
 import Data.Map (Map)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -50,7 +48,7 @@ import Obelisk.App (MonadObelisk)
 import Obelisk.CliApp
 import Obelisk.Command.Nix
 import Obelisk.Command.Thunk
-import Obelisk.Command.Utils (nixExePath, nixBuildExePath)
+import Obelisk.Command.Utils (nixBuildExePath, nixExePath, toNixPath)
 
 --TODO: Make this module resilient to random exceptions
 
@@ -248,13 +246,6 @@ filePermissionIsSafe s umask = not fileWorldWritable && fileGroupWritable <= uma
     fileWorldWritable = fileMode s .&. 0o002 == 0o002
     fileGroupWritable = fileMode s .&. 0o020 == 0o020
     umaskGroupWritable = umask .&. 0o020 == 0
-
--- | Nix syntax requires relative paths to be prefixed by @./@ or
--- @../@. This will make a 'FilePath' that can be embedded in a Nix
--- expression.
-toNixPath :: FilePath -> FilePath
-toNixPath root | "/" `isInfixOf` root = root
-               | otherwise = "./" <> root
 
 nixShellRunConfig :: MonadObelisk m => FilePath -> Bool -> Maybe String -> m NixShellConfig
 nixShellRunConfig root isPure command = do

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE QuasiQuotes #-}
 module Obelisk.Command.Run where
 
 import Control.Arrow ((&&&))

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -862,7 +862,7 @@ getThunkPtr checkClean dir mPrivate = do
 
   -- Get information on all branches and their (optional) designated upstream
   -- correspondents
-  (headDump :: [Text]) <- T.lines <$> readGitProcess thunkDir
+  headDump :: [Text] <- T.lines <$> readGitProcess thunkDir
     [ "for-each-ref"
     , "--format=%(refname:short) %(upstream:short) %(upstream:remotename)"
     , "refs/heads/"

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -450,7 +450,7 @@ updateThunkToLatest (ThunkUpdateConfig mBranch thunkConfig) target = spinner $ d
   case mBranch of
     Nothing -> do
       (overwrite, ptr) <- readThunk target >>= \case
-        Left err -> failWith $ T.pack $ "thunk update: " <> show err
+        Left err -> failWith [i|Thunk update: ${err}|]
         Right c -> case c of
           ThunkData_Packed _ t -> return (target, t)
           ThunkData_Checkout -> failWith "cannot update an unpacked thunk"
@@ -461,14 +461,14 @@ updateThunkToLatest (ThunkUpdateConfig mBranch thunkConfig) target = spinner $ d
         , _thunkPtr_rev = rev
         }
     Just branch -> readThunk target >>= \case
-      Left err -> failWith $ T.pack $ "thunk update: " <> show err
+      Left err -> failWith [i|Thunk update: ${err}|]
       Right c -> case c of
         ThunkData_Packed _ t -> case _thunkPtr_source t of
           ThunkSource_Git tsg -> setThunk thunkConfig target tsg branch
           ThunkSource_GitHub tsgh -> do
             let tsg = forgetGithub False tsgh
             setThunk thunkConfig target tsg branch
-        ThunkData_Checkout -> failWith $ T.pack $ "thunk located at " <> show target <> " is unpacked. Use ob thunk pack on the desired directory and then try ob thunk update again."
+        ThunkData_Checkout -> failWith [i|Thunk located at ${target} is unpacked. Use 'ob thunk pack' on the desired directory and then try 'ob thunk update' again.|]
   where
     spinner = withSpinner' ("Updating thunk " <> T.pack target <> " to latest") (pure $ const $ "Thunk " <> T.pack target <> " updated to latest")
 

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -203,7 +203,7 @@ data ReadThunkError
   deriving (Show)
 
 unpackedDirName :: FilePath
-unpackedDirName = "unpacked"
+unpackedDirName = "local"
 
 attrCacheFileName :: FilePath
 attrCacheFileName = ".attr-cache"
@@ -554,7 +554,7 @@ let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);
-in if builtins.pathExists ./unpacked then ./unpacked else fetch json
+in if builtins.pathExists ./local then ./local else fetch json
 |]
 
 parseGitHubJsonBytes :: LBS.ByteString -> Either String ThunkPtr
@@ -646,7 +646,7 @@ let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, pr
     url = realUrl; inherit rev sha256;
   };
   json = builtins.fromJSON (builtins.readFile ./git.json);
-in if builtins.pathExists ./unpacked then ./unpacked else fetch json
+in if builtins.pathExists ./local then ./local else fetch json
 |]
 
 parseGitJsonBytes :: LBS.ByteString -> Either String ThunkPtr
@@ -655,7 +655,7 @@ parseGitJsonBytes = parseJsonObject $ parseThunkPtr $ fmap ThunkSource_Git . par
 mkThunkSpec :: Text -> FilePath -> (LBS.ByteString -> Either String ThunkPtr) -> Text -> ThunkSpec
 mkThunkSpec name jsonFileName parser srcNix = ThunkSpec name $ Map.fromList
   [ ("default.nix", ThunkFileSpec_FileMatches defaultNixViaSrc)
-  , ("src.nix", ThunkFileSpec_FileMatches srcNix)
+  , ("thunk.nix", ThunkFileSpec_FileMatches srcNix)
   , (jsonFileName, ThunkFileSpec_Ptr parser)
   , (attrCacheFileName, ThunkFileSpec_AttrCache)
   , (unpackedDirName, ThunkFileSpec_CheckoutIndicator)
@@ -663,7 +663,7 @@ mkThunkSpec name jsonFileName parser srcNix = ThunkSpec name $ Map.fromList
   where
     defaultNixViaSrc = [here|
 # DO NOT HAND-EDIT THIS FILE
-import (import ./src.nix)
+import (import ./thunk.nix)
 |]
 
 

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -203,7 +203,7 @@ data ReadThunkError
   deriving (Show)
 
 unpackedDirName :: FilePath
-unpackedDirName = "_"
+unpackedDirName = "unpacked"
 
 attrCacheFileName :: FilePath
 attrCacheFileName = ".attr-cache"
@@ -551,7 +551,8 @@ let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256
   } else (import <nixpkgs> {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
-in if builtins.pathExists ./_ then ./_ else fetch (builtins.fromJSON (builtins.readFile ./github.json))
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in if builtins.pathExists ./unpacked then ./unpacked else fetch json
 |]
 
 parseGitHubJsonBytes :: LBS.ByteString -> Either String ThunkPtr
@@ -642,7 +643,8 @@ let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, pr
   } else (import <nixpkgs> {}).fetchgit {
     url = realUrl; inherit rev sha256;
   };
-in if builtins.pathExists ./_ then ./_ else fetch (builtins.fromJSON (builtins.readFile ./git.json))
+  json = builtins.fromJSON (builtins.readFile ./git.json);
+in if builtins.pathExists ./unpacked then ./unpacked else fetch json
 |]
 
 parseGitJsonBytes :: LBS.ByteString -> Either String ThunkPtr

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -814,11 +814,11 @@ packThunk = packThunk' False
 
 packThunk' :: MonadObelisk m => Bool -> ThunkPackConfig -> FilePath -> m ThunkPtr
 packThunk' noTrail (ThunkPackConfig force thunkConfig) thunkDir = checkThunkDirectory thunkDir *> readThunk thunkDir >>= \case
-  Left err -> failWith [i|Can't pack thunk at ${thunkDir}: ${err}|]
   Right (ThunkData_Packed _) -> failWith [i|Thunk at ${thunkDir} is is already packed|]
-  Right (ThunkData_Checkout _) -> do
-    withSpinner' ("Packing thunk " <> T.pack thunkDir)
-                 (finalMsg noTrail $ const $ "Packed thunk " <> T.pack thunkDir) $ do
+  _ -> withSpinner'
+    ("Packing thunk " <> T.pack thunkDir)
+    (finalMsg noTrail $ const $ "Packed thunk " <> T.pack thunkDir) $
+    do
       thunkPtr <- modifyThunkPtrByConfig thunkConfig <$> getThunkPtr (not force) thunkDir (_thunkConfig_private thunkConfig)
       callProcessAndLogOutput (Debug, Error) $ proc rmPath ["-rf", thunkDir] -- thunkDir may be a symlink
       createThunk thunkDir thunkPtr

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -32,6 +32,9 @@ import Obelisk.CliApp
 cp :: FilePath
 cp = $(staticWhich "cp")
 
+rmPath :: FilePath
+rmPath = $(staticWhich "rm")
+
 ghcidExePath :: FilePath
 ghcidExePath = $(staticWhich "ghcid")
 

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -10,19 +10,20 @@ module Obelisk.Command.Utils where
 import Control.Applicative hiding (many)
 import Control.Monad.Except
 import Data.Bool (bool)
-import qualified Text.Megaparsec.Char.Lexer as ML
 import Data.Bifunctor
 import Data.Char
 import Data.Either
-import Data.Semigroup ((<>))
+import Data.List (isInfixOf)
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (maybeToList)
+import Data.Semigroup ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Void (Void)
 import System.Exit (ExitCode)
 import System.Which (staticWhich)
+import qualified Text.Megaparsec.Char.Lexer as ML
 import Text.Megaparsec as MP
 import Text.Megaparsec.Char as MP
 
@@ -31,6 +32,9 @@ import Obelisk.CliApp
 
 cp :: FilePath
 cp = $(staticWhich "cp")
+
+mvPath :: FilePath
+mvPath = $(staticWhich "mv")
 
 rmPath :: FilePath
 rmPath = $(staticWhich "rm")
@@ -49,6 +53,14 @@ nixBuildExePath = $(staticWhich "nix-build")
 
 jreKeyToolPath :: FilePath
 jreKeyToolPath = $(staticWhich "keytool")
+
+-- | Nix syntax requires relative paths to be prefixed by @./@ or
+-- @../@. This will make a 'FilePath' that can be embedded in a Nix
+-- expression.
+toNixPath :: FilePath -> FilePath
+toNixPath root | "/" `isInfixOf` root = root
+               | otherwise = "./" <> root
+
 
 -- Check whether the working directory is clean
 checkGitCleanStatus :: MonadObelisk m => FilePath -> Bool -> m Bool

--- a/lib/command/src/Obelisk/Command/VmBuilder.hs
+++ b/lib/command/src/Obelisk/Command/VmBuilder.hs
@@ -21,6 +21,7 @@ import qualified System.Info
 
 import Obelisk.App (MonadObelisk, getObeliskUserStateDir)
 import Obelisk.CliApp
+import Obelisk.Command.Utils (rmPath)
 
 -- | Generate the `--builders` argument string to enable the VM builder after ensuring it is available.
 getNixBuildersArg :: MonadObelisk m => m String
@@ -95,7 +96,7 @@ setupNixDocker stateDir = withSpinner ("Creating Docker container named " <> con
 
   -- Create new SSH keys for this container
   callProcessAndLogOutput (Debug, Error) $
-    proc "rm" ["-f", stateDir </> sshKeyFileName, stateDir </> sshKeyFileName <.> "pub"]
+    proc rmPath ["-f", stateDir </> sshKeyFileName, stateDir </> sshKeyFileName <.> "pub"]
   callProcessAndLogOutput (Debug, Error) $
     proc "ssh-keygen" ["-t", "ed25519", "-f", stateDir </> sshKeyFileName, "-P", ""]
 

--- a/lib/selftest/obelisk-selftest.cabal
+++ b/lib/selftest/obelisk-selftest.cabal
@@ -9,6 +9,8 @@ library
   hs-source-dirs: src
   build-depends:
       base
+    , bytestring
+    , aeson
     , containers
     , directory
     , filepath

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -269,7 +269,7 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
         runOb_ ["thunk", "pack", repo]
         packedFiles <- Set.fromList <$> ls (fromText repo)
         liftIO $ assertEqual "" packedFiles $ Set.fromList $ (repo </>) <$>
-          ["default.nix", "src.nix", "github.json" :: FilePath]
+          ["default.nix", "thunk.nix", "github.json" :: FilePath]
 
         runOb_ ["thunk", "unpack", repo]
         chdir (fromText repo </> unpackedDirName) $ do
@@ -493,13 +493,13 @@ testLegacyGitThunks isVerbose = withSystemTempDirectory "test-git-repo" $ \gitDi
 
     for_ (legacyGitThunks (GitThunkParams gitDir rev sha256)) $ \mkFiles ->
       withSystemTempDirectory "test-thunks" $ \thunkDir -> do
-        let nixEval = run nixInstantiatePath ["--eval", toTextIgnore (thunkDir </> ("src.nix" :: FilePath))]
+        let nixEval = run nixInstantiatePath ["--eval", toTextIgnore (thunkDir </> ("thunk.nix" :: FilePath))]
         liftIO $ mkFiles thunkDir
         run_ "ob" ["thunk", "unpack", toTextIgnore thunkDir]
         unpackedEval <- nixEval
         run_ "ob" ["thunk", "pack", toTextIgnore thunkDir]
         packedEval <- nixEval
-        liftIO $ assertBool "Unpacked and packed src.nix should not eval to the same thing" $
+        liftIO $ assertBool "Unpacked and packed thunk.nix should not eval to the same thing" $
           unpackedEval /= packedEval
 
 data GitThunkParams = GitThunkParams
@@ -600,4 +600,4 @@ legacyGitThunks (GitThunkParams repo' rev sha256) =
       LBS.writeFile (dir </> ("git.json" :: FilePath)) (Aeson.encode gitJson)
 
 unpackedDirName :: FilePath
-unpackedDirName = "unpacked"
+unpackedDirName = "local"

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -241,7 +241,7 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
       run_ gitPath ["clone", "https://github.com/reflex-frp/reflex.git", toTextIgnore dir, "--branch", branch]
       runOb_ ["thunk", "pack", toTextIgnore dir]
       runOb_ ["thunk", "unpack", toTextIgnore dir]
-      branch' <- run gitPath ["-C", toTextIgnore $ dir </> ("_" :: FilePath), "rev-parse", "--abbrev-ref", "HEAD"]
+      branch' <- run gitPath ["-C", toTextIgnore $ dir </> unpackedDirName, "rev-parse", "--abbrev-ref", "HEAD"]
       liftIO $ assertEqual "" branch (T.strip branch')
 
     it "can pack and unpack plain git repos" $
@@ -256,7 +256,7 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
           ["default.nix", "src.nix", "github.json" :: FilePath]
 
         runOb_ ["thunk", "unpack", repo]
-        chdir (fromText repo </> ("_" :: FilePath)) $ do
+        chdir (fromText repo </> unpackedDirName) $ do
           unpackHash <- revParseHead
           assertRevEQ origHash unpackHash
 
@@ -399,7 +399,7 @@ testThunkPack executable args path' = withTempFile repoDir "test-file" $ \file h
   git $ gitUserConfig <> [ "stash" ]
   ensureThunkPackFails "has stashes"
   where
-    repoDir = path' </> ("_" :: FilePath)
+    repoDir = path' </> unpackedDirName
 
 -- | Blocks until a non-empty line is available
 hGetLineSkipBlanks :: MonadIO m => Handle -> m Text
@@ -460,3 +460,6 @@ getFreePorts n = Socket.withSocketsDo $ do
       sock <- Socket.socket (Socket.addrFamily addr) (Socket.addrSocketType addr) (Socket.addrProtocol addr)
       Socket.bind sock (Socket.addrAddress addr)
       pure sock
+
+unpackedDirName :: FilePath
+unpackedDirName = "unpacked"

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -253,7 +253,7 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
         runOb_ ["thunk", "pack", repo]
         packedFiles <- Set.fromList <$> ls (fromText repo)
         liftIO $ assertEqual "" packedFiles $ Set.fromList $ (repo </>) <$>
-          ["default.nix", "github.json", ".attr-cache" :: FilePath]
+          ["default.nix", "github.json" :: FilePath]
 
         runOb_ ["thunk", "unpack", repo]
         chdir (fromText repo) $ do

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 module Obelisk.SelfTest where


### PR DESCRIPTION
Fixes #601 

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
