### PR TITLE
Fix ob profile to work with custom Prelude

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -325,29 +325,28 @@ in rec {
           {-# LANGUAGE PackageImports #-}
           module Main where
 
-          import "base" Prelude
+          -- Explicitly import Prelude from base lest there be multiple modules called Prelude
+          import "base" Prelude (IO, (++), read)
 
-          import Control.Exception
-          import Reflex.Profiled
-          import System.Environment
+          import "base" Control.Exception (finally)
+          import "reflex" Reflex.Profiled (writeProfilingData)
+          import "base" System.Environment (getArgs)
 
-          import qualified Obelisk.Run
+          import qualified "obelisk-run" Obelisk.Run
           import qualified Frontend
           import qualified Backend
 
           main :: IO ()
           main = do
-            args <- getArgs
-            let port = read $ args !! 0
-                assets = args !! 1
-                profileFile = (args !! 2) <> ".rprof"
-            Obelisk.Run.run port (Obelisk.Run.runServeAsset assets) Backend.backend Frontend.frontend `finally` writeProfilingData profileFile
+            [portStr, assets, profFileName] <- getArgs
+            Obelisk.Run.run (read portStr) (Obelisk.Run.runServeAsset assets) Backend.backend Frontend.frontend
+              `finally` writeProfilingData (profFileName ++ ".rprof")
         '';
       in nixpkgs.runCommand "ob-run" {
         buildInputs = [ (profiled.ghc.ghcWithPackages (p: [p.backend p.frontend])) ];
       } ''
-        cp ${exeSource} $PWD/ob-run.hs
-        mkdir -p $out/bin/
+        cp ${exeSource} ob-run.hs
+        mkdir -p $out/bin
         ghc -x hs -prof -fno-prof-auto -threaded ob-run.hs -o $out/bin/ob-run
       '';
 

--- a/default.nix
+++ b/default.nix
@@ -321,7 +321,11 @@ in rec {
       __unstable__.profiledObRun = let
         profiled = projectOut { inherit system; enableLibraryProfiling = true; };
         exeSource = builtins.toFile "ob-run.hs" ''
+          {-# LANGUAGE NoImplicitPrelude #-}
+          {-# LANGUAGE PackageImports #-}
           module Main where
+
+          import "base" Prelude
 
           import Control.Exception
           import Reflex.Profiled
@@ -340,7 +344,7 @@ in rec {
             Obelisk.Run.run port (Obelisk.Run.runServeAsset assets) Backend.backend Frontend.frontend `finally` writeProfilingData profileFile
         '';
       in nixpkgs.runCommand "ob-run" {
-        buildInputs = [ (profiled.ghc.ghcWithPackages (p: [ p.backend p.frontend])) ];
+        buildInputs = [ (profiled.ghc.ghcWithPackages (p: [p.backend p.frontend])) ];
       } ''
         cp ${exeSource} $PWD/ob-run.hs
         mkdir -p $out/bin/


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
