### PR TITLE
Fix preprocessor matching

### DIFF
--- a/lib/command/src/Obelisk/Command/Preprocessor.hs
+++ b/lib/command/src/Obelisk/Command/Preprocessor.hs
@@ -12,28 +12,20 @@ import qualified Data.Text.Lazy.Encoding as TL
 import Distribution.Compiler (CompilerFlavor (..))
 import Language.Haskell.Extension (Extension (..), Language(..))
 import System.Directory (canonicalizePath)
-import System.IO (IOMode (..), hClose, hPutStrLn, openFile, stderr)
+import System.IO (IOMode (..), hPutStrLn, stderr, withFile)
 import System.FilePath (hasTrailingPathSeparator, joinPath, splitPath)
 
 import Obelisk.Command.Run (CabalPackageInfo (..), parseCabalPackage')
 
 applyPackages :: FilePath -> FilePath -> FilePath -> [FilePath] -> IO ()
-applyPackages origPath inPath outPath packagePaths' = do
+applyPackages origPath inPath outPath packagePaths' = withFile outPath WriteMode $ \outFile -> do
   -- This code is intended to be executed via ghci's -pgmF preprocessor option
   -- The command line arguments are passed in via ghc, which dictates the first three options and meanings
-  -- In order for this code to execute,  origPath must contain either a '.' character or a '/' character.
+  -- In order for this code to execute, origPath must contain either a '.' character or a '/' character.
   -- (This is to avoid the possibility of the command line syntax conflicting with another ob command)
   -- We do have control over the remaining arguments, but they must be the same for all files.
   -- Thus, the fourth command line argument must be "apply-packages",  which has already been handled.
   -- We assume all the remaining arguments passed in are paths to cabal or hpack package specifications.
-
-  outFile <- openFile outPath WriteMode
-  let hPutTextBuilder h = BU.hPutBuilder h . TL.encodeUtf8Builder . TL.toLazyText
-
-  -- putStr "--------------------------------------------------------------------------------\n"
-  -- print args
-  -- putStr "--------------------------------------------------------------------------------\n"
-
   -- Thus we must select among the packagePaths for the file we are going to parse.
 
   origPathCanonical <- canonicalizePath origPath
@@ -48,16 +40,19 @@ applyPackages origPath inPath outPath packagePaths' = do
   -- our file as a subdirectory.
 
   case matches of
-    [] -> hPutTextBuilder outFile (lineNumberPragma origPath) -- TODO: probably should produce a warning
-    (packagePath:_) -> do
+    [] ->
+      hPutStrLn stderr $ "Error: Unable to find cabal information for " <> origPath <> "; Skipping preprocessor."
+    packagePath:_ -> do
       parseCabalPackage' packagePath >>= \case
         Left err ->
-          hPutStrLn stderr $ "Error: Unable to parse cabal package " <> packagePath <> "; Skipping preprocessor on " <> origPath <> ". Error was " <> show err
+          hPutStrLn stderr $ "Error: Unable to parse cabal package " <> packagePath <> "; Skipping preprocessor on " <> origPath <> ". Error: " <> show err
         Right (_warnings, packageInfo) ->
           hPutTextBuilder outFile (generateHeader origPath packageInfo)
 
   BL.readFile inPath >>= BL.hPut outFile
-  hClose outFile
+
+  where
+    hPutTextBuilder h = BU.hPutBuilder h . TL.encodeUtf8Builder . TL.toLazyText
 
 
  -- I'm pretty sure there's a certain amount of oversimplification in CabalPackageInfo, so I doubt this is fully robust.
@@ -91,7 +86,7 @@ generateHeader origPath packageInfo =
         <> TL.fromText " #-}\n"
       else mempty
     optList = map TL.fromString
-                $ filter (\x -> not (isPrefixOf "-O" x))
+                $ filter (not . isPrefixOf "-O")
                 $ fromMaybe []
                 $ lookup GHC (_cabalPackageInfo_compilerOptions packageInfo)
 


### PR DESCRIPTION
In some cases the preprocessor would fail to recognize that a file matched a cabal file. These changes make this less common and issue a warning when it does happen. Also some random improvements along the way.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
