### PR TITLE
ob run: display warnings for 'common'

### DIFF
--- a/skeleton/common/common.cabal
+++ b/skeleton/common/common.cabal
@@ -12,3 +12,4 @@ library
   exposed-modules:
     Common.Api
     Common.Route
+  ghc-options: -Wall


### PR DESCRIPTION
I always find myself adding this one line to every ob project initialized ever. It already has one for backend.cabal and frontend.cabal.

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
