### PR TITLE
Use unix-compat instead of unix for windows compat

### DIFF
--- a/lib/asset/manifest/obelisk-asset-manifest.cabal
+++ b/lib/asset/manifest/obelisk-asset-manifest.cabal
@@ -24,7 +24,7 @@ library
     , template-haskell
     , text
     , transformers
-    , unix
+    , unix-compat
     , vector
   exposed-modules:
     Obelisk.Asset.Gather

--- a/lib/asset/manifest/src/Obelisk/Asset/Symlink.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/Symlink.hs
@@ -7,7 +7,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import System.Directory
 import System.FilePath.Posix
-import System.Posix.Files
+import System.PosixCompat.Files
 
 -- | Copy the given hashed files from one location to hashed paths in another
 -- location, and symlink the unhashed paths to the hashed ones

--- a/lib/asset/serve-snap/obelisk-asset-serve-snap.cabal
+++ b/lib/asset/serve-snap/obelisk-asset-serve-snap.cabal
@@ -23,7 +23,7 @@ library
     , obelisk-snap-extras
     , text
     , transformers
-    , unix
+    , unix-compat
   exposed-modules:
       Obelisk.Asset.Accept
       Obelisk.Asset.Serve.Snap

--- a/lib/asset/serve-snap/src/Obelisk/Asset/Serve/Snap.hs
+++ b/lib/asset/serve-snap/src/Obelisk/Asset/Serve/Snap.hs
@@ -31,7 +31,7 @@ import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import System.Directory (getDirectoryContents)
 import System.FilePath ((</>), splitFileName, takeDirectory)
 import System.IO.Error (isDoesNotExistError)
-import System.Posix (getFileStatus, fileSize)
+import System.PosixCompat.Files (getFileStatus, fileSize)
 
 -- | Serve static assets from an asset directory generated via @assets.nix@ or, failing that, from a regular directory.
 --

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -45,7 +45,7 @@ library
     , text
     , time
     , transformers
-    , unix
+    , unix-compat
     , unordered-containers
     , utf8-string
     , which

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -22,7 +22,7 @@ import System.Environment
 import System.FilePath
 import qualified System.Info
 import System.IO (hIsTerminalDevice, stdout)
-import System.Posix.Process (executeFile)
+import System.Process (rawSystem)
 
 import Obelisk.App
 import Obelisk.CliApp
@@ -363,7 +363,9 @@ main' argsCfg = do
         Just impl -> do
           -- Invoke the real implementation, using --no-handoff to prevent infinite recursion
           putLog Debug $ "Handing off to " <> T.pack impl
-          liftIO $ executeFile impl False ("--no-handoff" : myArgs) Nothing
+          --liftIO $ executeFile impl False ("--no-handoff" : myArgs) Nothing
+          _ <- liftIO $ rawSystem impl ("--no-handoff" : myArgs)
+          return ()
   case myArgs of
     "--no-handoff" : as -> go as -- If we've been told not to hand off, don't hand off
     origPath:inPath:outPath:preprocessorName:packagePaths

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -363,7 +363,6 @@ main' argsCfg = do
         Just impl -> do
           -- Invoke the real implementation, using --no-handoff to prevent infinite recursion
           putLog Debug $ "Handing off to " <> T.pack impl
-          --liftIO $ executeFile impl False ("--no-handoff" : myArgs) Nothing
           _ <- liftIO $ rawSystem impl ("--no-handoff" : myArgs)
           return ()
   case myArgs of

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -25,7 +25,7 @@ import GHC.Generics
 import System.Directory
 import System.FilePath
 import System.IO
-import System.Posix.Files
+import System.PosixCompat.Files
 import Text.URI (URI)
 import qualified Text.URI as URI
 import Text.URI.Lens

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -39,8 +39,9 @@ import System.Environment (lookupEnv)
 import System.FilePath
 import System.IO.Temp
 import System.IO.Unsafe (unsafePerformIO)
-import System.Posix (FileStatus, FileMode, CMode (..), UserID, deviceID, fileID, fileMode, fileOwner, getFileStatus, getRealUserID)
-import System.Posix.Files
+import System.PosixCompat.Files
+import System.PosixCompat.Types
+import System.PosixCompat.User
 import Text.ShellEscape (bash, bytes)
 
 import GitHub.Data.GitData (Branch)

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -56,7 +56,7 @@ import System.Exit
 import System.FilePath
 import System.IO.Error
 import System.IO.Temp
-import System.Posix (getSymbolicLinkStatus, modificationTime)
+import System.PosixCompat.Files (getSymbolicLinkStatus, modificationTime)
 import qualified Text.URI as URI
 
 import Obelisk.App (MonadObelisk)

--- a/lib/snap-extras/obelisk-snap-extras.cabal
+++ b/lib/snap-extras/obelisk-snap-extras.cabal
@@ -12,7 +12,6 @@ library
     , base
     , bytestring
     , snap-core
-    , unix
     , directory
     , filepath
     , text


### PR DESCRIPTION
Beginning of a better Windows compatibility story for Obelisk.

I have:

  - [X] Based work on latest `develop` branch
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
