### PR TITLE
Add 'tabulation' lib to 'obeliskEnvs'

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -43,7 +43,7 @@ in rec {
   pathGit = ./.;  # Used in CI by the migration graph hash algorithm to correctly ignore files.
   path = reflex-platform.filterGit ./.;
   obelisk = ghcObelisk;
-  obeliskEnvs = pkgs.lib.filterAttrs (k: _: pkgs.lib.strings.hasPrefix "obelisk-" k) ghcObeliskEnvs;
+  obeliskEnvs = pkgs.lib.filterAttrs (k: _: k == "tabulation" || pkgs.lib.strings.hasPrefix "obelisk-" k) ghcObeliskEnvs; #TODO: use thunkSet https://github.com/reflex-frp/reflex-platform/pull/671
   command = ghcObelisk.obelisk-command;
   shell = pinBuildInputs "obelisk-shell" ([command] ++ command.commandRuntimeDeps);
 


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
`nix-shell -A obeliskEnvs.tabulation --run "cd lib/tabulation && ghcid -c 'cabal new-repl'"` doesn't work

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
