### PR TITLE
Turn off hole fits to speed up compilation

### DIFF
--- a/skeleton/backend/backend.cabal
+++ b/skeleton/backend/backend.cabal
@@ -14,11 +14,12 @@ library
                , obelisk-route
   exposed-modules:
     Backend
-  ghc-options: -Wall
+  ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -fno-show-valid-hole-fits
 
 executable backend
   main-is: main.hs
   hs-source-dirs: src-bin
+  ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -threaded -fno-show-valid-hole-fits
   if impl(ghcjs)
     buildable: False
   build-depends: base

--- a/skeleton/common/common.cabal
+++ b/skeleton/common/common.cabal
@@ -9,9 +9,7 @@ library
                , obelisk-route
                , mtl
                , text
-  default-extensions:
-    TypeFamilies
-    PolyKinds
   exposed-modules:
     Common.Api
     Common.Route
+  ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -fno-show-valid-hole-fits

--- a/skeleton/frontend/frontend.cabal
+++ b/skeleton/frontend/frontend.cabal
@@ -9,13 +9,14 @@ library
                , common
                , obelisk-frontend
                , obelisk-route
+               , jsaddle
                , reflex-dom
                , obelisk-executable-config-lookup
                , obelisk-generated-static
                , text
   exposed-modules:
     Frontend
-  ghc-options: -Wall
+  ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -fno-show-valid-hole-fits
 
 executable frontend
   main-is: main.hs
@@ -27,7 +28,9 @@ executable frontend
                , reflex-dom
                , obelisk-generated-static
                , frontend
-  --TODO: Make these ghc-options optional
-  ghc-options: -threaded
+  ghc-options: -threaded -O -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -fno-show-valid-hole-fits
+  if impl(ghcjs)
+    ghc-options: -dedupe
+    cpp-options: -DGHCJS_BROWSER
   if os(darwin)
-     ghc-options: -dynamic
+    ghc-options: -dynamic


### PR DESCRIPTION
Any occurrance of a type hole or undefined identifier that starts with
an underscore causes substantial slowdowns in compilation without this
GHC option.

<!-- Provide a clear overview of your changes. -->

I have:

  - [X] Based work on latest `develop` branch
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
