### PR TITLE
"hack-on" tweaks

### DIFF
--- a/all-tests.nix
+++ b/all-tests.nix
@@ -63,15 +63,18 @@ in
         '';
       in ''
       start_all()
+
+      with subtest("obelisk is installed and git is configured"):
+          client.succeed("ob --help")
+          client.succeed('git config --global user.email "you@example.com"')
+          client.succeed('git config --global user.name "Your Name"')
+
       githost.wait_for_open_port("22")
 
-      with subtest("test obelisk is installed"):
-          client.succeed("ob --help")
-
-      with subtest("test the client can access the server via ssh"):
+      with subtest("the client can access the server via ssh"):
           client.succeed("mkdir -p ~/.ssh/")
           client.succeed(
-              "cp ${privateKeyFile}  ~/.ssh/id_rsa"
+              "cp ${privateKeyFile} ~/.ssh/id_rsa"
           )
           client.succeed("chmod 600 ~/.ssh/id_rsa")
           client.wait_until_succeeds(
@@ -82,36 +85,35 @@ in
           )
           client.wait_until_succeeds("ssh githost true")
 
-      with subtest("test a remote bare repo can be started"):
+      with subtest("a remote bare repo can be started"):
           githost.succeed("mkdir -p ~/myorg/myapp.git")
           githost.succeed("cd ~/myorg/myapp.git && git init --bare")
 
-      with subtest("test a git project can be configured with a remote using ssh"):
+      with subtest("a git project can be configured with a remote using ssh"):
           client.succeed("mkdir -p ~/code/myapp")
           client.succeed("cd ~/code/myapp && git init")
           client.succeed(
               "cp ${thunkableSample} ~/code/myapp/default.nix"
           )
           client.succeed("cd ~/code/myapp && git add .")
-          client.succeed('git config --global user.email "you@example.com"')
-          client.succeed('git config --global user.name "Your Name"')
+
           client.succeed('cd ~/code/myapp && git commit -m "Initial"')
           client.succeed(
               "cd ~/code/myapp && git remote add origin root@githost:/root/myorg/myapp.git"
           )
 
 
-      with subtest("test pushing code to the remote"):
+      with subtest("pushing code to the remote"):
           client.succeed("cd ~/code/myapp && git push -u origin master")
           client.succeed("cd ~/code/myapp && git status")
 
-      with subtest("test obelisk can pack"):
+      with subtest("obelisk can pack"):
           client.succeed("ob -v thunk pack ~/code/myapp")
-          client.succeed("grep -qF 'git' ~/code/myapp/default.nix")
+          client.succeed("grep -qF 'git.json' ~/code/myapp/thunk.nix")
           client.succeed("grep -qF 'myorg' ~/code/myapp/git.json")
           client.succeed("ob -v thunk unpack ~/code/myapp")
 
-      with subtest("test obelisk can set the public / private flag"):
+      with subtest("obelisk can set the public / private flag"):
           client.succeed("ob -v thunk pack ~/code/myapp --private")
           client.fail("""grep -qF '"private": practice' ~/code/myapp/git.json""")
           client.succeed("""grep -qF '"private": true' ~/code/myapp/git.json""")
@@ -122,22 +124,20 @@ in
           client.succeed("nix-build ~/code/myapp")
           client.succeed("ob -v thunk unpack ~/code/myapp")
 
-      with subtest("test building an invalid thunk fails"):
-          client.succeed("cd ~/code/myapp && git checkout -b bad")
+      with subtest("building an invalid thunk fails"):
+          client.succeed("cd ~/code/myapp/local && git checkout -b bad")
           client.succeed(
-              "cp ${invalidThunkableSample} ~/code/myapp/default.nix"
+              "cp ${invalidThunkableSample} ~/code/myapp/local/default.nix"
           )
-          client.succeed("cd ~/code/myapp && git add .")
-          client.succeed('git config --global user.email "you@example.com"')
-          client.succeed('git config --global user.name "Your Name"')
-          client.succeed('cd ~/code/myapp && git commit -m "Bad commit"')
-          client.succeed("cd ~/code/myapp && git push -u origin bad")
+          client.succeed("cd ~/code/myapp/local && git add .")
+          client.succeed('cd ~/code/myapp/local && git commit -m "Bad commit"')
+          client.succeed("cd ~/code/myapp/local && git push -u origin bad")
           client.succeed("ob -v thunk pack ~/code/myapp --public")
-          client.fail("nix-build  ~/code/myapp")
+          client.fail("nix-build ~/code/myapp")
           client.succeed("ob -v thunk unpack ~/code/myapp")
-          client.succeed("cd ~/code/myapp && git checkout master")
+          client.succeed("cd ~/code/myapp/local && git checkout master")
 
-      with subtest("test obelisk can detect private repos"):
+      with subtest("obelisk can detect private repos"):
           client.succeed("ob -v thunk pack ~/code/myapp")
           client.succeed("""grep -qF '"private": true' ~/code/myapp/git.json""")
           client.succeed("ob -v thunk unpack ~/code/myapp")

--- a/haskell-overlays/obelisk.nix
+++ b/haskell-overlays/obelisk.nix
@@ -34,6 +34,7 @@ in
       pkgs.coreutils
       pkgs.git
       pkgs.nix
+      pkgs.nix-prefetch-git
       pkgs.rsync
     ];
   };

--- a/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Spinner.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 -- | Provides a simple CLI spinner that interoperates cleanly with the rest of the logging output.
 module Obelisk.CliApp.Spinner
   ( withSpinner

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -18,6 +18,7 @@ library
     , either
     , errors
     , exceptions
+    , extra
     , filepath
     , git
     , github

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -85,11 +85,11 @@ initForce = switch (long "force" <> help "Allow ob init to overwrite files")
 data ObCommand
    = ObCommand_Init InitSource Bool
    | ObCommand_Deploy DeployCommand
-   | ObCommand_Run [(FilePath, HackOn)]
+   | ObCommand_Run [(FilePath, Interpret)]
    | ObCommand_Profile String [String]
    | ObCommand_Thunk ThunkOption
-   | ObCommand_Repl [(FilePath, HackOn)]
-   | ObCommand_Watch [(FilePath, HackOn)]
+   | ObCommand_Repl [(FilePath, Interpret)]
+   | ObCommand_Watch [(FilePath, Interpret)]
    | ObCommand_Shell ShellOpts
    | ObCommand_Doc String [String] -- shell and list of packages
    | ObCommand_Hoogle String Int -- shell and port
@@ -100,7 +100,7 @@ data ObInternal
    -- the preprocessor argument syntax is also handled outside
    -- optparse-applicative, but it shouldn't ever conflict with another syntax
    = ObInternal_ApplyPackages String String String [String]
-   | ObInternal_ExportGhciConfig [(FilePath, HackOn)]
+   | ObInternal_ExportGhciConfig [(FilePath, Interpret)]
    deriving Show
 
 obCommand :: ArgsConfig -> Parser ObCommand
@@ -108,11 +108,11 @@ obCommand cfg = hsubparser
   (mconcat
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
-    , command "run" $ info (ObCommand_Run <$> hackOnOpts) $ progDesc "Run current project in development mode"
+    , command "run" $ info (ObCommand_Run <$> interpretOpts) $ progDesc "Run current project in development mode"
     , command "profile" $ info (uncurry ObCommand_Profile <$> profileCommand) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkOption) $ progDesc "Manipulate thunk directories"
-    , command "repl" $ info (ObCommand_Repl <$> hackOnOpts) $ progDesc "Open an interactive interpreter"
-    , command "watch" $ info (ObCommand_Watch <$> hackOnOpts) $ progDesc "Watch current project for errors and warnings"
+    , command "repl" $ info (ObCommand_Repl <$> interpretOpts) $ progDesc "Open an interactive interpreter"
+    , command "watch" $ info (ObCommand_Watch <$> interpretOpts) $ progDesc "Watch current project for errors and warnings"
     , command "shell" $ info (ObCommand_Shell <$> shellOpts) $ progDesc "Enter a shell with project dependencies"
     , command "doc" $ info (ObCommand_Doc <$> shellFlags <*> packageNames) $
         progDesc "List paths to haddock documentation for specified packages"
@@ -125,7 +125,7 @@ obCommand cfg = hsubparser
 
 internalCommand :: Parser ObInternal
 internalCommand = hsubparser $ mconcat
-  [ command "export-ghci-configuration" $ info (ObInternal_ExportGhciConfig <$> hackOnOpts) $ progDesc "Export the GHCi configuration used by ob run, etc.; useful for IDE integration"
+  [ command "export-ghci-configuration" $ info (ObInternal_ExportGhciConfig <$> interpretOpts) $ progDesc "Export the GHCi configuration used by ob run, etc.; useful for IDE integration"
   ]
 
 packageNames :: Parser [String]
@@ -258,7 +258,7 @@ thunkOption = hsubparser $ mconcat
 data ShellOpts
   = ShellOpts
     { _shellOpts_shell :: String
-    , _shellOpts_hackPaths :: [(FilePath, HackOn)]
+    , _shellOpts_interpretPaths :: [(FilePath, Interpret)]
     , _shellOpts_command :: Maybe String
     }
   deriving Show
@@ -269,18 +269,21 @@ shellFlags =
   <|> flag "ghc" "ghcjs" (long "ghcjs" <> help "Enter a shell having ghcjs rather than ghc")
   <|> strOption (short 'A' <> long "argument" <> metavar "NIXARG" <> help "Use the environment specified by the given nix argument of `shells'")
 
-hackOnOpts :: Parser [(FilePath, HackOn)]
-hackOnOpts = many
-    (   (, HackOn_HackOn) <$>
-          strOption (common <> long "hack-on" <> help
+interpretOpts :: Parser [(FilePath, Interpret)]
+interpretOpts = many
+    (   (, Interpret_Interpret) <$>
+          strOption (common <> long "interpret" <> help
             "Don't pre-build packages found in DIR when constructing the package database. The default behavior is \
-            \'--hack-on <project-root>'. Use --hack-on and --no-hack-on multiple times to add or remove multiple trees \
-            \ from the environment. Right-most directories will override directories on the left in as much as they overlap."
+            \'--interpret <project-root>', which will load everything which is unpacked into GHCi. \
+            \ Use --interpret and --no-interpret multiple times to add or remove multiple trees \
+            \ from the environment. Settings for right-most directories will \
+            \ override settings for any identical directories given earlier."
           )
-    <|> (, HackOn_NoHackOn) <$>
-          strOption (common <> long "no-hack-on" <> help
+    <|> (, Interpret_NoInterpret) <$>
+          strOption (common <> long "no-interpret" <> help
             "Make packages found in DIR available in the package database (but only when they are used dependencies). \
-            \See help for --hack-on for how the two options are related."
+            \ This will build the packages in DIR before loading GHCi. \
+            \See help for ---on for how the two options are related."
           )
     )
   where
@@ -289,7 +292,7 @@ hackOnOpts = many
 shellOpts :: Parser ShellOpts
 shellOpts = ShellOpts
   <$> shellFlags
-  <*> hackOnOpts
+  <*> interpretOpts
   <*> optional (strArgument (metavar "COMMAND"))
 
 portOpt :: Int -> Parser Int
@@ -407,7 +410,7 @@ ob = \case
         Just RemoteBuilder_ObeliskVM -> (:[]) <$> VmBuilder.getNixBuildersArg
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
-  ObCommand_Run hackPathsList -> withHackPaths hackPathsList run
+  ObCommand_Run interpretPathsList -> withInterpretPaths interpretPathsList run
   ObCommand_Profile basePath rtsFlags -> profile basePath rtsFlags
   ObCommand_Thunk to -> case _thunkOption_command to of
     ThunkCommand_Update config -> for_ thunks (updateThunkToLatest config)
@@ -416,27 +419,27 @@ ob = \case
     ThunkCommand_Init -> for_ thunks initThunk
     where
       thunks = _thunkOption_thunks to
-  ObCommand_Repl hackPathsList -> withHackPaths hackPathsList runRepl
-  ObCommand_Watch hackPathsList -> withHackPaths hackPathsList runWatch
-  ObCommand_Shell (ShellOpts shellAttr hackPathsList cmd) -> withHackPaths hackPathsList $ \root hackPaths ->
-    nixShellForHackPaths False shellAttr root hackPaths cmd
+  ObCommand_Repl interpretPathsList -> withInterpretPaths interpretPathsList runRepl
+  ObCommand_Watch interpretPathsList -> withInterpretPaths interpretPathsList runWatch
+  ObCommand_Shell (ShellOpts shellAttr interpretPathsList cmd) -> withInterpretPaths interpretPathsList $ \root interpretPaths ->
+    nixShellForInterpretPaths False shellAttr root interpretPaths cmd
   ObCommand_Doc shellAttr pkgs -> withProjectRoot "." $ \root ->
-    nixShellForHackPaths True shellAttr root emptyPathTree $ Just $ haddockCommand pkgs
+    nixShellForInterpretPaths True shellAttr root emptyPathTree $ Just $ haddockCommand pkgs
   ObCommand_Hoogle shell' port -> withProjectRoot "." $ \root -> do
     nixShellWithHoogle root True shell' $ Just $ "hoogle server -p " <> show port <> " --local"
   ObCommand_Internal icmd -> case icmd of
     ObInternal_ApplyPackages origPath inPath outPath packagePaths -> do
       liftIO $ Preprocessor.applyPackages origPath inPath outPath packagePaths
-    ObInternal_ExportGhciConfig hackPathsList -> liftIO . putStrLn . unlines =<< withHackPaths hackPathsList exportGhciConfig
+    ObInternal_ExportGhciConfig interpretPathsList -> liftIO . putStrLn . unlines =<< withInterpretPaths interpretPathsList exportGhciConfig
 
 -- | A helper for the common case that the command you want to run needs the project root and a resolved
--- set of hacking paths.
-withHackPaths :: MonadObelisk m => [(FilePath, HackOn)] -> (FilePath -> PathTree HackOn -> m a) -> m a
-withHackPaths hackPathsList f = withProjectRoot "." $ \root -> do
-  hackPaths' <- resolveHackPaths $ (root, HackOn_HackOn) : hackPathsList
-  case hackPaths' of
+-- set of interpret paths.
+withInterpretPaths :: MonadObelisk m => [(FilePath, Interpret)] -> (FilePath -> PathTree Interpret -> m a) -> m a
+withInterpretPaths interpretPathsList f = withProjectRoot "." $ \root -> do
+  interpretPaths' <- resolveInterpretPaths $ (root, Interpret_Interpret) : interpretPathsList
+  case interpretPaths' of
     Nothing -> failWith "No paths provided for finding packages"
-    Just hackPaths -> f root hackPaths
+    Just interpretPaths -> f root interpretPaths
 
 haddockCommand :: [String] -> String
 haddockCommand pkgs = unwords
@@ -451,25 +454,21 @@ haddockCommand pkgs = unwords
 getArgsConfig :: IO ArgsConfig
 getArgsConfig = pure $ ArgsConfig { _argsConfig_enableVmBuilderByDefault = System.Info.os == "darwin" }
 
-
--- | Resolves an ordered list of paths for use with @--hack-on@/@--no-hack-on@ by coalescing
+-- | Resolves an ordered list of paths for use with @--interpret@/@--no-interpret@ by coalescing
 --   paths into a non-ambiguous set of paths. Ambiguity is resolved by chosing right-most paths
---   over any preceeding paths where they overlap.
+--   over any preceeding identical paths.
 --
---   For example: @a/b=ON a/b/c=OFF@ produces @a/b=ON a/b/c=OFF@ (the same value) but flipping
---   the order does not as @a/b/c=OFF a/b=ON@ produces @a/b=ON@ since @a/b/c@ is inside @a/b@ and
---   @a/b@ is the right-most.
+--   For example: @a/b=ON a/b/c=OFF@ and @a/b/c=OFF a/b=ON@ are the same.
+--   @a/b=ON a/b=OFF@ is reduced to @a/b=OFF@. We prefer right-biased choice to
+--   increase scriptability.
 --
 --   N.B. All the paths in the result will be canonicalized. It's impossible to determine path
 --   overlap otherwise.
-resolveHackPaths :: MonadIO m => [(FilePath, a)] -> m (Maybe (PathTree a))
-resolveHackPaths ps = do
+resolveInterpretPaths :: MonadIO m => [(FilePath, a)] -> m (Maybe (PathTree a))
+resolveInterpretPaths ps = do
   trees <- liftIO $ for ps $ \(p, a) -> pathToTree a <$> canonicalizePath p
-  pure $ foldr1 mergeRightBias <$> nonEmpty trees
+  pure $ foldr1 mergeTrees <$> nonEmpty trees
   where
     -- | Merge two 'PathTree's preferring leaves on the right in as much as they overlap with paths on the left.
-    mergeRightBias :: PathTree a -> PathTree a -> PathTree a
-    mergeRightBias = go
-      where
-        go _                   b@(PathTree_Node (Just _) _) = b -- When a leaf is present on the right, right always wins.
-        go (PathTree_Node v a)   (PathTree_Node Nothing b)  = PathTree_Node v $ Map.unionWith go a b
+    mergeTrees :: PathTree a -> PathTree a -> PathTree a
+    mergeTrees (PathTree_Node ax x) (PathTree_Node ay y) = PathTree_Node (ay <|> ax) $ Map.unionWith mergeTrees x y

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -283,7 +283,7 @@ interpretOpts = many
           strOption (common <> long "no-interpret" <> help
             "Make packages found in DIR available in the package database (but only when they are used dependencies). \
             \ This will build the packages in DIR before loading GHCi. \
-            \See help for ---on for how the two options are related."
+            \See help for --interpret for how the two options are related."
           )
     )
   where

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -13,7 +13,6 @@ module Obelisk.Command.Project
   , nixShellWithPkgs
   , obeliskDirName
   , toImplDir
-  , toNixPath
   , toObeliskDir
   , withProjectRoot
   ) where
@@ -28,7 +27,6 @@ import Data.Bits
 import qualified Data.ByteString.Lazy as BSL
 import Data.Default (def)
 import Data.Function ((&), on)
-import Data.List (isInfixOf)
 import Data.Map (Map)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -49,7 +47,7 @@ import Obelisk.App (MonadObelisk)
 import Obelisk.CliApp
 import Obelisk.Command.Nix
 import Obelisk.Command.Thunk
-import Obelisk.Command.Utils (nixExePath, nixBuildExePath)
+import Obelisk.Command.Utils (nixBuildExePath, nixExePath, toNixPath)
 
 --TODO: Make this module resilient to random exceptions
 
@@ -247,13 +245,6 @@ filePermissionIsSafe s umask = not fileWorldWritable && fileGroupWritable <= uma
     fileWorldWritable = fileMode s .&. 0o002 == 0o002
     fileGroupWritable = fileMode s .&. 0o020 == 0o020
     umaskGroupWritable = umask .&. 0o020 == 0
-
--- | Nix syntax requires relative paths to be prefixed by @./@ or
--- @../@. This will make a 'FilePath' that can be embedded in a Nix
--- expression.
-toNixPath :: FilePath -> FilePath
-toNixPath root | "/" `isInfixOf` root = root
-               | otherwise = "./" <> root
 
 nixShellRunConfig :: MonadObelisk m => FilePath -> Bool -> Maybe String -> m NixShellConfig
 nixShellRunConfig root isPure command = do

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -93,7 +93,12 @@ data CabalPackageInfo = CabalPackageInfo
   }
 
 -- | 'Bool' with a better name for it's purpose.
-data HackOn = HackOn_HackOn | HackOn_NoHackOn deriving (Eq, Ord, Show)
+data Interpret = Interpret_Interpret | Interpret_NoInterpret deriving (Eq, Ord, Show)
+
+textInterpret :: Interpret -> Text
+textInterpret = \case
+  Interpret_Interpret -> "Interpret"
+  Interpret_NoInterpret -> "NoInterpret"
 
 -- | Describe a set of 'FilePath's as a tree to facilitate merging them in a convenient way.
 data PathTree a = PathTree_Node
@@ -103,6 +108,17 @@ data PathTree a = PathTree_Node
 
 emptyPathTree :: PathTree a
 emptyPathTree = PathTree_Node Nothing mempty
+
+-- | 2D ASCII drawing of a 'PathTree'. Adapted from Data.Tree.draw.
+drawPathTree :: (a -> Text) -> PathTree a -> Text
+drawPathTree showA (PathTree_Node _ ts0) = T.intercalate "\n" $ goForest (Map.toList ts0)
+  where
+    annotated ma = maybe id (\a b -> b <> " [" <> showA a <> "]") ma . T.pack
+    goTree (fp, PathTree_Node ma forest) = annotated ma fp : goForest (Map.toList forest)
+    goForest [] = []
+    goForest [tree] = shift "└─ " "   " (goTree tree)
+    goForest (tree:forest) = shift "├─ " "│  " (goTree tree) <> goForest forest
+    shift first other = zipWith (<>) (first : repeat other)
 
 -- | Used to signal to obelisk that it's being invoked as a preprocessor
 preprocessorIdentifier :: String
@@ -142,9 +158,9 @@ profile profileBasePattern rtsFlags = withProjectRoot "." $ \root -> do
       <> [ "-RTS" ]
   void $ waitForProcess ph
 
-run :: MonadObelisk m => FilePath -> PathTree HackOn -> m ()
-run root hackPaths = do
-  pkgs <- getParsedLocalPkgs root hackPaths
+run :: MonadObelisk m => FilePath -> PathTree Interpret -> m ()
+run root interpretPaths = do
+  pkgs <- getParsedLocalPkgs root interpretPaths
   withGhciScript pkgs root $ \dotGhciPath -> do
     freePort <- getFreePort
     assets <- findProjectAssets root
@@ -157,51 +173,52 @@ run root hackPaths = do
       , "Frontend.frontend"
       ]
 
-runRepl :: MonadObelisk m => FilePath -> PathTree HackOn -> m ()
-runRepl root hackPaths = do
-  pkgs <- getParsedLocalPkgs root hackPaths
+runRepl :: MonadObelisk m => FilePath -> PathTree Interpret -> m ()
+runRepl root interpretPaths = do
+  pkgs <- getParsedLocalPkgs root interpretPaths
   withGhciScript pkgs "." $ \dotGhciPath ->
     runGhciRepl root pkgs dotGhciPath
 
-runWatch :: MonadObelisk m => FilePath -> PathTree HackOn -> m ()
-runWatch root hackPaths = do
-  pkgs <- getParsedLocalPkgs root hackPaths
+runWatch :: MonadObelisk m => FilePath -> PathTree Interpret -> m ()
+runWatch root interpretPaths = do
+  pkgs <- getParsedLocalPkgs root interpretPaths
   withGhciScript pkgs root $ \dotGhciPath ->
     runGhcid root True dotGhciPath pkgs Nothing
 
-exportGhciConfig :: MonadObelisk m => FilePath -> PathTree HackOn -> m [String]
-exportGhciConfig root hackPaths = do
-  pkgs <- getParsedLocalPkgs root hackPaths
+exportGhciConfig :: MonadObelisk m => FilePath -> PathTree Interpret -> m [String]
+exportGhciConfig root interpretPaths = do
+  pkgs <- getParsedLocalPkgs root interpretPaths
   getGhciSessionSettings pkgs "."
 
-nixShellForHackPaths :: MonadObelisk m => Bool -> String -> FilePath -> PathTree HackOn -> Maybe String -> m ()
-nixShellForHackPaths isPure shell root hackPaths cmd = do
-  pkgs <- getParsedLocalPkgs root hackPaths
+nixShellForInterpretPaths :: MonadObelisk m => Bool -> String -> FilePath -> PathTree Interpret -> Maybe String -> m ()
+nixShellForInterpretPaths isPure shell root interpretPaths cmd = do
+  pkgs <- getParsedLocalPkgs root interpretPaths
   nixShellWithPkgs root isPure False (packageInfoToNamePathMap pkgs) shell cmd
 
 -- | Like 'getLocalPkgs' but also parses them and fails if any of them can't be parsed.
-getParsedLocalPkgs :: MonadObelisk m => FilePath -> PathTree HackOn -> m (NonEmpty CabalPackageInfo)
-getParsedLocalPkgs root hackPaths = parsePackagesOrFail =<< getLocalPkgs root hackPaths
+getParsedLocalPkgs :: MonadObelisk m => FilePath -> PathTree Interpret -> m (NonEmpty CabalPackageInfo)
+getParsedLocalPkgs root interpretPaths = parsePackagesOrFail =<< getLocalPkgs root interpretPaths
 
 -- | Relative paths to local packages of an obelisk project.
 --
 -- These are a combination of the obelisk predefined local packages,
 -- and any packages that the user has set with the @packages@ argument
 -- to the Nix @project@ function.
-getLocalPkgs :: forall m. MonadObelisk m => FilePath -> PathTree HackOn -> m (Set FilePath)
-getLocalPkgs root hackPaths = do
-  putLog Debug [i|Finding packages with root ${root} and hacking paths ${hackPaths}|]
+getLocalPkgs :: forall m. MonadObelisk m => FilePath -> PathTree Interpret -> m (Set FilePath)
+getLocalPkgs root interpretPaths = do
+  putLog Debug $ [i|Finding packages with root ${root} and interpret paths:|] <> "\n" <> drawPathTree textInterpret interpretPaths
   obeliskPackagePaths <- runFind ["-L", root, "-name", ".obelisk", "-type", "d"]
 
   -- We do not want to find packages that are embedded inside other obelisk projects, unless that
   -- obelisk project is our own.
-  let obeliskPackageExclusions = Set.fromList $ filter (/= root) $ map takeDirectory obeliskPackagePaths
-      rootsAndExclusions = calcHackOnFinds "" hackPaths
+  obeliskPackageExclusions <- liftIO $ fmap Set.fromList $ traverse canonicalizePath $ filter (/= root) $ map takeDirectory obeliskPackagePaths
+  putLog Debug [i|Excluding obelisk packages: ${T.pack $ unwords $ Set.toList obeliskPackageExclusions}|]
+  let rootsAndExclusions = calcIntepretFinds "" interpretPaths
 
-  fmap fold $ for (Map.toAscList rootsAndExclusions) $ \(hackPathRoot, exclusions) ->
+  fmap fold $ for (Map.toAscList rootsAndExclusions) $ \(interpretPathRoot, exclusions) ->
     let allExclusions = obeliskPackageExclusions <> exclusions <> Set.singleton ("*" </> attrCacheFileName)
     in fmap (Set.fromList . map normalise) $ runFind $
-      ["-L", hackPathRoot, "(", "-name", "*.cabal", "-o", "-name", Hpack.packageConfig, ")", "-a", "-type", "f"]
+      ["-L", interpretPathRoot, "(", "-name", "*.cabal", "-o", "-name", Hpack.packageConfig, ")", "-a", "-type", "f"]
       <> concat [["-not", "-path", p </> "*"] | p <- toList allExclusions]
   where
     runFind args = do
@@ -211,12 +228,12 @@ getLocalPkgs root hackPaths = do
 
 -- | Calculates a set of root 'FilePath's along with each one's corresponding set of exclusions.
 --   This is used when constructing a set of @find@ commands to run to produce a set of packages
---   that matches the user's @--hack-on@/@--no-hack-on@ settings.
-calcHackOnFinds :: FilePath -> PathTree HackOn -> Map FilePath (Set FilePath)
-calcHackOnFinds treeRoot0 tree0 = runIdentity $ go treeRoot0 tree0
+--   that matches the user's @--interpret@/@--no-interpret@ settings.
+calcIntepretFinds :: FilePath -> PathTree Interpret -> Map FilePath (Set FilePath)
+calcIntepretFinds treeRoot0 tree0 = runIdentity $ go treeRoot0 tree0
   where
-    go treeRoot tree = foldPathTreeFor (== HackOn_HackOn) treeRoot tree $ \parent children -> do
-      exclusions <- foldPathTreeFor (== HackOn_NoHackOn) parent children $ \parent' children' ->
+    go treeRoot tree = foldPathTreeFor (== Interpret_Interpret) treeRoot tree $ \parent children -> do
+      exclusions <- foldPathTreeFor (== Interpret_NoInterpret) parent children $ \parent' children' ->
         pure $ Map.singleton parent' children'
       deeperFinds <- fmap fold $ Map.traverseWithKey go exclusions
       pure $ Map.singleton parent (Map.keysSet exclusions) <> deeperFinds

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -5,43 +5,17 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-module Obelisk.Command.Thunk
-  ( GitHubSource (..)
-  , GitUri (..)
-  , ReadThunkError (..)
-  , ThunkConfig (..)
-  , ThunkData (..)
-  , ThunkPackConfig (..)
-  , ThunkPtr (..)
-  , ThunkRev (..)
-  , ThunkSource (..)
-  , ThunkUpdateConfig (..)
-  , attrCacheFileName
-  , createThunk
-  , createThunkWithLatest
-  , getLatestRev
-  , getThunkGitBranch
-  , getThunkPtr
-  , gitUriToText
-  , nixBuildAttrWithCache
-  , nixBuildThunkAttrWithCache
-  , packThunk
-  , parseGitUri
-  , readThunk
-  , unpackThunk
-  , updateThunk
-  , updateThunkToLatest
-  , uriThunkPtr
-  ) where
+module Obelisk.Command.Thunk where
 
 import Control.Applicative
 import Control.Exception (displayException, try)
-import qualified Control.Lens as Lens
-import Control.Lens.Indexed hiding ((<.>))
+import Control.Lens (ifor, ifor_, (.~))
 import Control.Monad
-import Control.Monad.Catch (handle)
+import Control.Monad.Extra (findM, unlessM, whenM)
+import Control.Monad.Catch (MonadCatch, handle)
 import Control.Monad.Except
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
@@ -51,21 +25,27 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Containers.ListUtils (nubOrd)
 import Data.Default
 import Data.Either.Combinators (fromRight', rightToMaybe)
+import Data.Foldable (toList)
+import Data.Function ((&))
+import Data.Functor ((<&>))
 import Data.Git.Ref (Ref)
 import qualified Data.Git.Ref as Ref
 import qualified Data.List as L
-import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.String.Here.Interpolated (i)
+import Data.String.Here.Uninterpolated (here)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding
 import qualified Data.Text.IO as T
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Data.Traversable (for)
 import Data.Yaml (parseMaybe)
 import GitHub
 import GitHub.Data.Name
@@ -84,11 +64,10 @@ import Obelisk.Command.Utils
 
 --TODO: Support symlinked thunk data
 data ThunkData
-   = ThunkData_Packed ThunkPtr
+   = ThunkData_Packed ThunkSpec ThunkPtr
    -- ^ Packed thunk
-   | ThunkData_Checkout (Maybe ThunkPtr)
+   | ThunkData_Checkout
    -- ^ Checked out thunk that was unpacked from this pointer
-  deriving (Show, Eq, Ord)
 
 -- | A reference to the exact data that a thunk should translate into
 data ThunkPtr = ThunkPtr
@@ -213,96 +192,117 @@ nixPrefetchGit uri rev fetchSubmodules =
 
 --TODO: Pretty print these
 data ReadThunkError
-   = ReadThunkError_UnrecognizedFiles
-   | ReadThunkError_AmbiguousFiles
-   | ReadThunkError_UnrecognizedLoader Text
-   | ReadThunkError_UnparseablePtr LBS.ByteString
-   deriving (Show)
+  = ReadThunkError_UnrecognizedThunk
+  | ReadThunkError_UnrecognizedPaths (NonEmpty FilePath)
+  | ReadThunkError_MissingPaths (NonEmpty FilePath)
+  | ReadThunkError_UnparseablePtr FilePath String
+  | ReadThunkError_FileError IOError
+  | ReadThunkError_FileDoesNotMatch FilePath Text
+  | ReadThunkError_UnrecognizedState String
+  | ReadThunkError_AmbiguousPackedState ThunkPtr ThunkPtr
+  deriving (Show)
 
--- | Read a thunk and validate that it is only a thunk, either packed or unpacked.
--- If the thunk is packed and additional data is present, fail.
-readThunk :: MonadObelisk m => FilePath -> m (Either ReadThunkError ThunkData)
-readThunk thunkDir = do
-  files <- liftIO $ listDirectory thunkDir
-  case ".git" `elem` files of
-    True -> fmap ThunkData_Checkout <$> do
-      let origThunkPath = thunkDir </> ".git" </> "obelisk" </> "orig-thunk"
-      liftIO $ doesDirectoryExist origThunkPath >>= \case
-        True -> fmap Just <$> readPackedThunk origThunkPath
-        False -> return $ return Nothing
-    False -> liftIO $ fmap ThunkData_Packed <$> readPackedThunk thunkDir
+unpackedDirName :: FilePath
+unpackedDirName = "local"
 
 attrCacheFileName :: FilePath
 attrCacheFileName = ".attr-cache"
 
-data ThunkType = ThunkType
-  { _thunkType_loader :: FilePath
-  , _thunkType_json :: FilePath
-  , _thunkType_optional :: Set FilePath
-  , _thunkType_loaderVersions :: NonEmpty Text
-  , _thunkType_parser :: Aeson.Object -> Aeson.Parser ThunkPtr
+-- | Specification for how a file in a thunk version works.
+data ThunkFileSpec
+  = ThunkFileSpec_Ptr (LBS.ByteString -> Either String ThunkPtr) -- ^ This file specifies 'ThunkPtr' data
+  | ThunkFileSpec_FileMatches Text -- ^ This file must match the given content exactly
+  | ThunkFileSpec_CheckoutIndicator -- ^ Existence of this directory indicates that the thunk is unpacked
+  | ThunkFileSpec_AttrCache -- ^ This directory is an attribute cache
+
+-- | Specification for how a set of files in a thunk version work.
+data ThunkSpec = ThunkSpec
+  { _thunkSpec_name :: !Text
+  , _thunkSpec_files :: !(Map FilePath ThunkFileSpec)
   }
 
-gitHubThunkType :: ThunkType
-gitHubThunkType = ThunkType
-  { _thunkType_loader = "default.nix"
-  , _thunkType_json = "github.json"
-  , _thunkType_optional = Set.fromList [attrCacheFileName]
-  , _thunkType_loaderVersions = gitHubStandaloneLoaders
-  , _thunkType_parser = parseThunkPtr $ \v ->
-      ThunkSource_GitHub <$> parseGitHubSource v <|> ThunkSource_Git <$> parseGitSource v
-  }
+thunkSpecTypes :: NonEmpty (NonEmpty ThunkSpec)
+thunkSpecTypes = gitThunkSpecs :| [gitHubThunkSpecs]
 
-gitThunkType :: ThunkType
-gitThunkType = ThunkType
-  { _thunkType_loader = "default.nix"
-  , _thunkType_json = "git.json"
-  , _thunkType_optional = Set.fromList [attrCacheFileName]
-  , _thunkType_loaderVersions = plainGitStandaloneLoaders
-  , _thunkType_parser = parseThunkPtr $ fmap ThunkSource_Git . parseGitSource
-  }
+-- | Attempts to match a 'ThunkSpec' to a given directory.
+matchThunkSpecToDir
+  :: (MonadError ReadThunkError m, MonadIO m, MonadCatch m)
+  => ThunkSpec -- ^ 'ThunkSpec' to match against the given files/directory
+  -> FilePath -- ^ Path to directory
+  -> Set FilePath -- ^ Set of file paths relative to the given directory
+  -> m ThunkData
+matchThunkSpecToDir thunkSpec dir dirFiles = do
+  case nonEmpty (toList $ dirFiles `Set.difference` expectedPaths) of
+    Just fs -> throwError $ ReadThunkError_UnrecognizedPaths $ (dir </>) <$> fs
+    Nothing -> pure ()
+  case nonEmpty (toList $ requiredPaths `Set.difference` dirFiles) of
+    Just fs -> throwError $ ReadThunkError_MissingPaths $ (dir </>) <$> fs
+    Nothing -> pure ()
+  datas <- fmap toList $ flip Map.traverseMaybeWithKey (_thunkSpec_files thunkSpec) $ \expectedPath -> \case
+    ThunkFileSpec_AttrCache -> Nothing <$ dirMayExist expectedPath
+    ThunkFileSpec_CheckoutIndicator -> liftIO (doesDirectoryExist (dir </> expectedPath)) <&> \case
+      False -> Nothing
+      True -> Just ThunkData_Checkout
+    ThunkFileSpec_FileMatches expectedContents -> handle (\(e :: IOError) -> throwError $ ReadThunkError_FileError e) $ do
+      actualContents <- liftIO (T.readFile $ dir </> expectedPath)
+      case T.strip expectedContents == T.strip actualContents of
+        True -> pure Nothing
+        False -> throwError $ ReadThunkError_FileDoesNotMatch (dir </> expectedPath) expectedContents
+    ThunkFileSpec_Ptr parser -> handle (\(e :: IOError) -> throwError $ ReadThunkError_FileError e) $ do
+      let path = dir </> expectedPath
+      liftIO (doesFileExist path) >>= \case
+        False -> pure Nothing
+        True -> do
+          actualContents <- liftIO $ LBS.readFile path
+          case parser actualContents of
+            Right v -> pure $ Just (ThunkData_Packed thunkSpec v)
+            Left e -> throwError $ ReadThunkError_UnparseablePtr (dir </> expectedPath) e
 
-thunkTypes :: [ThunkType]
-thunkTypes = [gitThunkType, gitHubThunkType]
+  case nonEmpty datas of
+    Nothing -> throwError ReadThunkError_UnrecognizedThunk
+    Just xs -> fold1WithM xs $ \a b -> either throwError pure (mergeThunkData a b)
+  where
+    rootPathsOnly = Set.fromList . mapMaybe takeRootDir . Map.keys
+    takeRootDir = fmap NonEmpty.head . nonEmpty . splitPath
 
-findThunkType :: [ThunkType] -> FilePath -> IO (Either ReadThunkError ThunkType)
-findThunkType types thunkDir = do
-  matches <- fmap catMaybes $ forM types $ \thunkType -> do
-    let
-      expectedContents = Set.fromList $ (thunkDir </>) <$>
-        [ _thunkType_loader thunkType
-        , _thunkType_json thunkType
-        ]
-      optionalContents = Set.map (thunkDir </>) (_thunkType_optional thunkType)
+    expectedPaths = rootPathsOnly $ _thunkSpec_files thunkSpec
 
-    -- Ensure that there aren't any other files in the thunk
-    -- NB: System.Directory.listDirectory returns the contents without the directory path
-    files <- liftIO $ Set.fromList . fmap (thunkDir </>) <$> listDirectory thunkDir
-    let unexpectedContents = files `Set.difference` (expectedContents `Set.union` optionalContents)
-        missingContents = expectedContents `Set.difference` files
-    pure $ if Set.null unexpectedContents && Set.null missingContents
-      then Just thunkType
-      else Nothing
+    requiredPaths = rootPathsOnly $ Map.filter isRequiredFileSpec $ _thunkSpec_files thunkSpec
+    isRequiredFileSpec = \case
+      ThunkFileSpec_FileMatches _ -> True
+      _ -> False
 
-  pure $ case matches of
-    [singleMatch] -> Right singleMatch
-    [] -> Left ReadThunkError_UnrecognizedFiles
-    _ -> Left ReadThunkError_AmbiguousFiles
+    dirMayExist expectedPath = liftIO (doesFileExist (dir </> expectedPath)) >>= \case
+      True -> throwError $ ReadThunkError_UnrecognizedPaths $ expectedPath :| []
+      False -> pure ()
+
+    -- Combine 'ThunkData' from different files, preferring "Checkout" over "Packed"
+    mergeThunkData ThunkData_Checkout ThunkData_Checkout = Right ThunkData_Checkout
+    mergeThunkData ThunkData_Checkout ThunkData_Packed{} = Left bothPackedAndUnpacked
+    mergeThunkData ThunkData_Packed{} ThunkData_Checkout = Left bothPackedAndUnpacked
+    mergeThunkData a@(ThunkData_Packed _ ptrA) (ThunkData_Packed _ ptrB) =
+      if ptrA == ptrB then Right a else Left $ ReadThunkError_AmbiguousPackedState ptrA ptrB
+
+    bothPackedAndUnpacked = ReadThunkError_UnrecognizedState "Both packed data and checkout present"
+
+    fold1WithM (x :| xs) f = foldM f x xs
+
+readThunkWith
+  :: (MonadObelisk m)
+  => NonEmpty (NonEmpty ThunkSpec) -> FilePath -> m (Either ReadThunkError ThunkData)
+readThunkWith specTypes dir = do
+  dirFiles <- Set.fromList <$> liftIO (listDirectory dir)
+  let specs = concatMap toList $ toList $ NonEmpty.transpose specTypes -- Interleave spec types so we try each one in a "fair" ordering
+  flip fix specs $ \loop -> \case
+    [] -> pure $ Left ReadThunkError_UnrecognizedThunk
+    spec:rest -> runExceptT (matchThunkSpecToDir spec dir dirFiles) >>= \case
+      Left e -> putLog Debug [i|Thunk specification ${_thunkSpec_name spec} did not match ${dir}: ${e}|] *> loop rest
+      x@(Right _) -> x <$ putLog Debug [i|Thunk specification ${_thunkSpec_name spec} matched ${dir}|]
 
 -- | Read a thunk and validate that it is exactly a packed thunk.
 -- If additional data is present, fail.
-readPackedThunk :: FilePath -> IO (Either ReadThunkError ThunkPtr)
-readPackedThunk thunkDir = runExceptT $ do
-  thunkType <- ExceptT $ findThunkType thunkTypes thunkDir
-  -- Ensure that we recognize the thunk loader
-  loader <- liftIO $ T.readFile $ thunkDir </> _thunkType_loader thunkType
-  unless (loader `elem` _thunkType_loaderVersions thunkType) $ do
-    throwError $ ReadThunkError_UnrecognizedLoader loader
-
-  txt <- liftIO $ LBS.readFile $ thunkDir </> _thunkType_json thunkType
-  case parseMaybe (_thunkType_parser thunkType) =<< Aeson.decode txt of
-    Nothing -> throwError $ ReadThunkError_UnparseablePtr txt
-    Just ptr -> return ptr
+readThunk :: (MonadObelisk m) => FilePath -> m (Either ReadThunkError ThunkData)
+readThunk = readThunkWith thunkSpecTypes
 
 parseThunkPtr :: (Aeson.Object -> Aeson.Parser ThunkSource) -> Aeson.Object -> Aeson.Parser ThunkPtr
 parseThunkPtr parseSrc v = do
@@ -346,16 +346,18 @@ parseGitSource v = do
 overwriteThunk :: MonadObelisk m => FilePath -> ThunkPtr -> m ()
 overwriteThunk target thunk = do
   -- Ensure that this directory is a valid thunk (i.e. so we aren't losing any data)
-  Right _ <- readThunk target
+  readThunk target >>= \case
+    Left e -> failWith [i|Invalid thunk at ${target}: ${e}|]
+    Right _ -> pure ()
 
   --TODO: Is there a safer way to do this overwriting?
-  liftIO $ removeDirectoryRecursive target
-  liftIO $ createThunk target thunk
+  callProcessAndLogOutput (Debug, Error) $ proc rmPath ["-r", target] -- target may be a symlink
+  createThunk target $ Right thunk
 
-thunkPtrLoader :: ThunkPtr -> Text
-thunkPtrLoader thunk = case _thunkPtr_source thunk of
-  ThunkSource_GitHub _ -> NonEmpty.head gitHubStandaloneLoaders
-  ThunkSource_Git _ -> NonEmpty.head plainGitStandaloneLoaders
+thunkPtrToSpec :: ThunkPtr -> ThunkSpec
+thunkPtrToSpec thunk = case _thunkPtr_source thunk of
+  ThunkSource_GitHub _ -> NonEmpty.head gitHubThunkSpecs
+  ThunkSource_Git _ -> NonEmpty.head gitThunkSpecs
 
 -- It's important that formatting be very consistent here, because
 -- otherwise when people update thunks, their patches will be messy
@@ -402,35 +404,56 @@ encodeThunkPtrData (ThunkPtr rev src) = case src of
     , confTrailingNewline = True
     }
 
-createThunk :: MonadIO m => FilePath -> ThunkPtr -> m ()
-createThunk target thunk = liftIO $ do
-  createDirectoryIfMissing True (target </> attrCacheFileName)
-  T.writeFile (target </> "default.nix") (thunkPtrLoader thunk)
-  let
-    jsonFileName = case _thunkPtr_source thunk of
-      ThunkSource_GitHub _ -> "github"
-      ThunkSource_Git _ -> "git"
-  LBS.writeFile (target </> jsonFileName <.> "json") (encodeThunkPtrData thunk)
+-- | Initialize a git repository to an unpacked thunk.
+initThunk :: MonadObelisk m => FilePath -> m ()
+initThunk target = withSpinner [i|Initializing thunk at ${target}|] $ do
+  checkThunkDirectory target
+  unlessM (liftIO $ doesDirectoryExist $ target </> ".git") $ failWith [i|${target} is not a git checkout.|]
+  ptr <- getThunkPtr False target Nothing
+  let tempThunkDir = target <.> "thunk-init"
+  whenM (liftIO $ doesPathExist tempThunkDir) $
+    failWith [i|A previous 'thunk init' left unfinished state at ${tempThunkDir}. You will need to rename or remove that path before trying again.|]
+  createThunk tempThunkDir $ Left (thunkPtrToSpec ptr) -- Only write the skeleton, but skip the ptr itself since it's unpacked
+  liftIO $ do
+    renameDirectory target (tempThunkDir </> unpackedDirName)
+    removePathForcibly target
+    renameDirectory tempThunkDir target
+
+createThunk :: MonadObelisk m => FilePath -> Either ThunkSpec ThunkPtr -> m ()
+createThunk target ptrInfo =
+  ifor_ (_thunkSpec_files spec) $ \path -> \case
+    ThunkFileSpec_FileMatches content -> withReadyPath path $ \p -> liftIO $ T.writeFile p content
+    ThunkFileSpec_Ptr _ -> case ptrInfo of
+      Left _ -> pure () -- We can't write the ptr without it
+      Right ptr -> withReadyPath path $ \p -> liftIO $ LBS.writeFile p (encodeThunkPtrData ptr)
+    _ -> pure ()
+  where
+    spec = either id thunkPtrToSpec ptrInfo
+    withReadyPath path f = do
+      let fullPath = target </> path
+      putLog Debug $ "Writing thunk file " <> T.pack fullPath
+      liftIO $ createDirectoryIfMissing True $ takeDirectory fullPath
+      f fullPath
 
 createThunkWithLatest :: MonadObelisk m => FilePath -> ThunkSource -> m ()
 createThunkWithLatest target s = do
   rev <- getLatestRev s
-  createThunk target $ ThunkPtr
+  createThunk target $ Right $ ThunkPtr
     { _thunkPtr_source = s
     , _thunkPtr_rev = rev
     }
 
 updateThunkToLatest :: MonadObelisk m => ThunkUpdateConfig -> FilePath -> m ()
-updateThunkToLatest (ThunkUpdateConfig mBranch thunkConfig) target = withSpinner' ("Updating thunk " <> T.pack target <> " to latest") (pure $ const $ "Thunk " <> T.pack target <> " updated to latest") $ do
-  checkThunkDirectory "ob thunk update directory cannot be '.'" target
+updateThunkToLatest (ThunkUpdateConfig mBranch thunkConfig) target = spinner $ do
+  checkThunkDirectory target
   -- check to see if thunk should be updated to a specific branch or just update it's current branch
   case mBranch of
     Nothing -> do
       (overwrite, ptr) <- readThunk target >>= \case
-        Left err -> failWith $ T.pack $ "thunk update: " <> show err
+        Left err -> failWith [i|Thunk update: ${err}|]
         Right c -> case c of
-          ThunkData_Packed t -> return (target, t)
-          ThunkData_Checkout _ -> failWith "cannot update an unpacked thunk"
+          ThunkData_Packed _ t -> return (target, t)
+          ThunkData_Checkout -> failWith "cannot update an unpacked thunk"
       let src = _thunkPtr_source ptr
       rev <- getLatestRev src
       overwriteThunk overwrite $ modifyThunkPtrByConfig thunkConfig $ ThunkPtr
@@ -438,14 +461,16 @@ updateThunkToLatest (ThunkUpdateConfig mBranch thunkConfig) target = withSpinner
         , _thunkPtr_rev = rev
         }
     Just branch -> readThunk target >>= \case
-      Left err -> failWith $ T.pack $ "thunk update: " <> show err
+      Left err -> failWith [i|Thunk update: ${err}|]
       Right c -> case c of
-        ThunkData_Packed t -> case _thunkPtr_source t of
+        ThunkData_Packed _ t -> case _thunkPtr_source t of
           ThunkSource_Git tsg -> setThunk thunkConfig target tsg branch
           ThunkSource_GitHub tsgh -> do
             let tsg = forgetGithub False tsgh
             setThunk thunkConfig target tsg branch
-        ThunkData_Checkout _ -> failWith $ T.pack $ "thunk located at " <> show target <> " is unpacked. Use ob thunk pack on the desired directory and then try ob thunk update again."
+        ThunkData_Checkout -> failWith [i|Thunk located at ${target} is unpacked. Use 'ob thunk pack' on the desired directory and then try 'ob thunk update' again.|]
+  where
+    spinner = withSpinner' ("Updating thunk " <> T.pack target <> " to latest") (pure $ const $ "Thunk " <> T.pack target <> " updated to latest")
 
 setThunk :: MonadObelisk m => ThunkConfig -> FilePath -> GitSource -> String -> m ()
 setThunk thunkConfig target gs branch = do
@@ -455,21 +480,21 @@ setThunk thunkConfig target gs branch = do
 
 -- | All recognized github standalone loaders, ordered from newest to oldest.
 -- This tool will only ever produce the newest one when it writes a thunk.
-gitHubStandaloneLoaders :: NonEmpty Text
-gitHubStandaloneLoaders =
-  gitHubStandaloneLoaderV4 :|
-  [ gitHubStandaloneLoaderV3
-  , gitHubStandaloneLoaderV2
-  , gitHubStandaloneLoaderV1
+gitHubThunkSpecs :: NonEmpty ThunkSpec
+gitHubThunkSpecs =
+  gitHubThunkSpecV5 :|
+  [ gitHubThunkSpecV4
+  , gitHubThunkSpecV3
+  , gitHubThunkSpecV2
+  , gitHubThunkSpecV1
   ]
 
-gitHubStandaloneLoaderV1 :: Text
-gitHubStandaloneLoaderV1 = T.unlines
-  [ "import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./github.json)))"
-  ]
+gitHubThunkSpecV1 :: ThunkSpec
+gitHubThunkSpecV1 = legacyGitHubThunkSpec "github-v1"
+  "import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./github.json)))"
 
-gitHubStandaloneLoaderV2 :: Text
-gitHubStandaloneLoaderV2 = T.unlines
+gitHubThunkSpecV2 :: ThunkSpec
+gitHubThunkSpecV2 = legacyGitHubThunkSpec "github-v2" $ T.unlines
   [ "# DO NOT HAND-EDIT THIS FILE" --TODO: Add something about how to get more info on Obelisk, etc.
   , "import ((import <nixpkgs> {}).fetchFromGitHub ("
   , "  let json = builtins.fromJSON (builtins.readFile ./github.json);"
@@ -479,8 +504,8 @@ gitHubStandaloneLoaderV2 = T.unlines
   , "))"
   ]
 
-gitHubStandaloneLoaderV3 :: Text
-gitHubStandaloneLoaderV3 = T.unlines
+gitHubThunkSpecV3 :: ThunkSpec
+gitHubThunkSpecV3 = legacyGitHubThunkSpec "github-v3" $ T.unlines
   [ "# DO NOT HAND-EDIT THIS FILE"
   , "let"
   , "  fetch = { private ? false, ... }@args: if private && builtins.hasAttr \"fetchGit\" builtins"
@@ -499,8 +524,8 @@ gitHubStandaloneLoaderV3 = T.unlines
   , "in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))"
   ]
 
-gitHubStandaloneLoaderV4 :: Text
-gitHubStandaloneLoaderV4 = T.unlines
+gitHubThunkSpecV4 :: ThunkSpec
+gitHubThunkSpecV4 = legacyGitHubThunkSpec "github-v4" $ T.unlines
   [ "# DO NOT HAND-EDIT THIS FILE"
   , "let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:"
   , "  if !fetchSubmodules && !private then builtins.fetchTarball {"
@@ -511,24 +536,50 @@ gitHubStandaloneLoaderV4 = T.unlines
   , "in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))"
   ]
 
-plainGitStandaloneLoaders :: NonEmpty Text
-plainGitStandaloneLoaders =
-  plainGitStandaloneLoaderV4 :|
-  [ plainGitStandaloneLoaderV1
-  , plainGitStandaloneLoaderV2
-  , plainGitStandaloneLoaderV3
+legacyGitHubThunkSpec :: Text -> Text -> ThunkSpec
+legacyGitHubThunkSpec name loader = ThunkSpec name $ Map.fromList
+  [ ("default.nix", ThunkFileSpec_FileMatches $ T.strip loader)
+  , ("github.json" , ThunkFileSpec_Ptr parseGitHubJsonBytes)
+  , (attrCacheFileName, ThunkFileSpec_AttrCache)
+  , (".git", ThunkFileSpec_CheckoutIndicator)
   ]
 
-plainGitStandaloneLoaderV1 :: Text
-plainGitStandaloneLoaderV1 = T.unlines
+gitHubThunkSpecV5 :: ThunkSpec
+gitHubThunkSpecV5 = mkThunkSpec "github-v5" "github.json" parseGitHubJsonBytes [here|
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in if builtins.pathExists ./local then ./local else fetch json
+|]
+
+parseGitHubJsonBytes :: LBS.ByteString -> Either String ThunkPtr
+parseGitHubJsonBytes = parseJsonObject $ parseThunkPtr $ \v ->
+  ThunkSource_GitHub <$> parseGitHubSource v <|> ThunkSource_Git <$> parseGitSource v
+
+gitThunkSpecs :: NonEmpty ThunkSpec
+gitThunkSpecs =
+  gitThunkSpecV5 :|
+  [ gitThunkSpecV4
+  , gitThunkSpecV3
+  , gitThunkSpecV2
+  , gitThunkSpecV1
+  ]
+
+gitThunkSpecV1 :: ThunkSpec
+gitThunkSpecV1 = legacyGitThunkSpec "git-v1" $ T.unlines
   [ "# DO NOT HAND-EDIT THIS FILE"
   , "let fetchGit = {url, rev, ref ? null, branch ? null, sha256 ? null, fetchSubmodules ? null}:"
   , "  assert !fetchSubmodules; (import <nixpkgs> {}).fetchgit { inherit url rev sha256; };"
   , "in import (fetchGit (builtins.fromJSON (builtins.readFile ./git.json)))"
   ]
 
-plainGitStandaloneLoaderV2 :: Text
-plainGitStandaloneLoaderV2 = T.unlines
+gitThunkSpecV2 :: ThunkSpec
+gitThunkSpecV2 = legacyGitThunkSpec "git-v2" $ T.unlines
   [ "# DO NOT HAND-EDIT THIS FILE"
   , "let fetchGit = {url, rev, ref ? null, branch ? null, sha256 ? null, fetchSubmodules ? null}:"
   , "  if builtins.hasAttr \"fetchGit\" builtins"
@@ -539,8 +590,8 @@ plainGitStandaloneLoaderV2 = T.unlines
 
 -- This loader has a bug because @builtins.fetchGit@ is not given a @ref@
 -- and will fail to find commits without this because it does shallow clones.
-plainGitStandaloneLoaderV3 :: Text
-plainGitStandaloneLoaderV3 = T.unlines
+gitThunkSpecV3 :: ThunkSpec
+gitThunkSpecV3 = legacyGitThunkSpec "git-v3" $ T.unlines
   [ "# DO NOT HAND-EDIT THIS FILE"
   , "let fetch = {url, rev, ref ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:"
   , "  let realUrl = let firstChar = builtins.substring 0 1 url; in"
@@ -555,8 +606,8 @@ plainGitStandaloneLoaderV3 = T.unlines
   , "in import (fetch (builtins.fromJSON (builtins.readFile ./git.json)))"
   ]
 
-plainGitStandaloneLoaderV4 :: Text
-plainGitStandaloneLoaderV4 = T.unlines
+gitThunkSpecV4 :: ThunkSpec
+gitThunkSpecV4 = legacyGitThunkSpec "git-v4" $ T.unlines
   [ "# DO NOT HAND-EDIT THIS FILE"
   , "let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:"
   , "  let realUrl = let firstChar = builtins.substring 0 1 url; in"
@@ -572,10 +623,52 @@ plainGitStandaloneLoaderV4 = T.unlines
   , "in import (fetch (builtins.fromJSON (builtins.readFile ./git.json)))"
   ]
 
-thunkFileNames :: [FilePath]
-thunkFileNames = ["default.nix", "github.json", "git.json"]
+legacyGitThunkSpec :: Text -> Text -> ThunkSpec
+legacyGitThunkSpec name loader = ThunkSpec name $ Map.fromList
+  [ ("default.nix", ThunkFileSpec_FileMatches $ T.strip loader)
+  , ("git.json" , ThunkFileSpec_Ptr parseGitJsonBytes)
+  , (attrCacheFileName, ThunkFileSpec_AttrCache)
+  , (".git", ThunkFileSpec_CheckoutIndicator)
+  ]
 
---TODO: when checking something out, make a shallow clone
+gitThunkSpecV5 :: ThunkSpec
+gitThunkSpecV5 = mkThunkSpec "git-v5" "git.json" parseGitJsonBytes [here|
+# DO NOT HAND-EDIT THIS FILE
+let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:
+  let realUrl = let firstChar = builtins.substring 0 1 url; in
+    if firstChar == "/" then /. + url
+    else if firstChar == "." then ./. + url
+    else url;
+  in if !fetchSubmodules && private then builtins.fetchGit {
+    url = realUrl; inherit rev;
+    ${if branch == null then null else "ref"} = branch;
+  } else (import <nixpkgs> {}).fetchgit {
+    url = realUrl; inherit rev sha256;
+  };
+  json = builtins.fromJSON (builtins.readFile ./git.json);
+in if builtins.pathExists ./local then ./local else fetch json
+|]
+
+parseGitJsonBytes :: LBS.ByteString -> Either String ThunkPtr
+parseGitJsonBytes = parseJsonObject $ parseThunkPtr $ fmap ThunkSource_Git . parseGitSource
+
+mkThunkSpec :: Text -> FilePath -> (LBS.ByteString -> Either String ThunkPtr) -> Text -> ThunkSpec
+mkThunkSpec name jsonFileName parser srcNix = ThunkSpec name $ Map.fromList
+  [ ("default.nix", ThunkFileSpec_FileMatches defaultNixViaSrc)
+  , ("thunk.nix", ThunkFileSpec_FileMatches srcNix)
+  , (jsonFileName, ThunkFileSpec_Ptr parser)
+  , (attrCacheFileName, ThunkFileSpec_AttrCache)
+  , (unpackedDirName, ThunkFileSpec_CheckoutIndicator)
+  ]
+  where
+    defaultNixViaSrc = [here|
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)
+|]
+
+
+parseJsonObject :: (Aeson.Object -> Aeson.Parser a) -> LBS.ByteString -> Either String a
+parseJsonObject p bytes = Aeson.parseEither p =<< Aeson.eitherDecode bytes
 
 -- | Checks a cache directory to see if there is a fresh symlink
 -- to the result of building an attribute of a thunk.
@@ -583,44 +676,49 @@ thunkFileNames = ["default.nix", "github.json", "git.json"]
 -- and the result is symlinked into the cache.
 nixBuildThunkAttrWithCache
   :: MonadObelisk m
-  => FilePath
+  => ThunkSpec
+  -> FilePath
   -- ^ Path to directory containing Thunk
   -> String
   -- ^ Attribute to build
-  -> m FilePath
+  -> m (Maybe FilePath)
   -- ^ Symlink to cached or built nix output
 -- WARNING: If the thunk uses an impure reference such as '<nixpkgs>'
 -- the caching mechanism will fail as it merely measures the modification
 -- time of the cache link and the expression to build.
-nixBuildThunkAttrWithCache thunkDir attr = do
-  --NB: Expects thunkDir to be normalised with no trailing path separator.
-  --This should be guaranteed by the command argument parser.
-  let cacheErrHandler e
-        | isDoesNotExistError e = return Nothing -- expected from a cache miss
-        | otherwise = putLog Error (T.pack $ displayException e) >> return Nothing
-      cacheDir = thunkDir </> attrCacheFileName
-      cachePath = cacheDir </> attr <.> "out"
+nixBuildThunkAttrWithCache thunkSpec thunkDir attr = do
   latestChange <- liftIO $ do
-    createDirectoryIfMissing False cacheDir
-    let getModificationTimeMaybe = fmap rightToMaybe . try @IOError . getModificationTime
-    maximum . catMaybes <$> mapM (getModificationTimeMaybe . (thunkDir </>)) thunkFileNames
-  cacheHit <- handle cacheErrHandler $ do
-    cacheTime <- liftIO $ posixSecondsToUTCTime . realToFrac . modificationTime <$> getSymbolicLinkStatus cachePath
-    return $ if latestChange <= cacheTime
-      then Just cachePath
-      else Nothing
-  case cacheHit of
-    Just c -> return c
-    Nothing -> do
-      putLog Warning $ T.pack $ mconcat [thunkDir, ": ", attr, " not cached, building ..."]
-      _ <- nixCmd $ NixCmd_Build $ def
-        Lens.& nixBuildConfig_outLink Lens..~ OutLink_IndirectRoot cachePath
-        Lens.& nixCmdConfig_target Lens..~ Target
-          { _target_path = Just thunkDir
-          , _target_attr = Just attr
-          , _target_expr = Nothing
-          }
-      return cachePath
+    let
+      getModificationTimeMaybe = fmap rightToMaybe . try @IOError . getModificationTime
+      thunkFileNames = Map.keys $ _thunkSpec_files thunkSpec
+    maximum . catMaybes <$> traverse (getModificationTimeMaybe . (thunkDir </>)) thunkFileNames
+
+  let cachePaths' = nonEmpty $ Map.keys $ Map.filter (\case ThunkFileSpec_AttrCache -> True; _ -> False) $
+                      _thunkSpec_files thunkSpec
+  for cachePaths' $ \cachePaths ->
+    fmap NonEmpty.head $ for cachePaths $ \cacheDir -> do
+      let
+        cachePath = cacheDir </> attr <.> "out"
+        cacheErrHandler e
+          | isDoesNotExistError e = pure Nothing -- expected from a cache miss
+          | otherwise = Nothing <$ putLog Error (T.pack $ displayException e)
+      cacheHit <- handle cacheErrHandler $ do
+        cacheTime <- liftIO $ posixSecondsToUTCTime . realToFrac . modificationTime <$> getSymbolicLinkStatus cachePath
+        pure $ if latestChange <= cacheTime
+          then Just cachePath
+          else Nothing
+      case cacheHit of
+        Just c -> pure c
+        Nothing -> do
+          putLog Warning $ T.pack $ mconcat [thunkDir, ": ", attr, " not cached, building ..."]
+          liftIO $ createDirectoryIfMissing True (takeDirectory cachePath)
+          (cachePath <$) $ nixCmd $ NixCmd_Build $ def
+            & nixBuildConfig_outLink .~ OutLink_IndirectRoot cachePath
+            & nixCmdConfig_target .~ Target
+              { _target_path = Just thunkDir
+              , _target_attr = Just attr
+              , _target_expr = Nothing
+              }
 
 -- | Build a nix attribute, and cache the result if possible
 nixBuildAttrWithCache
@@ -631,13 +729,15 @@ nixBuildAttrWithCache
   -- ^ Attribute to build
   -> m FilePath
   -- ^ Symlink to cached or built nix output
-nixBuildAttrWithCache exprPath attr = do
-  readThunk exprPath >>= \case
-    -- Only packed thunks are cached. in particular, checkouts are not
-    Right (ThunkData_Packed _) -> nixBuildThunkAttrWithCache exprPath attr
-    _ -> nixCmd $ NixCmd_Build $ def
-      Lens.& nixBuildConfig_outLink Lens..~ OutLink_None
-      Lens.& nixCmdConfig_target Lens..~ Target
+nixBuildAttrWithCache exprPath attr = readThunk exprPath >>= \case
+  -- Only packed thunks are cached. In particular, checkouts are not.
+  Right (ThunkData_Packed spec _) ->
+    maybe build pure =<< nixBuildThunkAttrWithCache spec exprPath attr
+  _ -> build
+  where
+    build = nixCmd $ NixCmd_Build $ def
+      & nixBuildConfig_outLink .~ OutLink_None
+      & nixCmdConfig_target .~ Target
         { _target_path = Just exprPath
         , _target_attr = Just attr
         , _target_expr = Nothing
@@ -658,7 +758,7 @@ updateThunk p f = withSystemTempDirectory "obelisk-thunkptr-" $ \tmpDir -> do
   where
     copyThunkToTmp tmpDir thunkDir = readThunk thunkDir >>= \case
       Left err -> failWith $ "withThunkUnpacked: " <> T.pack (show err)
-      Right (ThunkData_Packed _) -> do
+      Right ThunkData_Packed{} -> do
         let tmpThunk = tmpDir </> "thunk"
         callProcessAndLogOutput (Notice, Error) $
           proc cp ["-r", "-T", thunkDir, tmpThunk]
@@ -676,58 +776,64 @@ unpackThunk :: MonadObelisk m => FilePath -> m ()
 unpackThunk = unpackThunk' False
 
 -- | Check that we are not somewhere inside the thunk directory
-checkThunkDirectory :: MonadObelisk m => Text -> FilePath -> m ()
-checkThunkDirectory msg thunkDir = do
+checkThunkDirectory :: MonadObelisk m => FilePath -> m ()
+checkThunkDirectory thunkDir = do
   currentDir <- liftIO getCurrentDirectory
   thunkDir' <- liftIO $ canonicalizePath thunkDir
-  when (thunkDir' `L.isInfixOf` currentDir) $ failWith msg
+  when (thunkDir' `L.isInfixOf` currentDir) $
+    failWith [i|Can't perform thunk operations from within the thunk directory: ${thunkDir}|]
+
+  -- Don't let thunk commands work when directly given an unpacked repo
+  when (takeFileName thunkDir == unpackedDirName) $
+    readThunk (takeDirectory thunkDir) >>= \case
+      Right _ -> failWith [i|Refusing to perform thunk operation on ${thunkDir} because it is a thunk's unpacked source|]
+      Left _ -> pure ()
 
 unpackThunk' :: MonadObelisk m => Bool -> FilePath -> m ()
-unpackThunk' noTrail thunkDir = checkThunkDirectory "Can't pack/unpack from within the thunk directory" thunkDir >> readThunk thunkDir >>= \case
-  Left err -> failWith $ "thunk unpack: " <> T.pack (show err)
+unpackThunk' noTrail thunkDir = checkThunkDirectory thunkDir *> readThunk thunkDir >>= \case
+  Left err -> failWith [i|Invalid thunk at ${thunkDir}: ${err}|]
   --TODO: Overwrite option that rechecks out thunk; force option to do so even if working directory is dirty
-  Right (ThunkData_Checkout _) -> failWith "thunk unpack: thunk is already unpacked"
-  Right (ThunkData_Packed tptr) -> do
+  Right ThunkData_Checkout -> failWith [i|Thunk at ${thunkDir} is already unpacked|]
+  Right (ThunkData_Packed _ tptr) -> do
     let (thunkParent, thunkName) = splitFileName thunkDir
-    withTempDirectory thunkParent thunkName $ \tmpRepo -> do
-      let obGitDir = tmpRepo </> ".git" </> "obelisk"
-          s = case _thunkPtr_source tptr of
-            ThunkSource_GitHub s' -> forgetGithub False s'
-            ThunkSource_Git s' -> s'
+    withTempDirectory thunkParent thunkName $ \tmpThunk -> do
+      let
+        (gitSrc, newSpec) = case _thunkPtr_source tptr of
+          ThunkSource_GitHub s' -> (forgetGithub False s', NonEmpty.head gitHubThunkSpecs)
+          ThunkSource_Git s' -> (s', NonEmpty.head gitThunkSpecs)
       withSpinner' ("Fetching thunk " <> T.pack thunkName)
                    (finalMsg noTrail $ const $ "Fetched thunk " <> T.pack thunkName) $ do
-        let git = callProcessAndLogOutput (Notice, Notice) . gitProc tmpRepo
+        let git = callProcessAndLogOutput (Notice, Notice) . gitProc (tmpThunk </> unpackedDirName)
         git $ [ "clone" ]
-          ++  ("--recursive" <$ guard (_gitSource_fetchSubmodules s))
-          ++  [ T.unpack $ gitUriToText $ _gitSource_url s ]
-          ++  do branch <- maybeToList $ _gitSource_branch s
+          ++  ["--recursive" | _gitSource_fetchSubmodules gitSrc]
+          ++  [ T.unpack $ gitUriToText $ _gitSource_url gitSrc ]
+          ++  do branch <- maybeToList $ _gitSource_branch gitSrc
                  [ "--branch", T.unpack $ untagName branch ]
         git ["reset", "--hard", Ref.toHexString $ _thunkRev_commit $ _thunkPtr_rev tptr]
-        when (_gitSource_fetchSubmodules s) $
+        when (_gitSource_fetchSubmodules gitSrc) $
           git ["submodule", "update", "--recursive", "--init"]
 
-        liftIO $ createDirectory obGitDir
-        callProcessAndLogOutput (Notice, Error) $
-          proc cp ["-r", "-T", thunkDir </> ".", obGitDir </> "orig-thunk"]
-        callProcessAndLogOutput (Notice, Error) $
-          proc "rm" ["-r", thunkDir]
-        callProcessAndLogOutput (Notice, Error) $
-          proc "mv" ["-T", tmpRepo, thunkDir]
+        createThunk tmpThunk $ Left newSpec
+
+        liftIO $ do
+          removePathForcibly thunkDir
+          renameDirectory tmpThunk thunkDir
+
 
 --TODO: add a rollback mode to pack to the original thunk
 packThunk :: MonadObelisk m => ThunkPackConfig -> FilePath -> m ThunkPtr
 packThunk = packThunk' False
 
 packThunk' :: MonadObelisk m => Bool -> ThunkPackConfig -> FilePath -> m ThunkPtr
-packThunk' noTrail (ThunkPackConfig force thunkConfig) thunkDir = checkThunkDirectory "Can't pack/unpack from within the thunk directory" thunkDir >> readThunk thunkDir >>= \case
-  Left err -> failWith $ T.pack $ "thunk pack: " <> show err
-  Right (ThunkData_Packed _) -> failWith "pack: thunk is already packed"
-  Right (ThunkData_Checkout _) -> do
-    withSpinner' ("Packing thunk " <> T.pack thunkDir)
-                 (finalMsg noTrail $ const $ "Packed thunk " <> T.pack thunkDir) $ do
+packThunk' noTrail (ThunkPackConfig force thunkConfig) thunkDir = checkThunkDirectory thunkDir *> readThunk thunkDir >>= \case
+  Right ThunkData_Packed{} -> failWith [i|Thunk at ${thunkDir} is is already packed|]
+  _ -> withSpinner'
+    ("Packing thunk " <> T.pack thunkDir)
+    (finalMsg noTrail $ const $ "Packed thunk " <> T.pack thunkDir) $
+    do
       thunkPtr <- modifyThunkPtrByConfig thunkConfig <$> getThunkPtr (not force) thunkDir (_thunkConfig_private thunkConfig)
-      callProcessAndLogOutput (Debug, Error) $ proc "rm" ["-rf", thunkDir]
-      liftIO $ createThunk thunkDir thunkPtr
+      callProcessAndLogOutput (Debug, Error) $ proc rmPath ["-rf", thunkDir] -- thunkDir may be a symlink
+      createThunk thunkDir $ Right thunkPtr
       pure thunkPtr
 
 modifyThunkPtrByConfig :: ThunkConfig -> ThunkPtr -> ThunkPtr
@@ -739,28 +845,29 @@ modifyThunkPtrByConfig (ThunkConfig markPrivate') ptr = case markPrivate' of
     }
 
 getThunkPtr :: forall m. MonadObelisk m => Bool -> FilePath -> Maybe Bool -> m ThunkPtr
-getThunkPtr checkClean thunkDir mPrivate = do
+getThunkPtr checkClean dir mPrivate = do
+  let repoLocations = [(".git", "."), (unpackedDirName, unpackedDirName)]
+  repoLocation' <- liftIO $ flip findM repoLocations $ doesDirectoryExist . (dir </>) . fst
+  thunkDir <- case repoLocation' of
+    Nothing -> failWith [i|Can't find an unpacked thunk in ${dir}|]
+    Just (_, path) -> pure $ normalise $ dir </> path
+
   when checkClean $ ensureCleanGitRepo thunkDir True
     "thunk pack: thunk checkout contains unsaved modifications"
 
   -- Check whether there are any stashes
-  stashOutput <- readGitProcess thunkDir ["stash", "list"]
-  when checkClean $ case T.null stashOutput of
-    False -> do
+  when checkClean $ do
+    stashOutput <- readGitProcess thunkDir ["stash", "list"]
+    unless (T.null stashOutput) $
       failWith $ T.unlines $
         [ "thunk pack: thunk checkout has stashes"
         , "git stash list:"
         ] ++ T.lines stashOutput
-    True -> return ()
 
   -- Get current branch
   (mCurrentBranch, mCurrentCommit) <- do
-    b <- listToMaybe
-      <$> T.lines
-      <$> readGitProcess thunkDir ["rev-parse", "--abbrev-ref", "HEAD"]
-    c <- listToMaybe
-      <$> T.lines
-      <$> readGitProcess thunkDir ["rev-parse", "HEAD"]
+    b <- listToMaybe . T.lines <$> readGitProcess thunkDir ["rev-parse", "--abbrev-ref", "HEAD"]
+    c <- listToMaybe . T.lines <$> readGitProcess thunkDir ["rev-parse", "HEAD"]
     case b of
       (Just "HEAD") -> failWith $ T.unlines
         [ "thunk pack: You are in 'detached HEAD' state."
@@ -771,7 +878,7 @@ getThunkPtr checkClean thunkDir mPrivate = do
 
   -- Get information on all branches and their (optional) designated upstream
   -- correspondents
-  (headDump :: [Text]) <- T.lines <$> readGitProcess thunkDir
+  headDump :: [Text] <- T.lines <$> readGitProcess thunkDir
     [ "for-each-ref"
     , "--format=%(refname:short) %(upstream:short) %(upstream:remotename)"
     , "refs/heads/"
@@ -817,7 +924,7 @@ getThunkPtr checkClean thunkDir mPrivate = do
       ]
 
     -- loosely by https://stackoverflow.com/questions/7773939/show-git-ahead-and-behind-info-for-all-branches-including-remotes
-    stats <- iforM headUpstream $ \branch (upstream, _remote) -> do
+    stats <- ifor headUpstream $ \branch (upstream, _remote) -> do
       (stat :: [Text]) <- T.lines <$> readGitProcess thunkDir
         [ "rev-list", "--left-right"
         , T.unpack branch <> "..." <> T.unpack upstream
@@ -841,8 +948,9 @@ getThunkPtr checkClean thunkDir mPrivate = do
         \pushed but this repo's remote tracking branches don't know it.)"
       ]
 
-  -- We assume it's safe to pack the thunk at this point
-  putLog Informational "All changes safe in git remotes. OK to pack thunk."
+  when checkClean $ do
+    -- We assume it's safe to pack the thunk at this point
+    putLog Informational "All changes safe in git remotes. OK to pack thunk."
 
   let remote = maybe "origin" snd $ flip Map.lookup headUpstream =<< mCurrentBranch
 

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -10,19 +10,20 @@ module Obelisk.Command.Utils where
 import Control.Applicative hiding (many)
 import Control.Monad.Except
 import Data.Bool (bool)
-import qualified Text.Megaparsec.Char.Lexer as ML
 import Data.Bifunctor
 import Data.Char
 import Data.Either
-import Data.Semigroup ((<>))
+import Data.List (isInfixOf)
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (maybeToList)
+import Data.Semigroup ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Void (Void)
 import System.Exit (ExitCode)
 import System.Which (staticWhich)
+import qualified Text.Megaparsec.Char.Lexer as ML
 import Text.Megaparsec as MP
 import Text.Megaparsec.Char as MP
 
@@ -31,6 +32,12 @@ import Obelisk.CliApp
 
 cp :: FilePath
 cp = $(staticWhich "cp")
+
+mvPath :: FilePath
+mvPath = $(staticWhich "mv")
+
+rmPath :: FilePath
+rmPath = $(staticWhich "rm")
 
 ghcidExePath :: FilePath
 ghcidExePath = $(staticWhich "ghcid")
@@ -46,6 +53,14 @@ nixBuildExePath = $(staticWhich "nix-build")
 
 jreKeyToolPath :: FilePath
 jreKeyToolPath = $(staticWhich "keytool")
+
+-- | Nix syntax requires relative paths to be prefixed by @./@ or
+-- @../@. This will make a 'FilePath' that can be embedded in a Nix
+-- expression.
+toNixPath :: FilePath -> FilePath
+toNixPath root | "/" `isInfixOf` root = root
+               | otherwise = "./" <> root
+
 
 -- Check whether the working directory is clean
 checkGitCleanStatus :: MonadObelisk m => FilePath -> Bool -> m Bool

--- a/lib/command/src/Obelisk/Command/VmBuilder.hs
+++ b/lib/command/src/Obelisk/Command/VmBuilder.hs
@@ -21,6 +21,7 @@ import qualified System.Info
 
 import Obelisk.App (MonadObelisk, getObeliskUserStateDir)
 import Obelisk.CliApp
+import Obelisk.Command.Utils (rmPath)
 
 -- | Generate the `--builders` argument string to enable the VM builder after ensuring it is available.
 getNixBuildersArg :: MonadObelisk m => m String
@@ -95,7 +96,7 @@ setupNixDocker stateDir = withSpinner ("Creating Docker container named " <> con
 
   -- Create new SSH keys for this container
   callProcessAndLogOutput (Debug, Error) $
-    proc "rm" ["-f", stateDir </> sshKeyFileName, stateDir </> sshKeyFileName <.> "pub"]
+    proc rmPath ["-f", stateDir </> sshKeyFileName, stateDir </> sshKeyFileName <.> "pub"]
   callProcessAndLogOutput (Debug, Error) $
     proc "ssh-keygen" ["-t", "ed25519", "-f", stateDir </> sshKeyFileName, "-P", ""]
 

--- a/lib/selftest/obelisk-selftest.cabal
+++ b/lib/selftest/obelisk-selftest.cabal
@@ -9,6 +9,8 @@ library
   hs-source-dirs: src
   build-depends:
       base
+    , bytestring
+    , aeson
     , containers
     , directory
     , filepath

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 module Obelisk.SelfTest where
@@ -13,13 +13,19 @@ import Control.Concurrent (threadDelay)
 import Control.Exception (bracket, throw, try)
 import Control.Monad
 import Control.Monad.IO.Class
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
 import Data.Bool (bool)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Foldable (for_)
 import Data.Function (fix)
+import qualified Data.Map as Map
 import Data.Semigroup ((<>))
 import qualified Data.Set as Set
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Types as HTTP
@@ -64,8 +70,14 @@ chmodPath = $(staticWhich "chmod")
 whoamiPath :: FilePath
 whoamiPath = $(staticWhich "whoami")
 
+nixInstantiatePath :: FilePath
+nixInstantiatePath = $(staticWhich "nix-instantiate")
+
 nixBuildPath :: FilePath
 nixBuildPath = $(staticWhich "nix-build")
+
+nixPrefetchGitPath :: FilePath
+nixPrefetchGitPath = $(staticWhich "nix-prefetch-git")
 
 lnPath :: FilePath
 lnPath = $(staticWhich "ln")
@@ -103,6 +115,17 @@ ob = "ob"
 augmentWithVerbosity :: (String -> [Text] -> a) -> String -> Bool -> [Text] -> a
 augmentWithVerbosity runner executable isVerbose args = runner executable $ (if isVerbose then ("-v" :) else id) args
 
+isolatedGitShell :: Bool -> FilePath -> (([Text] -> Sh Text) -> Sh a) -> IO a
+isolatedGitShell isVerbose dir f = shelly $ bool silently verbosely isVerbose $ do
+  setenv "HOME" "/dev/null"
+  setenv "GIT_CONFIG_NOSYSTEM" "1"
+  _ <- git ["init"]
+  _ <- git ["config", "user.name", "SelfTest"]
+  _ <- git ["config", "user.email", "self@test"]
+  f git
+  where
+    git args = run gitPath $ ["-C", toTextIgnore dir] <> args
+
 -- | Copies a git repo to a new location and "resets" the git history to include
 -- exactly one commit with all files added. It then restricts writing and reading
 -- for group and user to make the repo ideal for being a valid git remote for thunks.
@@ -110,21 +133,14 @@ augmentWithVerbosity runner executable isVerbose args = runner executable $ (if 
 -- Using this allows dirty repos to be used as git remotes during the test since 'git clone'ing
 -- a dirty repo will not include the uncommitted changes.
 copyForGitRemote :: Bool -> FilePath -> FilePath -> IO ()
-copyForGitRemote isVerbose origDir copyDir = shelly $ bool silently verbosely isVerbose $ do
-  setenv "HOME" "/dev/null"
-  setenv "GIT_CONFIG_NOSYSTEM" "1"
+copyForGitRemote isVerbose origDir copyDir = isolatedGitShell isVerbose copyDir $ \git -> do
   run_ rsyncPath
     [ "-r", "--no-perms", "--no-owner", "--no-group", "--exclude", ".git"
     , toTextIgnore (addTrailingPathSeparator origDir), toTextIgnore copyDir
     ]
-  git ["init"]
-  git ["config", "user.name", "SelfTest"]
-  git ["config", "user.email", "self@test"]
-  git ["add", "--all"]
-  git ["commit", "-m", "Copy repo"]
+  _ <- git ["add", "--all"]
+  _ <- git ["commit", "-m", "Copy repo"]
   run_ chmodPath ["-R", "u-w,g-rw,o-rw", toTextIgnore copyDir] -- Freeze this state
-  where
-    git args = run_ gitPath $ ["-C", toTextIgnore copyDir] <> args
 
 main :: IO ()
 main = do
@@ -241,7 +257,7 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
       run_ gitPath ["clone", "https://github.com/reflex-frp/reflex.git", toTextIgnore dir, "--branch", branch]
       runOb_ ["thunk", "pack", toTextIgnore dir]
       runOb_ ["thunk", "unpack", toTextIgnore dir]
-      branch' <- chdir dir $ run gitPath ["rev-parse", "--abbrev-ref", "HEAD"]
+      branch' <- run gitPath ["-C", toTextIgnore $ dir </> unpackedDirName, "rev-parse", "--abbrev-ref", "HEAD"]
       liftIO $ assertEqual "" branch (T.strip branch')
 
     it "can pack and unpack plain git repos" $
@@ -253,10 +269,10 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
         runOb_ ["thunk", "pack", repo]
         packedFiles <- Set.fromList <$> ls (fromText repo)
         liftIO $ assertEqual "" packedFiles $ Set.fromList $ (repo </>) <$>
-          ["default.nix", "github.json", ".attr-cache" :: FilePath]
+          ["default.nix", "thunk.nix", "github.json" :: FilePath]
 
         runOb_ ["thunk", "unpack", repo]
-        chdir (fromText repo) $ do
+        chdir (fromText repo </> unpackedDirName) $ do
           unpackHash <- revParseHead
           assertRevEQ origHash unpackHash
 
@@ -264,6 +280,8 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
 
     it "aborts thunk pack when there are uncommitted files" $ inTmpObInitWithImplCopy $ \dir -> do
       testThunkPack' (dir </> thunk)
+
+    it "works on legacy git thunks" $ testLegacyGitThunks isVerbose
 
   describe "ob thunk update --branch" $ parallel $ do
     it "can change a thunk to the latest version of a desired branch" $ withTmp $ \dir -> do
@@ -309,10 +327,11 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
 
     withObeliskImplClean f =
       withSystemTempDirectory "obelisk-impl-clean" $ \obeliskImpl -> do
-        void . shellyOb verbosity $ chdir obeliskImpl $ do
+        void . shellyOb verbosity $ do
           dirtyFiles <- T.strip <$> run gitPath ["-C", toTextIgnore obeliskRepoReadOnly, "diff", "--stat"]
           () <- when (dirtyFiles /= "") $ error "SelfTest does not work correctly with dirty obelisk repos as remote"
           run_ gitPath ["clone", "file://" <> toTextIgnore obeliskRepoReadOnly, toTextIgnore obeliskImpl]
+          runOb_ ["thunk", "init", toTextIgnore obeliskImpl]
         f obeliskImpl
 
     withInitCache f =
@@ -374,28 +393,31 @@ testObRunInDir executable extraArgs mdir httpManager = maskExitSuccess $ do
       else exit 0
 
 testThunkPack :: String -> [Text] -> FilePath -> Sh ()
-testThunkPack executable args path' = withTempFile (T.unpack $ toTextIgnore path') "test-file" $ \file handle -> do
-  let pack' = readProcessWithExitCode executable (T.unpack <$> ["thunk", "pack", toTextIgnore path'] ++ args) ""
-      ensureThunkPackFails q = liftIO $ pack' >>= \case
-        (code, out, err)
-          | code == ExitSuccess -> fail $ "ob thunk pack succeeded when it should have failed with error '" <> show q <> "'"
-          | q `T.isInfixOf` T.pack (out <> err) -> pure ()
-          | otherwise -> fail $ "ob thunk pack failed for an unexpected reason, expecting '" <> show q <> "', received: " <> show out <> "\nstderr: " <> err
-      git = chdir path' . run gitPath
+testThunkPack executable args path' = withTempFile repoDir "test-file" $ \file handle -> do
+  let
+    pack' = readProcessWithExitCode executable (["thunk", "pack", path'] ++ map T.unpack args) ""
+    ensureThunkPackFails q = liftIO $ pack' >>= \case
+      (code, out, err)
+        | code == ExitSuccess -> fail $ "ob thunk pack succeeded when it should have failed with error '" <> show q <> "'"
+        | q `T.isInfixOf` T.pack (out <> err) -> pure ()
+        | otherwise -> fail $ "ob thunk pack failed for an unexpected reason, expecting '" <> show q <> "', received: " <> show out <> "\nstderr: " <> err
+    git = chdir repoDir . run_ gitPath
   -- Untracked files
   ensureThunkPackFails "Untracked files"
-  void $ git ["add", T.pack file]
+  git ["add", T.pack file]
   -- Uncommitted files (staged)
   ensureThunkPackFails "unsaved"
-  chdir path' $ commit "test commit"
+  chdir repoDir $ commit "test commit"
   -- Non-pushed commits in any branch
   ensureThunkPackFails "not yet pushed"
   -- Uncommitted files (unstaged)
   liftIO $ T.hPutStrLn handle "test file" >> hClose handle
   ensureThunkPackFails "modified"
   -- Existing stashes
-  void $ git $ gitUserConfig <> [ "stash" ]
+  git $ gitUserConfig <> [ "stash" ]
   ensureThunkPackFails "has stashes"
+  where
+    repoDir = path' </> unpackedDirName
 
 -- | Blocks until a non-empty line is available
 hGetLineSkipBlanks :: MonadIO m => Handle -> m Text
@@ -456,3 +478,126 @@ getFreePorts n = Socket.withSocketsDo $ do
       sock <- Socket.socket (Socket.addrFamily addr) (Socket.addrSocketType addr) (Socket.addrProtocol addr)
       Socket.bind sock (Socket.addrAddress addr)
       pure sock
+
+testLegacyGitThunks :: Bool -> IO ()
+testLegacyGitThunks isVerbose = withSystemTempDirectory "test-git-repo" $ \gitDir -> do
+  isolatedGitShell isVerbose gitDir $ \git -> do
+    writefile (gitDir </> ("default.nix" :: FilePath)) "{}: \"hello\""
+    _ <- git ["add", "--all"]
+    _ <- git ["commit", "-m", "Initial commit"]
+    rev <- T.strip <$> git ["rev-parse", "HEAD"]
+    sha256 :: Text
+      <-  either error pure
+      =<< (Aeson.parseEither (Aeson..: "sha256") <=< Aeson.eitherDecodeStrict . T.encodeUtf8)
+      <$> run nixPrefetchGitPath [toTextIgnore gitDir]
+
+    for_ (legacyGitThunks (GitThunkParams gitDir rev sha256)) $ \mkFiles ->
+      withSystemTempDirectory "test-thunks" $ \thunkDir -> do
+        let nixEval = run nixInstantiatePath ["--eval", toTextIgnore (thunkDir </> ("thunk.nix" :: FilePath))]
+        liftIO $ mkFiles thunkDir
+        run_ "ob" ["thunk", "unpack", toTextIgnore thunkDir]
+        unpackedEval <- nixEval
+        run_ "ob" ["thunk", "pack", toTextIgnore thunkDir]
+        packedEval <- nixEval
+        liftIO $ assertBool "Unpacked and packed thunk.nix should not eval to the same thing" $
+          unpackedEval /= packedEval
+
+data GitThunkParams = GitThunkParams
+  { _gitThunkParams_repo :: !FilePath
+  , _gitThunkParams_rev :: !Text
+  , _gitThunkParams_sha256 :: !Text
+  } deriving Show
+
+legacyGitThunks :: GitThunkParams -> [FilePath -> IO ()]
+legacyGitThunks (GitThunkParams repo' rev sha256) =
+  [ mkLegacyIO
+      (T.unlines
+        [ "# DO NOT HAND-EDIT THIS FILE"
+        , "let fetchGit = {url, rev, ref ? null, branch ? null, sha256 ? null, fetchSubmodules ? null}:"
+        , "  assert !fetchSubmodules; (import <nixpkgs> {}).fetchgit { inherit url rev sha256; };"
+        , "in import (fetchGit (builtins.fromJSON (builtins.readFile ./git.json)))"
+        ]
+      )
+      (Map.fromList
+        [ ("url", repo)
+        , ("rev", rev)
+        , ("branch", "master")
+        , ("sha256", sha256)
+        ]
+      )
+  , mkLegacyIO
+      (T.unlines
+        [ "# DO NOT HAND-EDIT THIS FILE"
+        , "let fetchGit = {url, rev, ref ? null, branch ? null, sha256 ? null, fetchSubmodules ? null}:"
+        , "  if builtins.hasAttr \"fetchGit\" builtins"
+        , "    then builtins.fetchGit ({ inherit url rev; } // (if branch == null then {} else { ref = branch; }))"
+        , "    else abort \"Plain Git repositories are only supported on nix 2.0 or higher.\";"
+        , "in import (fetchGit (builtins.fromJSON (builtins.readFile ./git.json)))"
+        ]
+      )
+      (Map.fromList
+        [ ("url", repo)
+        , ("rev", rev)
+        , ("branch", "master")
+        , ("sha256", sha256)
+        ]
+      )
+  , mkLegacyIO
+      (T.unlines
+        [ "# DO NOT HAND-EDIT THIS FILE"
+        , "let fetch = {url, rev, ref ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:"
+        , "  let realUrl = let firstChar = builtins.substring 0 1 url; in"
+        , "    if firstChar == \"/\" then /. + url"
+        , "    else if firstChar == \".\" then ./. + url"
+        , "    else url;"
+        , "  in if !fetchSubmodules && private then builtins.fetchGit {"
+        , "    url = realUrl; inherit rev;"
+        , "  } else (import <nixpkgs> {}).fetchgit {"
+        , "    url = realUrl; inherit rev sha256;"
+        , "  };"
+        , "in import (fetch (builtins.fromJSON (builtins.readFile ./git.json)))"
+        ]
+      )
+      (Map.fromList
+        [ ("url", Aeson.String repo)
+        , ("rev", Aeson.String rev)
+        , ("branch", Aeson.String "master")
+        , ("sha256", Aeson.String sha256)
+        , ("private", Aeson.Bool False)
+        ]
+      )
+  , mkLegacyIO
+      (T.unlines
+        [ "# DO NOT HAND-EDIT THIS FILE"
+        , "let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:"
+        , "  let realUrl = let firstChar = builtins.substring 0 1 url; in"
+        , "    if firstChar == \"/\" then /. + url"
+        , "    else if firstChar == \".\" then ./. + url"
+        , "    else url;"
+        , "  in if !fetchSubmodules && private then builtins.fetchGit {"
+        , "    url = realUrl; inherit rev;"
+        , "    ${if branch == null then null else \"ref\"} = branch;"
+        , "  } else (import <nixpkgs> {}).fetchgit {"
+        , "    url = realUrl; inherit rev sha256;"
+        , "  };"
+        , "in import (fetch (builtins.fromJSON (builtins.readFile ./git.json)))"
+        ]
+      )
+      (Map.fromList
+        [ ("url", Aeson.String repo)
+        , ("rev", Aeson.String rev)
+        , ("branch", Aeson.String "master")
+        , ("sha256", Aeson.String sha256)
+        , ("private", Aeson.Bool False)
+        ]
+      )
+  ]
+  where
+    repo = T.pack repo'
+    mkLegacyIO :: Aeson.ToJSON v => Text -> Map.Map Text v -> FilePath -> IO ()
+    mkLegacyIO defaultNix gitJson dir = do
+      T.writeFile (dir </> ("default.nix" :: FilePath)) defaultNix
+      LBS.writeFile (dir </> ("git.json" :: FilePath)) (Aeson.encode gitJson)
+
+unpackedDirName :: FilePath
+unpackedDirName = "local"


### PR DESCRIPTION
Merged develop into the ghcide-compat branch
Renamed hack -> interpret
Use set-like merge for PathTree
Add slightly cleaner debugging for PathTree
Canonicalize excluded obelisk directories to match PathTree

cc @3noch 

I have:

  - [ ] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
