### PR TITLE
app-deploy guide: Fix typo

### DIFF
--- a/guides/app-deploy/README.md
+++ b/guides/app-deploy/README.md
@@ -232,7 +232,7 @@ xdg-open http://$VM_IP
 If that fails, just get the URL by running
 
 ```bash
-echo http://$VM_IP`
+echo http://$VM_IP
 ```
 
 and copy/paste that URL into your browser navigation input.


### PR DESCRIPTION
I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
