### PR TITLE
cli-app: expose createProcess

### DIFF
--- a/lib/cliapp/src/Obelisk/CliApp.hs
+++ b/lib/cliapp/src/Obelisk/CliApp.hs
@@ -39,6 +39,7 @@ module Obelisk.CliApp
   , callCommand
   , callProcess
   , callProcessAndLogOutput
+  , createProcess
   , createProcess_
   , overCreateProcess
   , proc


### PR DESCRIPTION
Expose the `createProcess` function written in `lib/cliapp/src/Obelisk/CliApp/Process.hs`

Note that the Process.hs module exports it, but it is not on the list of functions exposed by the package.
