### PR TITLE
Bump nixpkgs to fix Let's Encrypt

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -106,6 +106,7 @@ in rec {
       services.openssh.enable = true;
       services.openssh.permitRootLogin = "prohibit-password";
 
+      security.acme.acceptTerms = true;
       security.acme.certs = if enableHttps then {
         "${routeHost}".email = adminEmail;
       } else {};

--- a/dep/reflex-platform/default.nix
+++ b/dep/reflex-platform/default.nix
@@ -1,8 +1,2 @@
 # DO NOT HAND-EDIT THIS FILE
-let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
-  if !fetchSubmodules && !private then builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
-    inherit owner repo rev sha256 fetchSubmodules private;
-  };
-in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))
+import (import ./thunk.nix)

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "release/0.5.3.0",
+  "branch": "aa-backport-lego",
   "private": false,
-  "rev": "9779ea3b4c87fdc971057c561262696d5e9b1847",
-  "sha256": "0v87ilal9355xwz8y9m0zh14pm9c0f7pqch0854kkj92ybc5l62q"
+  "rev": "20166e560c90789d8fb80b1912d6e834acef42d6",
+  "sha256": "1b3ikis7njnshnvgcavds27xydb719lzf5wa56nwi7i80sjv0ff9"
 }

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -3,6 +3,6 @@
   "repo": "reflex-platform",
   "branch": "aa-backport-lego",
   "private": false,
-  "rev": "20166e560c90789d8fb80b1912d6e834acef42d6",
-  "sha256": "1b3ikis7njnshnvgcavds27xydb719lzf5wa56nwi7i80sjv0ff9"
+  "rev": "1eadb3ec47d5a235e8ee939dcdb39feeb1681d1d",
+  "sha256": "041163a4c584js2p6x2gargsx10qxm2fssch5avsgl1ridyhv718"
 }

--- a/dep/reflex-platform/thunk.nix
+++ b/dep/reflex-platform/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/34941

This bumps nixpkgs in reflex-platform to use [this branch](https://github.com/obsidiansystems/nixpkgs/tree/aa-backport-lego), which backports upstream changes to the `acme` module. The old client (simp_le) no longer works in some circumstances due to Let's Encrypt API changes, so we use the `lego` client instead.

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
