### PR TITLE
Update to reflex-platform 0.6.2.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ This project's release branch is `master`. This log is written from the perspect
 * [#801](https://github.com/obsidiansystems/obelisk/pull/801): Remove errors and warning for local packages without a library component
 * [#812](https://github.com/obsidiansystems/obelisk/pull/812): Add support for `NoImplicitPrelude` and other extensions disabled via `No`
 * Pinned version bumps:
-  * reflex-platform [0.6.1.0](https://github.com/reflex-frp/reflex-platform/releases/tag/v0.6.1.0)
+  * reflex-platform [0.6.2.0](https://github.com/reflex-frp/reflex-platform/releases/tag/v0.6.2.0)
   * hnix 0.8.0
 
 ## v0.9.0.1

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,7 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "rc/0.6.1.0",
-  "rev": "673c2622b288504bb57006e6b440d5240ce1865c",
-  "sha256": "0ny8dah1s3amvs1h5k8j1zwzmh07a12af833b6g32cxf0qlj3v0l"
+  "branch": "release/0.6.2.0",
+  "private": false,
+  "rev": "efc6d923c633207d18bd4d8cae3e20110a377864",
+  "sha256": "121rmnkx8nwiy96ipfyyv6vrgysv0zpr2br46y70zf4d0y1h1lz5"
 }


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
