### PR TITLE
command: Make ob shell work with '--'

### DIFF
--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -285,7 +285,7 @@ shellOpts :: Parser ShellOpts
 shellOpts = ShellOpts
   <$> shellFlags
   <*> interpretOpts
-  <*> optional (strArgument (metavar "COMMAND"))
+  <*> ((\xs -> if null xs then Nothing else Just $ unwords xs) <$> many (strArgument (metavar "COMMAND")))
 
 portOpt :: Int -> Parser Int
 portOpt dfault = option auto (long "port" <> short 'p' <> help "Port number for server" <> showDefault <> value dfault <> metavar "INT")

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -114,7 +114,7 @@ obCommand cfg = hsubparser
     , command "thunk" $ info (ObCommand_Thunk <$> thunkOption) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (ObCommand_Repl <$> interpretOpts) $ progDesc "Open an interactive interpreter"
     , command "watch" $ info (ObCommand_Watch <$> interpretOpts) $ progDesc "Watch current project for errors and warnings"
-    , command "shell" $ info (ObCommand_Shell <$> shellOpts) $ progDesc "Enter a shell with project dependencies"
+    , command "shell" $ info (ObCommand_Shell <$> shellOpts) $ progDesc "Enter a shell with project dependencies or run a command in such a shell. E.g. ob shell -- ghc-pkg list"
     , command "doc" $ info (ObCommand_Doc <$> shellFlags <*> packageNames) $
         progDesc "List paths to haddock documentation for specified packages"
         <> footerDoc (Just $
@@ -285,6 +285,9 @@ shellOpts :: Parser ShellOpts
 shellOpts = ShellOpts
   <$> shellFlags
   <*> interpretOpts
+  -- This funny construction is used to support optparse-applicative's @--@ parsing.
+  -- All arguments after @--@ are left unparsed and instead provided to the last positional parser
+  -- which must therefore be 'many' in order to consume the rest of the input.
   <*> ((\xs -> if null xs then Nothing else Just $ unwords xs) <$> many (strArgument (metavar "COMMAND")))
 
 portOpt :: Int -> Parser Int

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -243,7 +243,7 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
       uu <- update
       assertRevEQ u uu
 
-    it "can run 'ob doc'" $ inTmpObInit $ \_ -> runOb ["doc", "reflex"]
+    it "can run 'ob doc'" $ inTmpObInit $ \_ -> runOb_ ["doc", "reflex"]
 
   describe "ob thunk pack/unpack" $ parallel $ do
     it "has thunk pack and unpack inverses" $ inTmpObInitWithImplCopy $ \_ -> do
@@ -305,6 +305,11 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
       startingContents <- checkDir dir
       void $ errExit False $ runOb ["thunk", "update", toTextIgnore dir, "--branch", "dumble-palooza"]
       checkDir dir >>= liftIO . assertEqual "" startingContents
+
+  describe "ob shell" $ parallel $ do
+    it "works with --" $ inTmpObInit $ \_ -> do
+      output <- runOb ["shell", "--", "ghc-pkg", "list"]
+      liftIO $ assertBool "Unexpected output from ob shell" $ ("Cabal-" `T.isInfixOf` output) && ("ghc-" `T.isInfixOf` output)
 
   describe "ob hoogle" $ {- NOT parallel -} do
     it "starts a hoogle server on the given port" $ inTmpObInit $ \_ -> do


### PR DESCRIPTION
Fixes #738

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
