### PR TITLE
command: Don't check ignored files on deploy init

### DIFF
--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -56,7 +56,7 @@ deployInit deployOpts root = do
     failWith [i|Deploy directory ${deployDir} should not be the same as project root.|]
   thunkPtr <- readThunk root >>= \case
     Right (ThunkData_Packed _ ptr) -> return ptr
-    _ -> getThunkPtr True root Nothing
+    _ -> getThunkPtr CheckClean_NotIgnored root Nothing
   deployInit' thunkPtr deployOpts
 
 deployInit'


### PR DESCRIPTION
The strict checking on ignored files does not make sense unless we are about to delete the directory.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
