### PR TITLE
Copy ob-run.hs file to local directory

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -342,8 +342,9 @@ in rec {
       in nixpkgs.runCommand "ob-run" {
         buildInputs = [ (profiled.ghc.ghcWithPackages (p: [ p.backend p.frontend])) ];
       } ''
+        cp ${exeSource} $PWD/ob-run.hs
         mkdir -p $out/bin/
-        ghc -x hs -prof -fno-prof-auto -threaded ${exeSource} -o $out/bin/ob-run
+        ghc -x hs -prof -fno-prof-auto -threaded ob-run.hs -o $out/bin/ob-run
       '';
 
       linuxExeConfigurable = linuxExe;


### PR DESCRIPTION
In some environments, ghc will try to create .hi files in the same
directory as the source code when compiling. When the .hs file is in
the read-only Nix store this gives “openBinaryFile: permission
denied”. To avoid this, just copy the file to the working directory.
