### PR TITLE
Include cpp-options in OPTIONS_GHC with preprocessor

### DIFF
--- a/lib/command/src/Obelisk/Command/Preprocessor.hs
+++ b/lib/command/src/Obelisk/Command/Preprocessor.hs
@@ -79,10 +79,11 @@ generateHeader origPath packageInfo =
         then mempty
         else pragma $
           TL.fromText "OPTIONS_GHC " <> mconcat (intersperse (TL.fromText " ") (map TL.fromString optList))
-    optList
+    ghcOptList
       = filter (not . isPrefixOf "-O")
       $ fromMaybe []
       $ lookup GHC (_cabalPackageInfo_compilerOptions packageInfo)
+    optList = _cabalPackageInfo_cppOptions packageInfo <> ghcOptList
 
 lineNumberPragma :: FilePath -> TL.Builder
 lineNumberPragma origPath =

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -46,7 +46,7 @@ import Distribution.Compiler (CompilerFlavor(..))
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription)
 import Distribution.Parsec.ParseResult (runParseResult)
 import qualified Distribution.System as Dist
-import Distribution.Types.BuildInfo (buildable, defaultExtensions, defaultLanguage, hsSourceDirs, options)
+import Distribution.Types.BuildInfo (buildable, cppOptions, defaultExtensions, defaultLanguage, hsSourceDirs, options)
 import Distribution.Types.CondTree (simplifyCondTree)
 import Distribution.Types.GenericPackageDescription (ConfVar (Arch, Impl, OS), condLibrary)
 import Distribution.Types.Library (libBuildInfo)
@@ -94,6 +94,8 @@ data CabalPackageInfo = CabalPackageInfo
     -- ^ List of globally set languages of the library component
   , _cabalPackageInfo_compilerOptions :: [(CompilerFlavor, [String])]
     -- ^ List of compiler-specific options (e.g., the "ghc-options" field of the cabal file)
+  , _cabalPackageInfo_cppOptions :: [String]
+    -- ^ List of CPP (C Preprocessor) options (e.g. the "cpp-options" field of the cabal file)
   }
 
 -- | 'Bool' with a better name for its purpose.
@@ -350,6 +352,7 @@ parseCabalPackage' pkg = runExceptT $ do
         , _cabalPackageInfo_defaultLanguage =
             defaultLanguage $ libBuildInfo lib
         , _cabalPackageInfo_compilerOptions = options $ libBuildInfo lib
+        , _cabalPackageInfo_cppOptions = cppOptions $ libBuildInfo lib
         }
     Right Nothing -> throwError "Haskell package has no library component"
     Left (_, errors) ->


### PR DESCRIPTION
I thought this would help but it actually doesn't. The CPP pass happens *before* our preprocessor runs so we're too late to inject any new defines/etc. Instead we need to additionally wrap the cpp and insert our fields in first using `-pgmP`. But I still think these changes are worth keeping since the code is cleaner and we'll need some of this anyway when we go to fix it correctly.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
