### PR TITLE
executable-config: Add MonadFail instance for ConfigsT

### DIFF
--- a/lib/executable-config/lookup/src/Obelisk/Configs.hs
+++ b/lib/executable-config/lookup/src/Obelisk/Configs.hs
@@ -22,6 +22,7 @@ import Control.Applicative (Alternative)
 import Control.Monad (MonadPlus)
 import Control.Monad.Base (MonadBase)
 import Control.Monad.Catch (MonadThrow)
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Morph (MFunctor)
@@ -87,6 +88,7 @@ newtype ConfigsT m a = ConfigsT { unConfigsT :: ReaderT (Map Text ByteString) m 
     , Monad
     , MonadPlus
     , Alternative
+    , MonadFail
     , MonadFix
     , MonadThrow
     , MonadIO


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
