### PR TITLE
skeleton: Let Frontend:lib depends on reflex-dom-core instead of reflex-dom to reduce closure size

### DIFF
--- a/skeleton/frontend/frontend.cabal
+++ b/skeleton/frontend/frontend.cabal
@@ -10,7 +10,7 @@ library
                , obelisk-frontend
                , obelisk-route
                , jsaddle
-               , reflex-dom
+               , reflex-dom-core
                , obelisk-executable-config-lookup
                , obelisk-generated-static
                , text


### PR DESCRIPTION
This should fix part of the issue from #193.

#193 mentions that the `WebKit` and lots of xwindow libraries is brought into closure by `backend:exe`. By using `nix-tree` we can find that `backend:exe` requires `frontend:lib` and that's the root cause!

Since `frontend:lib` depends on `reflex-dom` and that brings `webkit` into closure, replacing `reflex-dom` with `reflex-dom-core` would fix it. We could using `ob init && nix-store -q --tree $(nix-build -A exe) | egrep "webkit|gtk"` to observe the difference.

With this commit the docker image size changes from 474MB to 150MB.

The reasons I think it's okay to modify is:
- `frontend:lib` didn't use `reflex-dom` at all. [link](https://github.com/obsidiansystems/obelisk/blob/develop/skeleton/frontend/src/Frontend.hs#L17)
- `reflex-dom-core` says that libraries should depends on `reflex-dom-core` instead of `reflex-dom`, that's for the executables. [link](https://github.com/reflex-frp/reflex-dom/blob/d16fa539ac2207b7715fd1f40a3de97424185ee5/reflex-dom-core/reflex-dom-core.cabal#L12)

I have:

  - [x] Based work on latest `develop` branch
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
