### PR TITLE
Fix Universe instance for (Some Void1), which should use UniverseSome

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -1038,8 +1038,8 @@ someSumEncoder = Encoder $ pure $ EncoderImpl
 
 data Void1 :: * -> * where {}
 
-instance Universe (Some Void1) where
-  universe = []
+instance UniverseSome Void1 where
+  universeSome = []
 
 void1Encoder :: (Applicative check, MonadError Text parse) => Encoder check parse (Some Void1) a
 void1Encoder = Encoder $ pure $ EncoderImpl


### PR DESCRIPTION
The current `Universe (Some Void1)` instance overlaps with the instance provided by `universe-dependent-sum`.


<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)