### PR TITLE
Fix Android build by Linux Nix builder on macOS

### DIFF
--- a/skeleton/default.nix
+++ b/skeleton/default.nix
@@ -1,5 +1,6 @@
-{ obelisk ? import ./.obelisk/impl {
-    system = builtins.currentSystem;
+{ system ? builtins.currentSystem
+, obelisk ? import ./.obelisk/impl {
+    inherit system;
     iosSdkVersion = "10.2";
     # You must accept the Android Software Development Kit License Agreement at
     # https://developer.android.com/studio/terms in order to build Android apps.


### PR DESCRIPTION
fix for #813

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
