### PR TITLE
Bump ghcide to 0.2.0

### DIFF
--- a/haskell-overlays/ghcide.nix
+++ b/haskell-overlays/ghcide.nix
@@ -1,34 +1,40 @@
 self: super:
-  let
-    pkgs = self.callPackage ({ pkgs }: pkgs) {};
-    inherit (pkgs.haskell.lib) dontCheck;
-  in {
-  ghcide = pkgs.haskell.lib.justStaticExecutables (dontCheck ((self.override {
-    overrides = self: super: {
-      ghc-check = self.callHackageDirect {
-        pkg = "ghc-check";
-        ver = "0.1.0.3";
-        sha256 = "038llbvryk5y27jbdpbshp0zw5lw1j6m7qk7vx1n96ykqdzkh649";
-      } {};
-      lsp-test = dontCheck (self.callHackage "lsp-test" "0.6.1.0" {});
-      haddock-library = dontCheck (self.callHackage "haddock-library" "1.8.0" {});
-      haskell-lsp = dontCheck (self.callHackage "haskell-lsp" "0.19.0.0" {});
-      haskell-lsp-types = dontCheck (self.callHackage "haskell-lsp-types" "0.19.0.0" {});
-      regex-posix = dontCheck (self.callHackage "regex-posix" "0.96.0.0" {});
-      test-framework = dontCheck (self.callHackage "test-framework" "0.8.2.0" {});
-      regex-base = dontCheck (self.callHackage "regex-base" "0.94.0.0" {});
-      regex-tdfa = dontCheck (self.callHackage "regex-tdfa" "1.3.1.0" {});
-      shake = dontCheck (self.callHackage "shake" "0.18.4" {});
-      hie-bios = dontCheck (self.callHackageDirect {
-        pkg = "hie-bios";
-        ver = "0.4.0";
-        sha256 = "19lpg9ymd9656cy17vna8wr1hvzfal94gpm2d3xpnw1d5qr37z7x";
-      } {});
-    };
-  }).callCabal2nix "ghcide" (pkgs.fetchFromGitHub {
-    owner = "digital-asset";
-    repo = "ghcide";
-    rev = "v0.1.0";
-    sha256 = "1kf71iix46hvyxviimrcv7kvsj67hcnnqlpdsmazmlmybf7wbqbb";
-  }) {}));
+let
+  pkgs = self.callPackage ({ pkgs }: pkgs) { };
+  inherit (pkgs.haskell.lib) dontCheck justStaticExecutables;
+  inherit (pkgs.haskellPackages) callHackageDirect callHackage;
+
+in {
+  ghcide = justStaticExecutables (dontCheck (callHackageDirect {
+    pkg = "ghcide";
+    ver = "0.2.0";
+    sha256 = "199l4qzrghhz6wbfkgqdl4gll4wvgpr190kinzhv88idnn9pxm96";
+  } rec {
+    ghc-check = callHackageDirect {
+      pkg = "ghc-check";
+      ver = "0.3.0.1";
+      sha256 = "1dj909m09m24315x51vxvcl28936ahsw4mavbc53danif3wy09ns";
+    } { };
+    lsp-test = dontCheck (callHackage "lsp-test" "0.6.1.0" { });
+    haddock-library = dontCheck (callHackage "haddock-library" "1.8.0" { });
+    haskell-lsp = dontCheck (callHackageDirect {
+      pkg = "haskell-lsp";
+      ver = "0.22.0.0";
+      sha256 = "1q3w46qcvzraxgmw75s7bl0qvb2fvff242r5vfx95sqska566b4m";
+    } { inherit haskell-lsp-types; });
+    haskell-lsp-types = dontCheck (callHackageDirect {
+      pkg = "haskell-lsp-types";
+      ver = "0.22.0.0";
+      sha256 = "1apjclphi2v6ggrdnbc0azxbb1gkfj3x1vkwpc8qd6lsrbyaf0n8";
+    } { });
+    regex-tdfa = dontCheck (callHackage "regex-tdfa" "1.3.1.0" {
+      regex-base = dontCheck (callHackage "regex-base" "0.94.0.0" { });
+    });
+    shake = dontCheck (callHackage "shake" "0.18.4" { });
+    hie-bios = dontCheck (callHackageDirect {
+      pkg = "hie-bios";
+      ver = "0.5.0";
+      sha256 = "116nmpva5jmlgc2dgy8cm5wv6cinhzmga1l0432p305074w720r2";
+    } { });
+  }));
 }


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

This is getting increasingly tedious against nixpkgs-19.09 but this is the bump of ghcide to 0.2.0.

I have:
  
  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
