### PR TITLE
Fix init unpack bug

### DIFF
--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -194,6 +194,11 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
         configs <- getConfigs
         return (either (const Nothing) Just $ getConfigRoute configs) `shouldNotReturn` Nothing
 
+    it "can unpack and repack .obelisk/impl after init with master branch impl" $ inTmp $ \_ -> do
+      runOb_ ["init", "--branch", "master"]
+      runOb_ ["thunk", "unpack", ".obelisk/impl"]
+      runOb_ ["thunk", "pack", ".obelisk/impl"]
+
   -- These tests fail with "Could not find module 'Obelisk.Generated.Static'"
   -- when not run by 'nix-build --attr selftest'
   describe "ob run" $ {- NOT parallel $ -} do


### PR DESCRIPTION
* Handoff to the obelisk we are `init`ing to repack the impl thunk
* Add a test for this

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
