### PR TITLE
Fix android deployments

### DIFF
--- a/lib/executable-config/default.nix
+++ b/lib/executable-config/default.nix
@@ -19,6 +19,8 @@ let
       exit 1
     fi
     cp -a "${config}"/* "$out/config"
+    # Needed for android deployments
+    find "$out/config" -type f -printf '%P\0' > "$out/config.files"
   '');
 in
 


### PR DESCRIPTION
This line was mistakenly deleted here

https://github.com/obsidiansystems/obelisk/pull/338/files#diff-e6a85aeb6dbab7746f3391bf74236f3dL19

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
