### PR TITLE
Bump reflex-platform to 0.5.3.0 to get newer hackGet

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "master",
+  "branch": "release/0.5.3.0",
   "private": false,
-  "rev": "41be4d952b75515a037318aa344dd6b13ad29cfe",
-  "sha256": "132yqzyzd3c5fjy7wwnwa5d6pjxv5ap2xz0swwbv3h5pwi8jwv0a"
+  "rev": "9779ea3b4c87fdc971057c561262696d5e9b1847",
+  "sha256": "0v87ilal9355xwz8y9m0zh14pm9c0f7pqch0854kkj92ybc5l62q"
 }


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
