### PR TITLE
Resurrect IDE support (VSCode + HLS)

### DIFF
--- a/skeleton/hie.yaml
+++ b/skeleton/hie.yaml
@@ -1,0 +1,8 @@
+cradle:
+  cabal:
+    - path: "./frontend"
+      component: "lib:frontend"
+    - path: "./common"
+      component: "lib:common"
+    - path: "./backend"
+      component: "lib:backend"

--- a/skeleton/shell.nix
+++ b/skeleton/shell.nix
@@ -1,0 +1,1 @@
+(import ./. {}).shells.ghc


### PR DESCRIPTION
With these two files in place, the skeleton works seemlessly on VSCode
with the Haskell plugin that uses haskell-language-server (the extension
downloads it as a static binary).

Just start vscode as `nix-shell --run "code ."`, or use the Nix Env Selector VScode extension (we can automate this by adding a [.vscode folder](https://github.com/srid/neuron/tree/master/.vscode)).


<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
