### PR TITLE
Sync obelisk-command version with current version

### DIFF
--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -1,5 +1,5 @@
 name: obelisk-command
-version: 0.6
+version: 0.7
 cabal-version: >= 1.8
 build-type: Simple
 


### PR DESCRIPTION
Seems like on the 0.7 release the `obelisk-command.cabal` file wasn't updated so following the install instructions shows nix as installing _`obelisk-command-0.6`._

I have:

  - [NA] Based work on latest `develop` branch
  - [NA] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [NA] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [NA] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
