### PR TITLE
Frontend: fix loading css file by ios app

### DIFF
--- a/lib/frontend/src/Obelisk/Frontend.hs
+++ b/lib/frontend/src/Obelisk/Frontend.hs
@@ -211,9 +211,7 @@ runFrontendWithConfigsAndCurrentRoute mode configs validFullEncoder frontend = d
       w appendHead appendBody = do
         rec switchover <- runRouteViewT ve switchover (_frontendMode_adjustRoute mode) $ do
               (switchover'', fire) <- newTriggerEvent
-              mapRoutedT (mapSetRouteT (mapRouteToUrlT (appendHead . runConfigsT configs))) $ do
-                -- The order here is important - baseTag has to be before headWidget!
-                baseTag
+              mapRoutedT (mapSetRouteT (mapRouteToUrlT (appendHead . runConfigsT configs))) $
                 _frontend_head frontend
               mapRoutedT (mapSetRouteT (mapRouteToUrlT (appendBody . runConfigsT configs))) $ do
                 _frontend_body frontend


### PR DESCRIPTION
A \<base href="/"\> element in the html string makes the ios app
look for (some of) its assets in `/static/` instead of where they
are:
`/private/var/containers/Bundle/Application/[BA9B...B8C]/frontend.app/static/`

There should probably be no base element in the html in a WKWebView
since the baseURL is set separately in a WKWebView.

Resolves: #790

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
