### PR TITLE
Remove COMPLETE pragma and add warning for (:.) on GHC < 8.10

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -224,7 +225,19 @@ hoistR f (x :=> Identity y) = f x :/ y
 infixr 5 :.
 type (:.) = (,)
 
+#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 810
 {-# COMPLETE (:.) #-}
+#else
+{-# WARNING (:.)
+  [ "Use of this pattern in GHC < 8.10 will result in spurious non-exhaustive warnings at every use site."
+  , "We cannot provide a COMPLETE pragma to silence these due to a GHC bug: https://gitlab.haskell.org/ghc/ghc/issues/17729."
+  , "The bug hides incompleteness warnings for all two tuples when the COMPLETE pattern is in scope."
+  , "Instead, you should use (,) directly until you can switch to GHC >= 8.10, where the COMPLETE pragma is reinstated."
+  ]
+  #-}
+#endif
+#endif
 pattern (:.) :: a -> b -> a :. b
 pattern a :. b = (a, b)
 


### PR DESCRIPTION
I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
