### PR TITLE
Add staticWhich around most executable paths in obelisk-command

### DIFF
--- a/haskell-overlays/obelisk.nix
+++ b/haskell-overlays/obelisk.nix
@@ -19,8 +19,12 @@ in
   obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (obeliskCleanSource ../lib/command) {}) {
     librarySystemDepends = [
       pkgs.jre
+      pkgs.git
       pkgs.nix
       pkgs.nix-prefetch-git
+      pkgs.openssh
+      pkgs.rsync
+      pkgs.which
       (haskellLib.justStaticExecutables self.ghcid)
     ];
   };

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -184,10 +184,10 @@ deployPush deployPath getNixBuilders = do
   isClean <- checkGitCleanStatus deployPath True
   when (not isClean) $ do
     withSpinner "Committing changes to Git" $ do
-      callProcessAndLogOutput (Debug, Error) $ proc gitPath
-        ["-C", deployPath, "add", "."]
-      callProcessAndLogOutput (Debug, Error) $ proc gitPath
-        ["-C", deployPath, "commit", "-m", "New deployment"]
+      callProcessAndLogOutput (Debug, Error) $
+        gitProc deployPath ["add", "."]
+      callProcessAndLogOutput (Debug, Error) $
+        gitProc deployPath ["commit", "-m", "New deployment"]
   putLog Notice $ "Deployed => " <> T.pack route
   where
     callProcess' envMap cmd args = do

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -85,14 +85,12 @@ deployInit' thunkPtr (DeployInitOpts deployDir sshKeyPath hostnames route adminE
   --accidentally create a production deployment that uses development
   --credentials to connect to some resources.  This could result in, e.g.,
   --production data backed up to a dev environment.
-  withSpinner "Creating project configuration directories" $ do
-    callProcessAndLogOutput (Notice, Error) $
-      proc mkdirPath
-        [ "-p"
-        , deployDir </> "config" </> "backend"
-        , deployDir </> "config" </> "common"
-        , deployDir </> "config" </> "frontend"
-        ]
+  withSpinner "Creating project configuration directories" $ liftIO $ do
+    mapM_ (createDirectoryIfMissing True)
+      [ deployDir </> "config" </> "backend"
+      , deployDir </> "config" </> "common"
+      , deployDir </> "config" </> "frontend"
+      ]
 
   let srcDir = deployDir </> "src"
   withSpinner ("Creating source thunk (" <> T.pack (makeRelative deployDir srcDir) <> ")") $ do

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -51,7 +51,7 @@ import Obelisk.App (MonadObelisk)
 import Obelisk.CliApp
 import Obelisk.Command.Nix
 import Obelisk.Command.Thunk
-import Obelisk.Command.Utils (nixBuildExePath, nixExePath, toNixPath)
+import Obelisk.Command.Utils (nixBuildExePath, nixExePath, toNixPath, cp, nixShellPath)
 
 --TODO: Make this module resilient to random exceptions
 
@@ -116,7 +116,7 @@ initProject source force = withSystemTempDirectory "ob-init" $ \tmpDir -> do
     skel <- nixBuildAttrWithCache implDir "skeleton" --TODO: I don't think there's actually any reason to cache this
 
     callProcessAndLogOutput (Notice, Error) $
-      proc "cp"
+      proc cp
         [ "-r"
         , "--preserve=links"
         , obDir
@@ -126,7 +126,7 @@ initProject source force = withSystemTempDirectory "ob-init" $ \tmpDir -> do
 
   withSpinner "Copying project skeleton" $ do
     callProcessAndLogOutput (Notice, Error) $
-      proc "cp"
+      proc cp
         [ "-r"
         , "--no-preserve=mode"
         , "-T"
@@ -292,7 +292,7 @@ bashEscape :: String -> String
 bashEscape = BSU.toString . bytes . bash . BSU.fromString
 
 nixShellRunProc :: NixShellConfig -> ProcessSpec
-nixShellRunProc cfg = setDelegateCtlc True $ proc "nix-shell" $ runNixShellConfig cfg
+nixShellRunProc cfg = setDelegateCtlc True $ proc nixShellPath $ runNixShellConfig cfg
 
 nixShellWithoutPkgs
   :: MonadObelisk m

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -39,9 +39,6 @@ mvPath = $(staticWhich "mv")
 rmPath :: FilePath
 rmPath = $(staticWhich "rm")
 
-mkdirPath :: FilePath
-mkdirPath = $(staticWhich "mkdir")
-
 ghcidExePath :: FilePath
 ghcidExePath = $(staticWhich "ghcid")
 

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -39,6 +39,9 @@ mvPath = $(staticWhich "mv")
 rmPath :: FilePath
 rmPath = $(staticWhich "rm")
 
+mkdirPath :: FilePath
+mkdirPath = $(staticWhich "mkdir")
+
 ghcidExePath :: FilePath
 ghcidExePath = $(staticWhich "ghcid")
 
@@ -59,6 +62,32 @@ nixPrefetchGitPath = $(staticWhich "nix-prefetch-git")
 
 nixPrefetchUrlPath :: FilePath
 nixPrefetchUrlPath = $(staticWhich "nix-prefetch-url")
+
+nixShellPath :: FilePath
+nixShellPath = $(staticWhich "nix-shell")
+
+rsyncPath :: FilePath
+rsyncPath = $(staticWhich "rsync")
+
+sshPath :: FilePath
+sshPath = $(staticWhich "ssh")
+
+gitPath :: FilePath
+gitPath = $(staticWhich "git")
+
+whichPath :: FilePath
+whichPath = $(staticWhich "which")
+
+sshKeygenPath :: FilePath
+sshKeygenPath = $(staticWhich "ssh-keygen")
+
+-- $(staticWhich "docker") was intentionally omitted, at least for now
+-- One concern is that I don't know how particular docker is about having the
+-- CLI exe match the version of the docker daemon, which is largely outside of
+-- the control of obelisk-command.
+-- TODO: Investigate the tradeoffs associated with this choice
+dockerPath :: FilePath
+dockerPath = "docker"
 
 -- | Nix syntax requires relative paths to be prefixed by @./@ or
 -- @../@. This will make a 'FilePath' that can be embedded in a Nix
@@ -97,7 +126,7 @@ initGit repo = do
   git ["commit", "-m", "Initial commit."]
 
 gitProcNoRepo :: [String] -> ProcessSpec
-gitProcNoRepo args = setEnvOverride (M.singleton "GIT_TERMINAL_PROMPT" "0" <>) $ proc "git" args
+gitProcNoRepo args = setEnvOverride (M.singleton "GIT_TERMINAL_PROMPT" "0" <>) $ proc gitPath args
 
 gitProc :: FilePath -> [String] -> ProcessSpec
 gitProc repo = gitProcNoRepo . runGitInDir


### PR DESCRIPTION
I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
