### PR TITLE
Fix ssh option flags syntax

### DIFF
--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -114,7 +114,7 @@ isolateGitProc = setEnvOverride (overrides <>)
       , ("GIT_CONFIG_NOSYSTEM", "1")
       , ("GIT_TERMINAL_PROMPT", "0") -- git 2.3+
       , ("GIT_ASKPASS", "echo") -- pre git 2.3 to just use empty password
-      , ("GIT_SSH_COMMAND", "ssh -o PreferredAuthentications password -o PubkeyAuthentication no -o GSSAPIAuthentication no")
+      , ("GIT_SSH_COMMAND", "ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no -o GSSAPIAuthentication=no")
       ]
 
 -- | Recursively copy a directory using `cp -a` -- TODO: Should use -rT instead of -a


### PR DESCRIPTION
On my system, on both bash and zsh:

```bash
$ ssh -o PreferredAuthentications password
command-line line 0: Missing argument.

$ ssh -o PreferredAuthentications=password
usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface]
           [-b bind_address] [-c cipher_spec] [-D [bind_address:]port]
           [-E log_file] [-e escape_char] [-F configfile] [-I pkcs11]
           [-i identity_file] [-J [user@]host[:port]] [-L address]
           [-l login_name] [-m mac_spec] [-O ctl_cmd] [-o option] [-p port]
           [-Q query_option] [-R address] [-S ctl_path] [-W host:port]
           [-w local_tun[:remote_tun]] destination [command]
```

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
