### PR TITLE
Use system temp dir for temporary thunk clone

### DIFF
--- a/lib/command/src/Obelisk/Command/Thunk.hs
+++ b/lib/command/src/Obelisk/Command/Thunk.hs
@@ -782,8 +782,8 @@ unpackThunk' noTrail thunkDir = checkThunkDirectory thunkDir *> readThunk thunkD
   --TODO: Overwrite option that rechecks out thunk; force option to do so even if working directory is dirty
   Right ThunkData_Checkout -> failWith [i|Thunk at ${thunkDir} is already unpacked|]
   Right (ThunkData_Packed _ tptr) -> do
-    let (thunkParent, thunkName) = splitFileName thunkDir
-    withTempDirectory thunkParent thunkName $ \tmpThunk -> do
+    let thunkName = takeFileName thunkDir
+    withSystemTempDirectory thunkName $ \tmpThunk -> do
       let
         gitSrc = thunkSourceToGitSource $ _thunkPtr_source tptr
         newSpec = case _thunkPtr_source tptr of


### PR DESCRIPTION
Obelisk seems not to handle the ssh prompt correctly so when that kicks in I have to cancel `ob thunk unpack` to get the ssh-agent going, and end up with cruft in my local directory, hence this PR.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
