### PR TITLE
Use absolute paths by default in exported ghci config and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ To try out the **experimental** [`ghcide`](https://github.com/digital-asset/ghci
       EOF
       chmod +x hie-bios.sh
       ```
+      * **Note:** In some projects you need to use `ob internal export-ghci-configuration --use-relative-paths` in this script instead. This is known to happen when your project contains symlinks to other packages.
   * Add `hie.yaml` to the root of your project:
       ```shell
       echo 'cradle: { bios: { program: hie-bios.sh } }' > hie.yaml

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -74,8 +74,8 @@ argsInfo cfg = info (args cfg <**> helper) $ mconcat
 initSource :: Parser InitSource
 initSource = foldl1 (<|>)
   [ pure InitSource_Default
-  , InitSource_Branch <$> strOption (long "branch" <> metavar "BRANCH")
-  , InitSource_Symlink <$> strOption (long "symlink" <> action "directory" <> metavar "PATH")
+  , InitSource_Branch <$> strOption (long "branch" <> metavar "BRANCH" <> help "Initialize the project using the given BRANCH of Obelisk's official repository")
+  , InitSource_Symlink <$> strOption (long "symlink" <> action "directory" <> metavar "PATH" <> help "(Use with caution) Initialize the project using the copy of Obelisk found at the given PATH")
   ]
 
 initForce :: Parser Bool

--- a/lib/command/src/Obelisk/Command/Nix.hs
+++ b/lib/command/src/Obelisk/Command/Nix.hs
@@ -207,7 +207,7 @@ nixCmdProc' cmdCfg = (proc (T.unpack cmd) options, cmd)
         )
 
 nixCmd :: MonadObelisk m => NixCmd -> m FilePath
-nixCmd cmdCfg = withSpinner' ("Running " <> cmd <> desc) (Just $ const $ "Built " <> desc) $ do
+nixCmd cmdCfg = withSpinner' (T.unwords $ "Running" : cmd : desc) (Just $ const $ T.unwords $ "Built" : desc) $ do
   output <- readProcessAndLogStderr Debug cmdProc
   -- Remove final newline that Nix appends
   Just (outPath, '\n') <- pure $ T.unsnoc output
@@ -218,7 +218,7 @@ nixCmd cmdCfg = withSpinner' ("Running " <> cmd <> desc) (Just $ const $ "Built 
       NixCmd_Build cfg' -> cfg' ^. nixCommonConfig
       NixCmd_Instantiate cfg' -> cfg' ^. nixCommonConfig
     path = commonCfg ^. nixCmdConfig_target . target_path
-    desc = T.pack $ mconcat $ catMaybes
-      [ ("on " <>) <$> path
-      , (\a -> " [" <> a <> "]") <$> (commonCfg ^. nixCmdConfig_target . target_attr)
+    desc = concat $ catMaybes
+      [ (\x -> ["on", T.pack x]) <$> path
+      , (\a -> ["[" <> T.pack a <> "]"]) <$> (commonCfg ^. nixCmdConfig_target . target_attr)
       ]


### PR DESCRIPTION
Makes `export-ghci-configuration` use absolute paths by default with a switch to regain relative paths. This fixes IDE integrations which are bad at relative paths.

This also includes other random fixes...

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
