### PR TITLE
Use reflex-dom-core instead of reflex-dom

### DIFF
--- a/lib/backend/obelisk-backend.cabal
+++ b/lib/backend/obelisk-backend.cabal
@@ -21,7 +21,7 @@ library
                  obelisk-frontend,
                  obelisk-route,
                  obelisk-snap-extras,
-                 reflex-dom,
+                 reflex-dom-core,
                  snap,
                  snap-server,
                  text,

--- a/lib/backend/src/Obelisk/Backend.hs
+++ b/lib/backend/src/Obelisk/Backend.hs
@@ -58,7 +58,7 @@ import qualified Obelisk.ExecutableConfig.Lookup as Lookup
 import Obelisk.Frontend
 import Obelisk.Route
 import Obelisk.Snap.Extras (doNotCache, serveFileIfExistsAs)
-import Reflex.Dom
+import Reflex.Dom.Core
 import Snap (MonadSnap, Snap, commandLineConfig, defaultConfig, getsRequest, httpServe, modifyResponse
             , rqPathInfo, rqQueryString, setContentType, writeBS, writeText
             , rqCookies, Cookie(..) , setHeader)

--- a/lib/executable-config/lookup/obelisk-executable-config-lookup.cabal
+++ b/lib/executable-config/lookup/obelisk-executable-config-lookup.cabal
@@ -39,7 +39,7 @@ library
     primitive,
     monad-control,
     reflex,
-    reflex-dom,
+    reflex-dom-core,
     jsaddle
 
   ghc-options: -Wall

--- a/lib/executable-config/lookup/src/Obelisk/Configs.hs
+++ b/lib/executable-config/lookup/src/Obelisk/Configs.hs
@@ -35,7 +35,7 @@ import Data.Text (Text)
 import qualified Data.Text.Encoding as T
 import Reflex
 import Reflex.Host.Class
-import Reflex.Dom
+import Reflex.Dom.Core
 #ifndef ghcjs_HOST_OS
 import Language.Javascript.JSaddle (MonadJSM)
 #endif

--- a/lib/run/obelisk-run.cabal
+++ b/lib/run/obelisk-run.cabal
@@ -33,7 +33,7 @@ library
     , process
     , ref-tf
     , reflex
-    , reflex-dom
+    , reflex-dom-core
     , snap-core
     , streaming-commons
     , text


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
