### PR TITLE
Implement a dockerTools.buildLayeredImage target for obelisk projects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ This project's release branch is `master`. This log is written from the perspect
   * **Migration:** New Obelisk projects will automatically benefit from this change, but existing projects need to apply a change similar to [this one](https://github.com/obsidiansystems/obelisk/blob/371cb3302085601c5ec73e9574d51c8b95e3e493/skeleton/frontend/frontend.cabal#L32-L34).
 * ([#742](https://github.com/obsidiansystems/obelisk/pull/742)) Update `reflex-platform` which includes:
     * A new version of GHCJS where `-dedupe` is fixed.
+* ([#697](https://github.com/obsidiansystems/obelisk/pull/697)) Add Docker support using nix's [`dockerTools.buildImage`](https://nixos.org/nixpkgs/manual/#ssec-pkgs-dockerTools-buildImage)
 
 ## v0.8.0.0
 


### PR DESCRIPTION
This is a rebase (solving conflicts) and squash of #512

I have:
  - [X] Based work on latest `develop` branch
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [X] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)

Changes from #512:
 - ChangeLog Next entry on merge
 - version became optional with default "latest" docker tag
 - moved docker build along deployment in readme
 - changed buildImage to buildLayeredImage for image efficiency/reusability.
 - use an optional internalPort argument