### PR TITLE
Put processed all.js files into an .assets directory

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -78,7 +78,7 @@ in rec {
     cd '${haskellLib.justStaticExecutables frontend}'
     shopt -s globstar
     for f in **/all.js; do
-      dir="$out/$(basename "$(dirname "$f")")"
+      dir="$out/$(basename "$(dirname "$f")").assets"
       mkdir -p "$dir"
       ln -s "$(realpath "$f")" "$dir/all.unminified.js"
       ${if optimizationLevel == null then ''

--- a/default.nix
+++ b/default.nix
@@ -81,7 +81,7 @@ in rec {
     cd '${haskellLib.justStaticExecutables frontend}'
     shopt -s globstar
     for f in **/all.js; do
-      dir="$out/$(basename "$(dirname "$f")").assets"
+      dir="$out/$(basename "$(dirname "$f")")"
       mkdir -p "$dir"
       ln -s "$(realpath "$f")" "$dir/all.unminified.js"
       ${if optimizationLevel == null then ''
@@ -186,7 +186,9 @@ in rec {
       set -eux
       ln -s '${if profiling then backend else haskellLib.justStaticExecutables backend}'/bin/* $out/
       ln -s '${mkAssets assets}' $out/static.assets
-      ln -s '${mkAssets (compressedJs frontend optimizationLevel)}'/* $out
+      for d in '${mkAssets (compressedJs frontend optimizationLevel)}'/*/; do
+        ln -s "$d" "$out"/"$(basename "$d").assets"
+      done
       echo ${version} > $out/version
     '';
 


### PR DESCRIPTION
The consequence of this bug is all.js always 404s on full builds

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
