### PR TITLE
Add an option to ob run for taking a certificate directory to use for TLS/HTTPS

### DIFF
--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -160,8 +160,8 @@ profile profileBasePattern rtsFlags = withProjectRoot "." $ \root -> do
     ] <> rtsFlags
       <> [ "-RTS" ]
 
-run :: MonadObelisk m => FilePath -> PathTree Interpret -> m ()
-run root interpretPaths = do
+run :: MonadObelisk m => Maybe FilePath -> FilePath -> PathTree Interpret -> m ()
+run certDir root interpretPaths = do
   pkgs <- getParsedLocalPkgs root interpretPaths
   assets <- findProjectAssets root
   putLog Debug $ "Assets impurely loaded from: " <> assets
@@ -171,6 +171,7 @@ run root interpretPaths = do
     runGhcid root True (ghciArgs <> dotGhciArgs) pkgs $ Just $ unwords
       [ "Obelisk.Run.run"
       , show freePort
+      , "(" ++ show certDir ++ ")"
       , "(Obelisk.Run.runServeAsset " ++ show assets ++ ")"
       , "Backend.backend"
       , "Frontend.frontend"

--- a/lib/run/obelisk-run.cabal
+++ b/lib/run/obelisk-run.cabal
@@ -14,6 +14,7 @@ library
     , cookie
     , dependent-sum
     , dependent-sum-template
+    , filepath
     , ghcjs-dom
     , HsOpenSSL
     , http-client

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -65,6 +65,7 @@ import qualified OpenSSL.X509.Request as X509Request
 import Reflex.Dom.Core
 import Snap.Core (Snap)
 import System.Environment
+import System.FilePath ((</>))
 import System.IO
 import System.Process
 import Text.URI (URI)
@@ -78,11 +79,13 @@ import qualified System.Which
 
 run
   :: Int -- ^ Port to run the backend
+  -> Maybe FilePath -- ^ Optional directory in which to find "cert.pem", "chain.pem" and "privkey.pem" to be used for TLS.
+                    -- If this is Nothing and TLS is enabled, we'll generate a self-signed cert.
   -> ([Text] -> Snap ()) -- ^ Static asset handler
   -> Backend backendRoute frontendRoute -- ^ Backend
   -> Frontend (R frontendRoute) -- ^ Frontend
   -> IO ()
-run port serveStaticAsset backend frontend = do
+run port certDir serveStaticAsset backend frontend = do
   prettifyOutput
   let handleBackendErr (e :: IOException) = hPutStrLn stderr $ "backend stopped; make a change to your code to reload - error " <> show e
   --TODO: Use Obelisk.Backend.runBackend; this will require separating the checking and running phases
@@ -102,7 +105,7 @@ run port serveStaticAsset backend frontend = do
                     appRouteToUrl (k :/ v) = renderObeliskRoute validFullEncoder (FullRoute_Frontend (ObeliskRoute_App k) :/ v)
                     allJsUrl = renderAllJsPath validFullEncoder
 
-      let conf = defRunConfig { _runConfig_redirectPort = port }
+      let conf = defRunConfig { _runConfig_redirectPort = port, _runConfig_certDir = certDir }
       runWidget conf publicConfigs frontend validFullEncoder `finally` killThread backendTid
 
 -- Convenience wrapper to handle path segments for 'Snap.serveAsset'
@@ -135,24 +138,29 @@ runWidget conf configs frontend validFullEncoder = do
       -- Providing TLS here will also incidentally provide it to proxied requests to the backend.
       prepareRunner = case uri ^? uriScheme . _Just . unRText of
         Just "https" -> do
-          -- Generate a private key and self-signed certificate for TLS
-          privateKey <- RSA.generateRSAKey' 2048 3
+          case _runConfig_certDir conf of
+            Nothing -> do
+              -- Generate a private key and self-signed certificate for TLS
+              privateKey <- RSA.generateRSAKey' 2048 3
 
-          certRequest <- X509Request.newX509Req
-          _ <- X509Request.setPublicKey certRequest privateKey
-          _ <- X509Request.signX509Req certRequest privateKey Nothing
+              certRequest <- X509Request.newX509Req
+              _ <- X509Request.setPublicKey certRequest privateKey
+              _ <- X509Request.signX509Req certRequest privateKey Nothing
 
-          cert <- X509.newX509 >>= X509Request.makeX509FromReq certRequest
-          _ <- X509.setPublicKey cert privateKey
-          now <- getCurrentTime
-          _ <- X509.setNotBefore cert $ addUTCTime (-1) now
-          _ <- X509.setNotAfter cert $ addUTCTime (365 * 24 * 60 * 60) now
-          _ <- X509.signX509 cert privateKey Nothing
+              cert <- X509.newX509 >>= X509Request.makeX509FromReq certRequest
+              _ <- X509.setPublicKey cert privateKey
+              now <- getCurrentTime
+              _ <- X509.setNotBefore cert $ addUTCTime (-1) now
+              _ <- X509.setNotAfter cert $ addUTCTime (365 * 24 * 60 * 60) now
+              _ <- X509.signX509 cert privateKey Nothing
 
-          certByteString <- BSUTF8.fromString <$> PEM.writeX509 cert
-          privateKeyByteString <- BSUTF8.fromString <$> PEM.writePKCS8PrivateKey privateKey Nothing
+              certByteString <- BSUTF8.fromString <$> PEM.writeX509 cert
+              privateKeyByteString <- BSUTF8.fromString <$> PEM.writePKCS8PrivateKey privateKey Nothing
 
-          return $ runTLSSocket (tlsSettingsMemory certByteString privateKeyByteString)
+              return $ runTLSSocket (tlsSettingsMemory certByteString privateKeyByteString)
+            Just certDir -> do
+              putStrLn $ "Using certificate information from: " ++ certDir
+              return $ runTLSSocket (tlsSettingsChain (certDir </> "cert.pem") [certDir </> "chain.pem"] (certDir </> "privkey.pem"))
         _ -> return runSettingsSocket
   runner <- prepareRunner
   bracket
@@ -257,6 +265,7 @@ data RunConfig = RunConfig
   , _runConfig_redirectHost :: ByteString
   , _runConfig_redirectPort :: Int
   , _runConfig_retryTimeout :: Int -- seconds
+  , _runConfig_certDir :: Maybe FilePath
   }
 
 defRunConfig :: RunConfig
@@ -265,4 +274,5 @@ defRunConfig = RunConfig
   , _runConfig_redirectHost = "127.0.0.1"
   , _runConfig_redirectPort = 3001
   , _runConfig_retryTimeout = 1
+  , _runConfig_certDir = Nothing
   }


### PR DESCRIPTION
This just adds a -c/--cert option to ob run which takes a path from which to obtain cert.pem/chain.pem/privkey.pem for use in HTTPS, since browsers get annoyed if they know about a proper certificate for a domain and start receiving a self-signed thing.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
     -- Test suite seems broken, but it's broken in a way where I don't think it's my fault here?
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
