### PR TITLE
Fix disabling implicit prelude

### DIFF
--- a/lib/command/src/Obelisk/Command/Preprocessor.hs
+++ b/lib/command/src/Obelisk/Command/Preprocessor.hs
@@ -75,7 +75,7 @@ generateHeader origPath packageInfo =
           ext -> (TL.fromString (show ext) :)
     showExt = \case
       EnableExtension ext -> [TL.fromString (show ext)]
-      DisableExtension _ -> []
+      DisableExtension ext -> ["No" <> TL.fromString (show ext)]
       UnknownExtension ext -> [TL.fromString ext]
 
     ghcOptions =


### PR DESCRIPTION
Setting the `default-extension` `NoImplicitPrelude` in `.cabal` files had no effect. Turning on `-Wimplicit-prelude` revealed `Prelude` still gets loaded implicitly. eg:

```
common/src/Common/Route.hs:1:1: warning: [-Wimplicit-prelude]
    Module `Prelude' implicitly imported
```

Debugging revealed `NoImplicitPrelude` was not being included in the `LANGUAGE` pragma heading added by the `ob` preprocessor. This is because `NoImplicitPrelude` in Cabal is considered to be a [disabling of the `ImplicitPrelude` extension](http://hackage.haskell.org/package/Cabal-3.2.0.0/docs/Language-Haskell-Extension.html) and `ob` was ignoring disabled extensions. This PR adds support for disabled extensions and thus fixes `NoImplicitPrelude`. It should also fix other similarly treated extensions such as `NoMonomorphismRestriction`

I have:

  - [X] Based work on latest `develop` branch
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
