### PR TITLE
Add prompts to successful ob init logs

### DIFF
--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -137,6 +137,12 @@ initProject source force = withSystemTempDirectory "ob-init" $ \tmpDir -> do
     let configDir = "config"
     createDirectoryIfMissing False configDir
     mapM_ (createDirectoryIfMissing False . (configDir </>)) ["backend", "common", "frontend"]
+  putLog Notice $ T.intercalate "\n"
+    [ "An obelisk project has been successfully initialized. Next steps:"
+    , "  'ob run': Start a development server"
+    , "  'ob watch': Watch for changes without starting a server"
+    , "  'ob repl': Load your project into GHCi"
+    ]
 
 callHandoffOb
   :: MonadObelisk m


### PR DESCRIPTION

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
