### PR TITLE
Add catMaybesEncoder

### DIFF
--- a/lib/route/obelisk-route.cabal
+++ b/lib/route/obelisk-route.cabal
@@ -35,7 +35,8 @@ library
                  th-extras,
                  transformers,
                  universe,
-                 universe-dependent-sum
+                 universe-dependent-sum,
+                 witherable
   exposed-modules: Obelisk.Route
                    Obelisk.Route.TH
                    Obelisk.Route.Frontend


### PR DESCRIPTION
This is useful for working with, for example, optional query parameters.


<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)