### PR TITLE
Disable nginx's access log for obelisk server

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -137,6 +137,9 @@ in rec {
           locations.${baseUrl} = {
             proxyPass = "http://127.0.0.1:" + toString internalPort;
             proxyWebsockets = true;
+            extraConfig = ''
+              access_log stdout;
+            '';
           };
         };
       };

--- a/default.nix
+++ b/default.nix
@@ -138,7 +138,7 @@ in rec {
             proxyPass = "http://127.0.0.1:" + toString internalPort;
             proxyWebsockets = true;
             extraConfig = ''
-              access_log stdout;
+              access_log off;
             '';
           };
         };


### PR DESCRIPTION
Otherwise nginx will save access logs to disk which can fill up the disk

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
