### PR TITLE
Put cache in thunk dir

### DIFF
--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -699,7 +699,7 @@ nixBuildThunkAttrWithCache thunkSpec thunkDir attr = do
   for cachePaths' $ \cachePaths ->
     fmap NonEmpty.head $ for cachePaths $ \cacheDir -> do
       let
-        cachePath = cacheDir </> attr <.> "out"
+        cachePath = thunkDir </> cacheDir </> attr <.> "out"
         cacheErrHandler e
           | isDoesNotExistError e = pure Nothing -- expected from a cache miss
           | otherwise = Nothing <$ putLog Error (T.pack $ displayException e)


### PR DESCRIPTION
This fixes a bug where the cache was placed in the wrong directory, meaning older .obelisk/impl (master currently) would pick up files from attr-cache instead of frontend, for example.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
