### PR TITLE
Use 'staticWhich' in nix prefetch

### DIFF
--- a/haskell-overlays/obelisk.nix
+++ b/haskell-overlays/obelisk.nix
@@ -20,6 +20,7 @@ in
     librarySystemDepends = [
       pkgs.jre
       pkgs.nix
+      pkgs.nix-prefetch-git
       (haskellLib.justStaticExecutables self.ghcid)
     ];
   };

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -58,7 +58,6 @@ import System.FilePath
 import System.IO.Error
 import System.IO.Temp
 import System.PosixCompat.Files (getSymbolicLinkStatus, modificationTime)
-import System.Which (staticWhich)
 import qualified Text.URI as URI
 
 import Obelisk.App (MonadObelisk)
@@ -180,14 +179,14 @@ getNixSha256ForUriUnpacked
 getNixSha256ForUriUnpacked uri =
   withExitFailMessage ("nix-prefetch-url: Failed to determine sha256 hash of URL " <> gitUriToText uri) $ do
     [hash] <- fmap T.lines $ readProcessAndLogOutput (Debug, Debug) $
-      proc $(staticWhich "nix-prefetch-url") ["--unpack", "--type", "sha256", T.unpack $ gitUriToText uri]
+      proc nixPrefetchUrlPath ["--unpack", "--type", "sha256", T.unpack $ gitUriToText uri]
     pure hash
 
 nixPrefetchGit :: MonadObelisk m => GitUri -> Text -> Bool -> m NixSha256
 nixPrefetchGit uri rev fetchSubmodules =
   withExitFailMessage ("nix-prefetch-git: Failed to determine sha256 hash of Git repo " <> gitUriToText uri <> " at " <> rev) $ do
     out <- readProcessAndLogStderr Debug $
-      proc $(staticWhich "nix-prefetch-git") $ filter (/="")
+      proc nixPrefetchGitPath $ filter (/="")
         [ "--url", T.unpack $ gitUriToText uri
         , "--rev", T.unpack rev
         , if fetchSubmodules then "--fetch-submodules" else ""

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 module Obelisk.Command.Thunk where
 

--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 module Obelisk.Command.Thunk where
 
@@ -57,6 +58,7 @@ import System.FilePath
 import System.IO.Error
 import System.IO.Temp
 import System.Posix (getSymbolicLinkStatus, modificationTime)
+import System.Which (staticWhich)
 import qualified Text.URI as URI
 
 import Obelisk.App (MonadObelisk)
@@ -178,14 +180,14 @@ getNixSha256ForUriUnpacked
 getNixSha256ForUriUnpacked uri =
   withExitFailMessage ("nix-prefetch-url: Failed to determine sha256 hash of URL " <> gitUriToText uri) $ do
     [hash] <- fmap T.lines $ readProcessAndLogOutput (Debug, Debug) $
-      proc "nix-prefetch-url" ["--unpack", "--type", "sha256", T.unpack $ gitUriToText uri]
+      proc $(staticWhich "nix-prefetch-url") ["--unpack", "--type", "sha256", T.unpack $ gitUriToText uri]
     pure hash
 
 nixPrefetchGit :: MonadObelisk m => GitUri -> Text -> Bool -> m NixSha256
 nixPrefetchGit uri rev fetchSubmodules =
   withExitFailMessage ("nix-prefetch-git: Failed to determine sha256 hash of Git repo " <> gitUriToText uri <> " at " <> rev) $ do
     out <- readProcessAndLogStderr Debug $
-      proc "nix-prefetch-git" $ filter (/="")
+      proc $(staticWhich "nix-prefetch-git") $ filter (/="")
         [ "--url", T.unpack $ gitUriToText uri
         , "--rev", T.unpack rev
         , if fetchSubmodules then "--fetch-submodules" else ""

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -54,6 +54,12 @@ nixBuildExePath = $(staticWhich "nix-build")
 jreKeyToolPath :: FilePath
 jreKeyToolPath = $(staticWhich "keytool")
 
+nixPrefetchGitPath :: FilePath
+nixPrefetchGitPath = $(staticWhich "nix-prefetch-git")
+
+nixPrefetchUrlPath :: FilePath
+nixPrefetchUrlPath = $(staticWhich "nix-prefetch-url")
+
 -- | Nix syntax requires relative paths to be prefixed by @./@ or
 -- @../@. This will make a 'FilePath' that can be embedded in a Nix
 -- expression.


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
This was causing runtime errors in code using `obelisk-command` as a library

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
