### PR TITLE
command: Unpack latest thunk type inplace instead of in local

### DIFF
--- a/all-tests.nix
+++ b/all-tests.nix
@@ -125,17 +125,17 @@ in
           client.succeed("ob -v thunk unpack ~/code/myapp")
 
       with subtest("building an invalid thunk fails"):
-          client.succeed("cd ~/code/myapp/local && git checkout -b bad")
+          client.succeed("cd ~/code/myapp && git checkout -b bad")
           client.succeed(
-              "cp ${invalidThunkableSample} ~/code/myapp/local/default.nix"
+              "cp ${invalidThunkableSample} ~/code/myapp/default.nix"
           )
-          client.succeed("cd ~/code/myapp/local && git add .")
-          client.succeed('cd ~/code/myapp/local && git commit -m "Bad commit"')
-          client.succeed("cd ~/code/myapp/local && git push -u origin bad")
+          client.succeed("cd ~/code/myapp && git add .")
+          client.succeed('cd ~/code/myapp && git commit -m "Bad commit"')
+          client.succeed("cd ~/code/myapp && git push -u origin bad")
           client.succeed("ob -v thunk pack ~/code/myapp --public")
           client.fail("nix-build ~/code/myapp")
           client.succeed("ob -v thunk unpack ~/code/myapp")
-          client.succeed("cd ~/code/myapp/local && git checkout master")
+          client.succeed("cd ~/code/myapp && git checkout master")
 
       with subtest("obelisk can detect private repos"):
           client.succeed("ob -v thunk pack ~/code/myapp")

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -225,7 +225,6 @@ data ThunkCommand
   = ThunkCommand_Update ThunkUpdateConfig
   | ThunkCommand_Unpack
   | ThunkCommand_Pack ThunkPackConfig
-  | ThunkCommand_Init
   deriving Show
 
 thunkOption :: Parser ThunkOption
@@ -233,7 +232,6 @@ thunkOption = hsubparser $ mconcat
   [ command "update" $ info (thunkOptionWith $ ThunkCommand_Update <$> thunkUpdateConfig) $ progDesc "Update packed thunk to latest revision available on the tracked branch"
   , command "unpack" $ info (thunkOptionWith $ pure ThunkCommand_Unpack) $ progDesc "Unpack thunk into git checkout of revision it points to"
   , command "pack" $ info (thunkOptionWith $ ThunkCommand_Pack <$> thunkPackConfig) $ progDesc "Pack git checkout or unpacked thunk into thunk that points at the current branch's upstream"
-  , command "init" $ info (thunkOptionWith $ pure ThunkCommand_Init) $ progDesc "Initialize git checkout by converting it to an unpacked thunk"
   ]
   where
     thunkOptionWith f = ThunkOption
@@ -390,7 +388,6 @@ ob = \case
     ThunkCommand_Update config -> for_ thunks (updateThunkToLatest config)
     ThunkCommand_Unpack -> for_ thunks unpackThunk
     ThunkCommand_Pack config -> for_ thunks (packThunk config)
-    ThunkCommand_Init -> for_ thunks initThunk
     where
       thunks = _thunkOption_thunks to
   ObCommand_Repl interpretPathsList -> withInterpretPaths interpretPathsList runRepl

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -497,14 +497,9 @@ testLegacyGitThunks isVerbose = withSystemTempDirectory "test-git-repo" $ \gitDi
 
     for_ (legacyGitThunks (GitThunkParams gitDir rev sha256)) $ \mkFiles ->
       withSystemTempDirectory "test-thunks" $ \thunkDir -> do
-        let nixEval = run nixInstantiatePath ["--eval", toTextIgnore (thunkDir </> ("thunk.nix" :: FilePath))]
         liftIO $ mkFiles thunkDir
         run_ "ob" ["thunk", "unpack", toTextIgnore thunkDir]
-        unpackedEval <- nixEval
         run_ "ob" ["thunk", "pack", toTextIgnore thunkDir]
-        packedEval <- nixEval
-        liftIO $ assertBool "Unpacked and packed thunk.nix should not eval to the same thing" $
-          unpackedEval /= packedEval
 
 data GitThunkParams = GitThunkParams
   { _gitThunkParams_repo :: !FilePath

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -336,7 +336,6 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
           dirtyFiles <- T.strip <$> run gitPath ["-C", toTextIgnore obeliskRepoReadOnly, "diff", "--stat"]
           () <- when (dirtyFiles /= "") $ error "SelfTest does not work correctly with dirty obelisk repos as remote"
           run_ gitPath ["clone", "file://" <> toTextIgnore obeliskRepoReadOnly, toTextIgnore obeliskImpl]
-          runOb_ ["thunk", "init", toTextIgnore obeliskImpl]
         f obeliskImpl
 
     withInitCache f =
@@ -605,4 +604,4 @@ legacyGitThunks (GitThunkParams repo' rev sha256) =
       LBS.writeFile (dir </> ("git.json" :: FilePath)) (Aeson.encode gitJson)
 
 unpackedDirName :: FilePath
-unpackedDirName = "local"
+unpackedDirName = "."


### PR DESCRIPTION
I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
