### PR TITLE
Silence implicit prelude warnings

### DIFF
--- a/lib/command/src/Obelisk/Command/Preprocessor.hs
+++ b/lib/command/src/Obelisk/Command/Preprocessor.hs
@@ -84,8 +84,8 @@ generateHeader origPath packageInfo =
         else pragma $
           TL.fromText "OPTIONS_GHC " <> mconcat (intersperse (TL.fromText " ") (map TL.fromString optList))
     ghcOptList
-      = ([ "Wno-implicit-prelude" ] ++)
-      $ filter (not . (== "Wimplicit-prelude"))
+      = ([ "-Wno-implicit-prelude" ] ++)
+      $ filter (not . (== "-Wimplicit-prelude"))
       $ filter (not . isPrefixOf "-O")
       $ fromMaybe []
       $ lookup GHC (_cabalPackageInfo_compilerOptions packageInfo)

--- a/lib/command/src/Obelisk/Command/Preprocessor.hs
+++ b/lib/command/src/Obelisk/Command/Preprocessor.hs
@@ -84,7 +84,9 @@ generateHeader origPath packageInfo =
         else pragma $
           TL.fromText "OPTIONS_GHC " <> mconcat (intersperse (TL.fromText " ") (map TL.fromString optList))
     ghcOptList
-      = filter (not . isPrefixOf "-O")
+      = ([ "Wno-implicit-prelude" ] ++)
+      $ filter (not . (== "Wimplicit-prelude"))
+      $ filter (not . isPrefixOf "-O")
       $ fromMaybe []
       $ lookup GHC (_cabalPackageInfo_compilerOptions packageInfo)
     optList = _cabalPackageInfo_cppOptions packageInfo <> ghcOptList

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -409,6 +409,7 @@ withGhciScriptArgs packageInfos f = withGhciScript loadPreludeManually packageIn
     loadPreludeManually =
       [ ":add Prelude" -- @:add@ is used because it's less noisy when there is no custom Prelude
       , ":set -XImplicitPrelude" -- Turn the default setting on
+      , ":set -Wno-implicit-prelude" -- Silence any warnings caused by setting ImplicitPrelude 
       ]
 
 -- | Create ghci configuration to load the given packages

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -409,7 +409,6 @@ withGhciScriptArgs packageInfos f = withGhciScript loadPreludeManually packageIn
     loadPreludeManually =
       [ ":add Prelude" -- @:add@ is used because it's less noisy when there is no custom Prelude
       , ":set -XImplicitPrelude" -- Turn the default setting on
-      , ":set -Wno-implicit-prelude" -- Silence any warnings caused by setting ImplicitPrelude 
       ]
 
 -- | Create ghci configuration to load the given packages


### PR DESCRIPTION
`ob` launches `ghci` with some defaults that enable an implicit prelude. When cabal has been configured to warn on an implicit prelude, this results in warnings being generated for every module. This change turns those warnings off.

This means the `ob` suite will be unable to trigger warnings for implicit preludes and projects will have to rely on other tools to reveal the warnings.

(Draft: Does not appear to be working as intended yet)

I have:

  - [X] Based work on latest `develop` branch
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
