### PR TITLE
Add immutable directive to Cache-Control header

### DIFF
--- a/lib/snap-extras/src/Obelisk/Snap/Extras.hs
+++ b/lib/snap-extras/src/Obelisk/Snap/Extras.hs
@@ -17,7 +17,7 @@ import System.Directory
 -- | Set response header for "permanent" caching
 cachePermanently :: MonadSnap m => m ()
 cachePermanently = do
-  modifyResponse $ setHeader "Cache-Control" "public, max-age=315360000"
+  modifyResponse $ setHeader "Cache-Control" "public, max-age=315360000, immutable"
   modifyResponse $ setHeader "Expires" "Tue, 01 Feb 2050 00:00:00 GMT" --TODO: This should be set to "approximately one year from the time the response is sent"
 
 -- | Set response header to not cache


### PR DESCRIPTION
When serving up a Content-Addressed static asset,  include immutable on the cache-control header

However, I did notice that when serving up a asset that is Content-Addressed and redirects are disabled, we are disabling all caching.   We could modify [`Obelisk.Asset.Serve.Snap.serveAsset'`](https://github.com/obsidiansystems/obelisk/blob/4f2d3f1c1312d833ae814b7a86cf7b65ea0614ec/lib/asset/serve-snap/src/Obelisk/Asset/Serve/Snap.hs#L74) to be less conservative and more precise on this regard:  in doing so, we'd need to remember the whether or not the _first_ call to `serveAsset'` before it recurses is an `immutable` or a `redirect`,  and then use that instead of `doRedirect` on [line 94](https://github.com/obsidiansystems/obelisk/blob/4f2d3f1c1312d833ae814b7a86cf7b65ea0614ec/lib/asset/serve-snap/src/Obelisk/Asset/Serve/Snap.hs#L74).

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
