### PR TITLE
Autoreload static asset derivations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ This project's release branch is `master`. This log is written from the perspect
   * Migration: All uses of `static @"some/path"` become `$(static "some/path")`. Instead of requiring `TypeApplications` and `DataKinds`, modules calling `static` must now enable `TemplateHaskell`.
   * Deprecation: Deprecate static asset modules generated via 'obelisk-asset-manifest-generate' in favor of modules generated via 'obelisk-asset-th-generate'. The new executable takes the same arguments as the old and should be a drop-in replacement. To preserve the old behavior, set `__deprecated.useObeliskAssetManifestGenerate = true;` in your obelisk project configuration.
   * Feature: Files added to the static directory while `ob run` is active no longer require `ob run` to be restarted
+* When `staticFiles` is a derivation, as opposed to a regular directory, produce a symlink to the result of that derivation at `static.out` and have `ob run` serve static assets from that symlink. This makes is possible for the static asset derivation to be rebuilt and the new results served without restarting `ob run`.
 
 ## v0.9.1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,13 @@
 
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released.
 
+## Unreleased
+
+* Use TemplateHaskell to determine asset file paths
+  * Migration: All uses of `static @"some/path"` become `$(static "some/path")`. Instead of requiring `TypeApplications` and `DataKinds`, modules calling `static` must now enable `TemplateHaskell`.
+  * Deprecation: Deprecate static asset modules generated via 'obelisk-asset-manifest-generate' in favor of modules generated via 'obelisk-asset-th-generate'. The new executable takes the same arguments as the old and should be a drop-in replacement.
+  * Feature: Files added to the static directory while `ob run` is active no longer require `ob run` to be restarted
+
 ## v0.9.1.0
 
 * [#801](https://github.com/obsidiansystems/obelisk/pull/801): Remove errors and warning for local packages without a library component

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,8 @@ This project's release branch is `master`. This log is written from the perspect
   * Migration: All uses of `static @"some/path"` become `$(static "some/path")`. Instead of requiring `TypeApplications` and `DataKinds`, modules calling `static` must now enable `TemplateHaskell`.
   * Deprecation: Deprecate static asset modules generated via 'obelisk-asset-manifest-generate' in favor of modules generated via 'obelisk-asset-th-generate'. The new executable takes the same arguments as the old and should be a drop-in replacement. To preserve the old behavior, set `__deprecated.useObeliskAssetManifestGenerate = true;` in your obelisk project configuration.
   * Feature: Files added to the static directory while `ob run` is active no longer require `ob run` to be restarted
-* When `staticFiles` is a derivation, as opposed to a regular directory, produce a symlink to the result of that derivation at `static.out` and have `ob run` serve static assets from that symlink. This makes is possible for the static asset derivation to be rebuilt and the new results served without restarting `ob run`.
+* Feature: When `staticFiles` is a derivation, as opposed to a regular directory, produce a symlink to the result of that derivation at `static.out` and have `ob run` serve static assets from that symlink. This makes is possible for the static asset derivation to be rebuilt and the new results served without restarting `ob run`.
+* Feature: Rebuild static asset derivations while `ob run` is active as long as the change to the derivation is within the project folder. `ob run` now displays a message ("Static assets rebuilt and symlinked to static.out") whenever static assets have been rebuilt and the new static assets are being served.
 
 ## v0.9.1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ This project's release branch is `master`. This log is written from the perspect
 
 * Use TemplateHaskell to determine asset file paths
   * Migration: All uses of `static @"some/path"` become `$(static "some/path")`. Instead of requiring `TypeApplications` and `DataKinds`, modules calling `static` must now enable `TemplateHaskell`.
-  * Deprecation: Deprecate static asset modules generated via 'obelisk-asset-manifest-generate' in favor of modules generated via 'obelisk-asset-th-generate'. The new executable takes the same arguments as the old and should be a drop-in replacement.
+  * Deprecation: Deprecate static asset modules generated via 'obelisk-asset-manifest-generate' in favor of modules generated via 'obelisk-asset-th-generate'. The new executable takes the same arguments as the old and should be a drop-in replacement. To preserve the old behavior, set `__deprecated.useObeliskAssetManifestGenerate = true;` in your obelisk project configuration.
   * Feature: Files added to the static directory while `ob run` is active no longer require `ob run` to be restarted
 
 ## v0.9.1.0

--- a/default.nix
+++ b/default.nix
@@ -73,7 +73,7 @@ in rec {
     set -euo pipefail
     touch "$out"
     mkdir -p "$symlinked"
-    obelisk-asset-manifest-generate "$src" "$haskellManifest" ${packageName} ${moduleName} "$symlinked"
+    obelisk-asset-th-generate "$src" "$haskellManifest" ${packageName} ${moduleName} "$symlinked"
   '';
 
   compressedJs = frontend: optimizationLevel: pkgs.runCommand "compressedJs" {} ''

--- a/default.nix
+++ b/default.nix
@@ -65,7 +65,7 @@ in rec {
   '';
   nullIfAbsent = p: if lib.pathExists p then p else null;
   #TODO: Avoid copying files within the nix store.  Right now, obelisk-asset-manifest-generate copies files into a big blob so that the android/ios static assets can be imported from there; instead, we should get everything lined up right before turning it into an APK, so that copies, if necessary, only exist temporarily.
-  processAssets = { src, packageName ? "obelisk-generated-static", moduleName ? "Obelisk.Generated.Static" }: pkgs.runCommand "asset-manifest" {
+  processAssets = { src, packageName ? "obelisk-generated-static", moduleName ? "Obelisk.Generated.Static", exe ? "obelisk-asset-th-generate" }: pkgs.runCommand "asset-manifest" {
     inherit src;
     outputs = [ "out" "haskellManifest" "symlinked" ];
     nativeBuildInputs = [ ghcObelisk.obelisk-asset-manifest ];
@@ -73,7 +73,7 @@ in rec {
     set -euo pipefail
     touch "$out"
     mkdir -p "$symlinked"
-    obelisk-asset-th-generate "$src" "$haskellManifest" ${packageName} ${moduleName} "$symlinked"
+    ${exe} "$src" "$haskellManifest" ${packageName} ${moduleName} "$symlinked"
   '';
 
   compressedJs = frontend: optimizationLevel: pkgs.runCommand "compressedJs" {} ''
@@ -237,13 +237,14 @@ in rec {
             , withHoogle ? false # Setting this to `true` makes shell reloading far slower
             , __closureCompilerOptimizationLevel ? "ADVANCED" # Set this to `null` to skip the closure-compiler step
             , __withGhcide ? false
+            , __deprecated ? {}
             }:
             let
               allConfig = nixpkgs.lib.makeExtensible (self: {
                 base = base';
                 inherit args;
                 userSettings = {
-                  inherit android ios packages overrides tools shellToolOverrides withHoogle __closureCompilerOptimizationLevel __withGhcide;
+                  inherit android ios packages overrides tools shellToolOverrides withHoogle __closureCompilerOptimizationLevel __withGhcide __deprecated;
                   staticFiles = if staticFiles == null then self.base + /static else staticFiles;
                 };
                 frontendName = "frontend";
@@ -251,7 +252,12 @@ in rec {
                 commonName = "common";
                 staticName = "obelisk-generated-static";
                 staticFilesImpure = let fs = self.userSettings.staticFiles; in if lib.isDerivation fs then fs else toString fs;
-                processedStatic = processAssets { src = self.userSettings.staticFiles; };
+                processedStatic = processAssets {
+                  src = self.userSettings.staticFiles;
+                  exe = if lib.attrByPath ["userSettings" "__deprecated" "useObeliskAssetManifestGenerate"] false self
+                    then builtins.trace "obelisk-asset-manifest-generate is deprecated. Use obelisk-asset-th-generate instead." "obelisk-asset-manifest-generate"
+                    else "obelisk-asset-th-generate";
+                };
                 # The packages whose names and roles are defined by this package
                 predefinedPackages = lib.filterAttrs (_: x: x != null) {
                   ${self.frontendName} = nullIfAbsent (self.base + "/frontend");

--- a/lib/asset/README.md
+++ b/lib/asset/README.md
@@ -5,7 +5,7 @@
 
 **Efficiently served, aggressively cached static web resources.**
 
-The `assets.nix` file contains nix expressions that are a mutually recursive set of attributes used to create static asset directories with hashable file encodings. This file should be incorporated within your project's `default.nix` file. (See `example/default.nix`, line 2)
+The `assets.nix` file contains nix expressions that are a mutually recursive set of attributes used to create static asset directories with hashable file encodings. This file should be incorporated within your project's `default.nix` file.
 
 ```nix
 { assets ? import ./../assets.nix { inherit nixpkgs; } }:
@@ -19,7 +19,7 @@ In this example, `mkAssets` is used on a directory that has a `.png` file inside
 myAssets = assets.mkAssets ./static;
 ```
 
-Once you have successfully incorporated `assets.nix` into your project's nix file(s), use `nix-build` to generate a symlink of your `mkAssets` expression. The following command from `example/run-example` (line 3) will generate an immutable symlink that holds hashed static assets.
+Once you have successfully incorporated `assets.nix` into your project's nix file(s), use `nix-build` to generate a symlink of your `mkAssets` expression. The following command will generate an immutable symlink that holds hashed static assets.
 
 ```bash
 nix-build -o static.assets -A myAssets

--- a/lib/asset/manifest/obelisk-asset-manifest.cabal
+++ b/lib/asset/manifest/obelisk-asset-manifest.cabal
@@ -27,6 +27,7 @@ library
     , unix-compat
     , vector
   exposed-modules:
+    Obelisk.Asset.Cabal
     Obelisk.Asset.Gather
     Obelisk.Asset.Promoted
     Obelisk.Asset.Symlink
@@ -35,7 +36,7 @@ library
   other-extensions: TemplateHaskell
   ghc-options:
     -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O2
-   -fno-warn-unused-do-bind -funbox-strict-fields -fprof-auto-calls
+    -fno-warn-unused-do-bind -funbox-strict-fields -fprof-auto-calls
 
 executable obelisk-asset-manifest-generate
   hs-source-dirs: src-bin
@@ -43,4 +44,13 @@ executable obelisk-asset-manifest-generate
   build-depends:
       base
     , obelisk-asset-manifest
+    , text
+
+executable obelisk-asset-th-generate
+  hs-source-dirs: src-bin
+  main-is: static-th.hs
+  build-depends:
+      base
+    , obelisk-asset-manifest
+    , filepath
     , text

--- a/lib/asset/manifest/src-bin/static-th.hs
+++ b/lib/asset/manifest/src-bin/static-th.hs
@@ -1,0 +1,59 @@
+import qualified Data.Text as T
+import Obelisk.Asset.Cabal
+import Obelisk.Asset.Gather
+import Obelisk.Asset.Symlink
+import System.Environment
+import System.FilePath
+
+main :: IO ()
+main = do
+  --TODO: Usage
+  [root, haskellTarget, packageName, moduleName, fileTarget] <- getArgs
+  paths <- gatherHashedPaths root
+  writeCabalProject haskellTarget $ SimplePkg
+    { _simplePkg_name = T.pack packageName
+    , _simplePkg_moduleName = T.pack moduleName
+    , _simplePkg_dependencies = map T.pack
+      [ "base"
+      , "filepath"
+      , "obelisk-asset-manifest"
+      , "template-haskell"
+      ]
+    , _simplePkg_moduleContents = T.pack $ unlines
+      [ "{-# Language BangPatterns #-}"
+      , "{-# Language CPP #-}"
+      , "{-# Language OverloadedStrings #-}"
+      , "{-|"
+      , "  Description:"
+      , "    Automatically generated module that provides the 'static' TH function"
+      , "    to generate paths to static assets."
+      , "-}"
+      , "module " <> moduleName <> " ( static ) where"
+      , ""
+      , "import Obelisk.Asset.Gather"
+      , "import Language.Haskell.TH"
+      , "import Language.Haskell.TH.Syntax"
+      , "import System.FilePath"
+      , ""
+      , "-- | Produces a string literal with the hashed path of the file"
+      , "assetPath :: FilePath -> FilePath -> Q Exp"
+      , "assetPath root relativePath = do"
+      , "  qAddDependentFile $ root </> relativePath"
+      , "  LitE . StringL . (prefix</>) <$> runIO (toHashedPath root relativePath)"
+      , ""
+      , "-- | Produces a string literal with the raw (i.e., unhashed) path of the file"
+      , "assetPathRaw :: FilePath -> Q Exp"
+      , "assetPathRaw fp = returnQ $ LitE $ StringL $ prefix </> fp"
+      , ""
+      , "prefix :: FilePath"
+      , "prefix = \"/static\""
+      , ""
+      , "static :: FilePath -> Q Exp"
+      , "#ifdef PASSTHRU"
+      , "static = assetPathRaw"
+      , "#else"
+      , "static = assetPath " <> show root
+      , "#endif"
+      ]
+    }
+  copyAndSymlink paths root fileTarget

--- a/lib/asset/manifest/src-bin/static-th.hs
+++ b/lib/asset/manifest/src-bin/static-th.hs
@@ -15,14 +15,11 @@ main = do
     , _simplePkg_moduleName = T.pack moduleName
     , _simplePkg_dependencies = map T.pack
       [ "base"
-      , "filepath"
       , "obelisk-asset-manifest"
       , "template-haskell"
       ]
     , _simplePkg_moduleContents = T.pack $ unlines
-      [ "{-# Language BangPatterns #-}"
-      , "{-# Language CPP #-}"
-      , "{-# Language OverloadedStrings #-}"
+      [ "{-# Language CPP #-}"
       , "{-|"
       , "  Description:"
       , "    Automatically generated module that provides the 'static' TH function"
@@ -30,29 +27,14 @@ main = do
       , "-}"
       , "module " <> moduleName <> " ( static ) where"
       , ""
-      , "import Obelisk.Asset.Gather"
+      , "import Obelisk.Asset.TH"
       , "import Language.Haskell.TH"
-      , "import Language.Haskell.TH.Syntax"
-      , "import System.FilePath"
-      , ""
-      , "-- | Produces a string literal with the hashed path of the file"
-      , "assetPath :: FilePath -> FilePath -> Q Exp"
-      , "assetPath root relativePath = do"
-      , "  qAddDependentFile $ root </> relativePath"
-      , "  LitE . StringL . (prefix</>) <$> runIO (toHashedPath root relativePath)"
-      , ""
-      , "-- | Produces a string literal with the raw (i.e., unhashed) path of the file"
-      , "assetPathRaw :: FilePath -> Q Exp"
-      , "assetPathRaw fp = returnQ $ LitE $ StringL $ prefix </> fp"
-      , ""
-      , "prefix :: FilePath"
-      , "prefix = \"/static\""
       , ""
       , "static :: FilePath -> Q Exp"
-      , "#ifdef PASSTHRU"
-      , "static = assetPathRaw"
+      , "#ifdef OBELISK_ASSET_PASSTHRU"
+      , "static = staticAssetRaw"
       , "#else"
-      , "static = assetPath " <> show root
+      , "static = staticAssetHashed " <> show root
       , "#endif"
       ]
     }

--- a/lib/asset/manifest/src/Obelisk/Asset/Cabal.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/Cabal.hs
@@ -1,0 +1,42 @@
+{-# Language OverloadedStrings #-}
+module Obelisk.Asset.Cabal where
+
+import qualified Data.List as L
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import System.Directory
+import System.FilePath
+
+-- | A generated single-module package
+data SimplePkg = SimplePkg
+  { _simplePkg_name :: Text
+  , _simplePkg_moduleName :: Text
+  , _simplePkg_moduleContents :: Text
+  , _simplePkg_dependencies :: [Text]
+  }
+
+cabalFile :: SimplePkg -> Text
+cabalFile (SimplePkg packageName moduleName _ deps) = T.unlines
+  [ "name: " <> packageName
+  , "version: 0"
+  , "cabal-version: >= 1.2"
+  , "build-type: Simple"
+  , ""
+  , "library"
+  , "  hs-source-dirs: src"
+  , "  build-depends:"
+  , "    " <> T.intercalate ", " deps
+  , "  exposed-modules: " <> moduleName
+  ]
+
+writeCabalProject :: FilePath -> SimplePkg -> IO ()
+writeCabalProject target pkg = do
+  createDirectoryIfMissing True target
+  T.writeFile (target </> T.unpack (_simplePkg_name pkg) <.> "cabal") $ cabalFile pkg
+  let moduleName = _simplePkg_moduleName pkg
+      (modName', moduleDirPath) = case L.uncons (reverse $ T.splitOn "." moduleName) of
+        Nothing -> error $ "writeStaticProject: invalid module name " <> T.unpack moduleName
+        Just (name, parents) -> (name, target </> "src" </> T.unpack (T.intercalate "/" $ reverse parents))
+  createDirectoryIfMissing True moduleDirPath
+  T.writeFile (moduleDirPath </> T.unpack modName' <.> "hs") $ _simplePkg_moduleContents pkg

--- a/lib/asset/manifest/src/Obelisk/Asset/Gather.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/Gather.hs
@@ -6,21 +6,21 @@ module Obelisk.Asset.Gather
   , toHashedPath
   ) where
 
-import Control.DeepSeq
+import Control.DeepSeq (force)
 import Control.Monad (forM)
-import Data.Bits
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString.Lazy.Builder as LBS
-import Data.Char
-import Data.Digest.Pure.SHA
+import Data.Bits (shift, (.|.), (.&.))
+import qualified Data.ByteString.Lazy as LBS (readFile, toStrict, ByteString, length, index)
+import qualified Data.ByteString.Lazy.Builder as LBS (toLazyByteString, word8)
+import Data.Char (ord)
+import Data.Digest.Pure.SHA (bytestringDigest, sha256)
 import Data.Map (Map)
-import qualified Data.Map as Map
-import qualified Data.Text as T
-import Data.Text.Encoding
-import qualified Data.Vector.Unboxed as UV
-import Data.Word
-import System.FilePath.Posix
-import System.Directory
+import qualified Data.Map as Map (singleton)
+import qualified Data.Text as T (unpack)
+import Data.Text.Encoding (decodeUtf8)
+import qualified Data.Vector.Unboxed as UV ((!), fromList)
+import Data.Word (Word8)
+import System.FilePath.Posix ((</>), splitFileName, normalise)
+import System.Directory (listDirectory, doesFileExist)
 
 -- | Given a path, recursively explore it, creating hashed paths for all files found
 gatherHashedPaths

--- a/lib/asset/manifest/src/Obelisk/Asset/TH.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/TH.hs
@@ -1,9 +1,14 @@
+{-|
+Description:
+  Template Haskell for generating asset paths.
+-}
 module Obelisk.Asset.TH
   ( assetPath
   ) where
 
 import Obelisk.Asset.Gather
 
+import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import System.FilePath.Posix
 

--- a/lib/cliapp/src/Obelisk/CliApp/Logging.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Logging.hs
@@ -44,7 +44,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import GHC.IO.Encoding.Types
-import System.Console.ANSI (Color (Red, Yellow), ColorIntensity (Vivid),
+import System.Console.ANSI (Color (..), ColorIntensity (Vivid),
                             ConsoleIntensity (FaintIntensity), ConsoleLayer (Foreground),
                             SGR (SetColor, SetConsoleIntensity), clearLine)
 import System.Exit (ExitCode (..))
@@ -184,6 +184,8 @@ writeLog withNewLine noColor (WithSeverity severity s) = if T.null s then pure (
       | noColor && severity <= Warning = liftIO $ putFn $ T.pack (show severity) <> ": " <> s
       | not noColor && severity <= Error = TS.putStrWithSGR errorColors h withNewLine s
       | not noColor && severity <= Warning = TS.putStrWithSGR warningColors h withNewLine s
+      | not noColor && severity == Notice = TS.putStrWithSGR noticeColors h withNewLine s
+      | not noColor && severity == Informational = TS.putStrWithSGR infoColors h withNewLine s
       | not noColor && severity >= Debug = TS.putStrWithSGR debugColors h withNewLine s
       | otherwise = liftIO $ putFn s
 
@@ -191,6 +193,8 @@ writeLog withNewLine noColor (WithSeverity severity s) = if T.null s then pure (
     h = if severity <= Error then stderr else stdout
     errorColors = [SetColor Foreground Vivid Red]
     warningColors = [SetColor Foreground Vivid Yellow]
+    infoColors = [SetColor Foreground Vivid Green]
+    noticeColors = [SetColor Foreground Vivid Blue]
     debugColors = [SetConsoleIntensity FaintIntensity]
 
 -- | Allow the user to immediately switch to verbose logging upon pressing a particular key.

--- a/lib/command/obelisk-command.cabal
+++ b/lib/command/obelisk-command.cabal
@@ -20,6 +20,7 @@ library
     , exceptions
     , extra
     , filepath
+    , fsnotify
     , git
     , github
     , here
@@ -39,6 +40,8 @@ library
     , optparse-applicative
     , placeholders
     , process
+    , reflex
+    , reflex-fsnotify
     , shell-escape
     , temporary
     , terminal-size

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -358,6 +358,7 @@ findProjectAssets root = do
 getHaskellManifestProjectPath :: MonadObelisk m => FilePath -> m Text
 getHaskellManifestProjectPath root = fmap T.strip $ readProcessAndLogStderr Debug $ setCwd (Just root) $
   proc nixBuildExePath
-    [ "-E"
+    [ "--no-out-link"
+    , "-E"
     , "(let a = import ./. {}; in a.passthru.processedStatic.haskellManifest)"
     ]

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -347,11 +347,13 @@ findProjectAssets root = do
       ]
   -- Check whether the impure static files are a derivation (and so must be built)
   if isDerivation == "1"
-    then fmap T.strip $ readProcessAndLogStderr Debug $ setCwd (Just root) $ -- Strip whitespace here because nix-build has no --raw option
-      proc nixBuildExePath
-        [ "--no-out-link"
-        , "-E", "(import ./. {}).passthru.staticFilesImpure"
-        ]
+    then do
+      _ <- readProcessAndLogStderr Debug $ setCwd (Just root) $
+        proc nixBuildExePath
+          [ "-o", "static.out"
+          , "-E", "(import ./. {}).passthru.staticFilesImpure"
+          ]
+      pure $ T.pack $ root </> "static.out"
     else readProcessAndLogStderr Debug $ setCwd (Just root) $
       proc nixExePath ["eval", "-f", ".", "passthru.staticFilesImpure", "--raw"]
 

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
 module Obelisk.Command.Project
   ( InitSource (..)
   , findProjectObeliskCommand
@@ -17,12 +20,16 @@ module Obelisk.Command.Project
   , withProjectRoot
   , bashEscape
   , getHaskellManifestProjectPath
+  , AssetSource(..)
+  , describeImpureAssetSource
+  , watchStaticFilesDerivation
   ) where
 
 import Control.Concurrent.MVar (MVar, newMVar, withMVarMasked)
-import Control.Lens ((.~), (?~), (<&>))
+import Control.Lens ((.~), (?~), (<&>), (^.), _3)
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Log
 import Control.Monad.State
 import qualified Data.Aeson as Json
 import qualified Data.ByteString.UTF8 as BSU
@@ -35,14 +42,19 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Traversable (for)
+import Reflex
+import Reflex.FSNotify
+import Reflex.Host.Headless
 import System.Directory
 import System.Environment (lookupEnv)
 import System.FilePath
+import System.FSNotify (defaultConfig)
 import System.IO.Temp
 import System.IO.Unsafe (unsafePerformIO)
 import System.PosixCompat.Files
 import System.PosixCompat.Types
 import System.PosixCompat.User
+import qualified System.Process as Proc
 import Text.ShellEscape (bash, bytes)
 
 import GitHub.Data.GitData (Branch)
@@ -335,7 +347,21 @@ nixShellWithHoogle root isPure shell' command = do
         \})).project.shells.${shell}"
     & nixShellConfig_common . nixCmdConfig_args .~ [ strArg "shell" shell' ]
 
-findProjectAssets :: MonadObelisk m => FilePath -> m Text
+-- | Describes the provenance of static assets (i.e., are they the result of a derivation
+-- that was built, or just a folder full of files.
+data AssetSource = AssetSource_Derivation
+                 | AssetSource_Files
+  deriving (Eq)
+
+-- | Some log messages to make it easier to tell where static files are coming from
+describeImpureAssetSource :: AssetSource -> Text -> Text
+describeImpureAssetSource src path = case src of
+  AssetSource_Files -> "Assets impurely loaded from: " <> path
+  AssetSource_Derivation -> "Assets derivation built and impurely loaded from: " <> path
+
+-- | Determine where the static files of a project are and whether they're plain files or a derivation.
+-- If they are a derivation, that derivation will be built.
+findProjectAssets :: MonadObelisk m => FilePath -> m (AssetSource, Text)
 findProjectAssets root = do
   isDerivation <- readProcessAndLogStderr Debug $ setCwd (Just root) $
     proc nixExePath
@@ -349,14 +375,13 @@ findProjectAssets root = do
   if isDerivation == "1"
     then do
       _ <- readProcessAndLogStderr Debug $ setCwd (Just root) $
-        proc nixBuildExePath
-          [ "-o", "static.out"
-          , "-E", "(import ./. {}).passthru.staticFilesImpure"
-          ]
-      pure $ T.pack $ root </> "static.out"
-    else readProcessAndLogStderr Debug $ setCwd (Just root) $
+        proc nixBuildExePath staticFilesDrvSymlinkArgs
+
+      pure (AssetSource_Derivation, T.pack $ root </> "static.out")
+    else fmap (AssetSource_Files,) $ readProcessAndLogStderr Debug $ setCwd (Just root) $
       proc nixExePath ["eval", "-f", ".", "passthru.staticFilesImpure", "--raw"]
 
+-- | Get the nix store path to the generated static asset manifest module (e.g., "obelisk-generated-static")
 getHaskellManifestProjectPath :: MonadObelisk m => FilePath -> m Text
 getHaskellManifestProjectPath root = fmap T.strip $ readProcessAndLogStderr Debug $ setCwd (Just root) $
   proc nixBuildExePath
@@ -364,3 +389,43 @@ getHaskellManifestProjectPath root = fmap T.strip $ readProcessAndLogStderr Debu
     , "-E"
     , "(let a = import ./. {}; in a.passthru.processedStatic.haskellManifest)"
     ]
+
+staticFilesDrvSymlinkArgs :: [String]
+staticFilesDrvSymlinkArgs =
+  [ "-o", "static.out"
+  , "-E", "(import ./. {}).passthru.staticFilesImpure"
+  ]
+
+-- | Watch the project directory for file changes and check whether those file changes
+-- cause changes in the static files nix derivation. If so, rebuild it.
+watchStaticFilesDerivation
+  :: MonadObelisk m
+  => FilePath
+  -> m ()
+watchStaticFilesDerivation root = do
+  cfg <- getCliConfig
+  drv0 <- liftIO runShowDrv
+  liftIO $ runHeadlessApp $ do
+    pb <- getPostBuild
+    checkForChanges <- watchDirectoryTree defaultConfig (root <$ pb) (const True)
+    drv <- performEvent $ liftIO runShowDrv <$ checkForChanges
+    drvs <- foldDyn (\new (_, old, _) -> (old, new, old /= new)) (drv0, drv0, False) drv
+    out <- throttleBatchWithLag
+      (\e -> performEvent $ ffor e $ \_ -> liftIO $ void runDrvBuild)
+      (void $ ffilter (^._3) $ updated drvs)
+    performEvent_ $ ffor out $ \_ ->
+      runCli cfg $
+        putLog Informational "Static assets rebuilt and symlinked to static.out"
+    pure never
+  where
+    showDrv :: Proc.CreateProcess
+    showDrv = (Proc.proc nixExePath
+      [ "show-derivation"
+      , "-f", "."
+      , "passthru.staticFilesImpure"
+      ]) { Proc.cwd = Just root }
+    runShowDrv :: IO String
+    runShowDrv = Proc.readCreateProcess showDrv ""
+    runDrvBuild :: IO String
+    runDrvBuild = Proc.readCreateProcess
+      ((Proc.proc nixBuildExePath staticFilesDrvSymlinkArgs) { Proc.cwd = Just root }) ""

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -16,6 +16,7 @@ module Obelisk.Command.Project
   , toObeliskDir
   , withProjectRoot
   , bashEscape
+  , getHaskellManifestProjectPath
   ) where
 
 import Control.Concurrent.MVar (MVar, newMVar, withMVarMasked)
@@ -353,3 +354,10 @@ findProjectAssets root = do
         ]
     else readProcessAndLogStderr Debug $ setCwd (Just root) $
       proc nixExePath ["eval", "-f", ".", "passthru.staticFilesImpure", "--raw"]
+
+getHaskellManifestProjectPath :: MonadObelisk m => FilePath -> m Text
+getHaskellManifestProjectPath root = fmap T.strip $ readProcessAndLogStderr Debug $ setCwd (Just root) $
+  proc nixBuildExePath
+    [ "-E"
+    , "(let a = import ./. {}; in a.passthru.processedStatic.haskellManifest)"
+    ]

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -60,7 +60,7 @@ import Text.ShellEscape (bash, bytes)
 import GitHub.Data.GitData (Branch)
 import GitHub.Data.Name (Name)
 
-import Obelisk.App (MonadObelisk)
+import Obelisk.App (MonadObelisk, runObelisk, getObelisk)
 import Obelisk.CliApp
 import Obelisk.Command.Nix
 import Obelisk.Command.Thunk
@@ -374,9 +374,7 @@ findProjectAssets root = do
   -- Check whether the impure static files are a derivation (and so must be built)
   if isDerivation == "1"
     then do
-      _ <- readProcessAndLogStderr Debug $ setCwd (Just root) $
-        proc nixBuildExePath staticFilesDrvSymlinkArgs
-
+      _ <- buildStaticFilesDerivationAndSymlink root
       pure (AssetSource_Derivation, T.pack $ root </> "static.out")
     else fmap (AssetSource_Files,) $ readProcessAndLogStderr Debug $ setCwd (Just root) $
       proc nixExePath ["eval", "-f", ".", "passthru.staticFilesImpure", "--raw"]
@@ -390,42 +388,47 @@ getHaskellManifestProjectPath root = fmap T.strip $ readProcessAndLogStderr Debu
     , "(let a = import ./. {}; in a.passthru.processedStatic.haskellManifest)"
     ]
 
-staticFilesDrvSymlinkArgs :: [String]
-staticFilesDrvSymlinkArgs =
-  [ "-o", "static.out"
-  , "-E", "(import ./. {}).passthru.staticFilesImpure"
-  ]
-
 -- | Watch the project directory for file changes and check whether those file changes
 -- cause changes in the static files nix derivation. If so, rebuild it.
 watchStaticFilesDerivation
-  :: MonadObelisk m
+  :: (MonadIO m, MonadObelisk m)
   => FilePath
   -> m ()
 watchStaticFilesDerivation root = do
-  cfg <- getCliConfig
-  drv0 <- liftIO runShowDrv
+  ob <- getObelisk
+  drv0 <- showDerivation
   liftIO $ runHeadlessApp $ do
     pb <- getPostBuild
     checkForChanges <- watchDirectoryTree defaultConfig (root <$ pb) (const True)
-    drv <- performEvent $ liftIO runShowDrv <$ checkForChanges
+    drv <- performEvent $ ffor checkForChanges $ \_ ->
+      liftIO $ runObelisk ob showDerivation
     drvs <- foldDyn (\new (_, old, _) -> (old, new, old /= new)) (drv0, drv0, False) drv
     out <- throttleBatchWithLag
-      (\e -> performEvent $ ffor e $ \_ -> liftIO $ void runDrvBuild)
+      (\e -> performEvent $ ffor e $ \_ -> liftIO $ runObelisk ob $
+        buildStaticFilesDerivationAndSymlink root >> pure ())
       (void $ ffilter (^._3) $ updated drvs)
-    performEvent_ $ ffor out $ \_ ->
-      runCli cfg $
-        putLog Informational "Static assets rebuilt and symlinked to static.out"
+    performEvent_ $ ffor out $ \_ -> runObelisk ob $
+      putLog Notice "Static assets rebuilt and symlinked to static.out"
     pure never
   where
-    showDrv :: Proc.CreateProcess
-    showDrv = (Proc.proc nixExePath
-      [ "show-derivation"
-      , "-f", "."
-      , "passthru.staticFilesImpure"
-      ]) { Proc.cwd = Just root }
-    runShowDrv :: IO String
-    runShowDrv = Proc.readCreateProcess showDrv ""
-    runDrvBuild :: IO String
-    runDrvBuild = Proc.readCreateProcess
-      ((Proc.proc nixBuildExePath staticFilesDrvSymlinkArgs) { Proc.cwd = Just root }) ""
+    showDerivation :: MonadObelisk m => m Text
+    showDerivation = readProcessAndLogStderr Debug $
+      setCwd (Just root) $ ProcessSpec
+        { _processSpec_createProcess = Proc.proc nixExePath
+          [ "show-derivation"
+          , "-f", "."
+          , "passthru.staticFilesImpure"
+          ]
+        , _processSpec_overrideEnv = Nothing
+        }
+
+buildStaticFilesDerivationAndSymlink :: MonadObelisk m => FilePath -> m Text
+buildStaticFilesDerivationAndSymlink root = readProcessAndLogStderr Debug $
+  setCwd (Just root) $ ProcessSpec
+    { _processSpec_createProcess = Proc.proc
+        nixBuildExePath
+        [ "-o", "static.out"
+        , "-E", "(import ./. {}).passthru.staticFilesImpure"
+        ]
+    , _processSpec_overrideEnv = Nothing
+    }

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -460,7 +460,7 @@ getGhciSessionSettings (toList -> packageInfos) pathBase useRelativePaths = do
 
   pure
     $  baseGhciOptions
-    <> ["-DPASSTHRU"] -- For passthrough static assets
+    <> ["-DOBELISK_ASSET_PASSTHRU"] -- For passthrough static assets
     <> ["-F", "-pgmF", selfExe, "-optF", preprocessorIdentifier]
     <> concatMap (\p -> ["-optF", p]) pkgFiles
     <> [ "-i" <> intercalate ":" (concatMap toList pkgSrcPaths) ]

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -77,7 +77,7 @@ import Obelisk.CliApp (
     withSpinner,
   )
 import Obelisk.Command.Nix
-import Obelisk.Command.Project (nixShellWithoutPkgs, withProjectRoot, findProjectAssets, bashEscape)
+import Obelisk.Command.Project (nixShellWithoutPkgs, withProjectRoot, findProjectAssets, bashEscape, getHaskellManifestProjectPath)
 import Obelisk.Command.Thunk (attrCacheFileName)
 import Obelisk.Command.Utils (findExePath, ghcidExePath)
 
@@ -164,8 +164,9 @@ run :: MonadObelisk m => FilePath -> PathTree Interpret -> m ()
 run root interpretPaths = do
   pkgs <- getParsedLocalPkgs root interpretPaths
   assets <- findProjectAssets root
+  manifestPkg <- parsePackagesOrFail . (:[]) . T.unpack =<< getHaskellManifestProjectPath root
   putLog Debug $ "Assets impurely loaded from: " <> assets
-  ghciArgs <- getGhciSessionSettings pkgs root True
+  ghciArgs <- getGhciSessionSettings (pkgs <> manifestPkg) root True
   freePort <- getFreePort
   withGhciScriptArgs pkgs $ \dotGhciArgs -> do
     runGhcid root True (ghciArgs <> dotGhciArgs) pkgs $ Just $ unwords
@@ -400,7 +401,8 @@ withGhciScriptArgs
   => f CabalPackageInfo -- ^ List of packages to load into ghci
   -> ([String] -> m ()) -- ^ Action to run with the extra ghci arguments
   -> m ()
-withGhciScriptArgs packageInfos f = withGhciScript loadPreludeManually packageInfos $ \fp -> f ["-XNoImplicitPrelude", "-ghci-script", fp]
+withGhciScriptArgs packageInfos f = withGhciScript loadPreludeManually packageInfos $ \fp ->
+  f ["-XNoImplicitPrelude", "-ghci-script", fp]
   where
     -- These lines must be first and allow the session to support a custom Prelude when @-XNoImplicitPrelude@
     -- is passed to the ghci session.
@@ -458,6 +460,7 @@ getGhciSessionSettings (toList -> packageInfos) pathBase useRelativePaths = do
 
   pure
     $  baseGhciOptions
+    <> ["-DPASSTHRU"] -- For passthrough static assets
     <> ["-F", "-pgmF", selfExe, "-optF", preprocessorIdentifier]
     <> concatMap (\p -> ["-optF", p]) pkgFiles
     <> [ "-i" <> intercalate ":" (concatMap toList pkgSrcPaths) ]

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -223,7 +223,12 @@ getLocalPkgs root interpretPaths = do
   let rootsAndExclusions = calcIntepretFinds "" interpretPaths
 
   fmap fold $ for (MMap.toAscList rootsAndExclusions) $ \(interpretPathRoot, exclusions) ->
-    let allExclusions = obeliskPackageExclusions <> exclusions <> Set.singleton ("*" </> attrCacheFileName)
+    let allExclusions = obeliskPackageExclusions
+          <> exclusions
+          <> Set.singleton ("*" </> attrCacheFileName)
+          <> Set.singleton ("*" </> "lib/asset/manifest") -- NB: obelisk-asset-manifest is excluded because it generates
+                                                          -- a module that in turn imports it. This will cause ob run to
+                                                          -- fail in its current implementation.
     in fmap (Set.fromList . map normalise) $ runFind $
       ["-L", interpretPathRoot, "(", "-name", "*.cabal", "-o", "-name", Hpack.packageConfig, ")", "-a", "-type", "f"]
       <> concat [["-not", "-path", p </> "*"] | p <- toList allExclusions]

--- a/skeleton/frontend/src/Frontend.hs
+++ b/skeleton/frontend/src/Frontend.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Frontend where
 
@@ -27,7 +26,7 @@ frontend :: Frontend (R FrontendRoute)
 frontend = Frontend
   { _frontend_head = do
       el "title" $ text "Obelisk Minimal Example"
-      elAttr "link" ("href" =: static @"main.css" <> "type" =: "text/css" <> "rel" =: "stylesheet") blank
+      elAttr "link" ("href" =: $(static "main.css") <> "type" =: "text/css" <> "rel" =: "stylesheet") blank
   , _frontend_body = do
       el "h1" $ text "Welcome to Obelisk!"
       el "p" $ text $ T.pack commonStuff
@@ -38,7 +37,7 @@ frontend = Frontend
       -- print "Hello, World!" on the client.
       prerender_ blank $ liftJSM $ void $ eval ("console.log('Hello, World!')" :: T.Text)
 
-      elAttr "img" ("src" =: static @"obelisk.jpg") blank
+      elAttr "img" ("src" =: $(static "obelisk.jpg")) blank
       el "div" $ do
         exampleConfig <- getConfig "common/example"
         case exampleConfig of


### PR DESCRIPTION
On top of #830 

Provides automatic reloading of a staticFiles derivation without restarting ob run.

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
