### PR TITLE
Allow body widget to return a dynamic for consumption in head widget

### DIFF
--- a/lib/backend/src/Obelisk/Backend.hs
+++ b/lib/backend/src/Obelisk/Backend.hs
@@ -79,9 +79,9 @@ data BackendConfig frontendRoute = BackendConfig
   } deriving (Generic)
 
 -- | The static assets provided must contain a compiled GHCJS app that corresponds exactly to the Frontend provided
-data GhcjsApp route = GhcjsApp
+data GhcjsApp route a = GhcjsApp
   { _ghcjsApp_compiled :: !StaticAssets
-  , _ghcjsApp_value :: !(Frontend route)
+  , _ghcjsApp_value :: !(Frontend route a)
   } deriving (Generic)
 
 -- | Widgets used to load all.js on the frontend
@@ -108,7 +108,7 @@ serveDefaultObeliskApp
   => (R appRoute -> Text)
   -> GhcjsWidgets (FrontendWidgetT (R appRoute) ())
   -> ([Text] -> m ())
-  -> Frontend (R appRoute)
+  -> Frontend (R appRoute) a
   -> Map Text ByteString
   -> R (ObeliskRoute appRoute)
   -> m ()
@@ -172,7 +172,7 @@ serveObeliskApp
   => (R appRoute -> Text)
   -> GhcjsWidgets (FrontendWidgetT (R appRoute) ())
   -> ([Text] -> m ())
-  -> GhcjsApp (R appRoute)
+  -> GhcjsApp (R appRoute) a
   -> Map Text ByteString
   -> R (ObeliskRoute appRoute)
   -> m ()
@@ -208,7 +208,7 @@ serveGhcjsApp
   :: (MonadSnap m, HasCookies m, MonadFail m)
   => (R appRouteComponent -> Text)
   -> GhcjsWidgets (FrontendWidgetT (R appRouteComponent) ())
-  -> GhcjsApp (R appRouteComponent)
+  -> GhcjsApp (R appRouteComponent) a
   -> Map Text ByteString
   -> R (GhcjsAppRoute appRouteComponent)
   -> m ()
@@ -224,14 +224,14 @@ defaultBackendConfig :: BackendConfig frontendRoute
 defaultBackendConfig = BackendConfig runSnapWithCommandLineArgs defaultStaticAssets defaultGhcjsWidgets
 
 -- | Run an obelisk backend with the default configuration.
-runBackend :: Backend backendRoute frontendRoute -> Frontend (R frontendRoute) -> IO ()
+runBackend :: Backend backendRoute frontendRoute -> Frontend (R frontendRoute) a -> IO ()
 runBackend = runBackendWith defaultBackendConfig
 
 -- | Run an obelisk backend with the given configuration.
 runBackendWith
   :: BackendConfig frontendRoute
   -> Backend backendRoute frontendRoute
-  -> Frontend (R frontendRoute)
+  -> Frontend (R frontendRoute) a
   -> IO ()
 runBackendWith (BackendConfig runSnap staticAssets ghcjsWidgets) backend frontend = case checkEncoder $ _backend_routeEncoder backend of
   Left e -> fail $ "backend error:\n" <> T.unpack e
@@ -255,7 +255,7 @@ renderGhcjsFrontend
   -> GhcjsWidgets (FrontendWidgetT route ())
   -> route
   -> Map Text ByteString
-  -> Frontend route
+  -> Frontend route a
   -> m ByteString
 renderGhcjsFrontend urlEnc ghcjsWidgets route configs f = do
   cookies <- askCookies

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -80,7 +80,7 @@ run
   :: Int -- ^ Port to run the backend
   -> ([Text] -> Snap ()) -- ^ Static asset handler
   -> Backend backendRoute frontendRoute -- ^ Backend
-  -> Frontend (R frontendRoute) -- ^ Frontend
+  -> Frontend (R frontendRoute) a -- ^ Frontend
   -> IO ()
 run port serveStaticAsset backend frontend = do
   prettifyOutput
@@ -121,7 +121,7 @@ getConfigRoute configs = case Map.lookup "common/route" configs of
 runWidget
   :: RunConfig
   -> Map Text ByteString
-  -> Frontend (R frontendRoute)
+  -> Frontend (R frontendRoute) a
   -> Encoder Identity Identity (R (FullRoute backendRoute frontendRoute)) PageName
   -> IO ()
 runWidget conf configs frontend validFullEncoder = do
@@ -164,10 +164,10 @@ runWidget conf configs frontend validFullEncoder = do
         runner settings skt app)
 
 obeliskApp
-  :: forall frontendRoute backendRoute
+  :: forall frontendRoute backendRoute a
   .  Map Text ByteString
   -> ConnectionOptions
-  -> Frontend (R frontendRoute)
+  -> Frontend (R frontendRoute) a
   -> Encoder Identity Identity (R (FullRoute backendRoute frontendRoute)) PageName
   -> URI
   -> Application
@@ -203,7 +203,7 @@ renderJsaddleFrontend
   -> Cookies
   -> (route -> Text)
   -> route
-  -> Frontend route
+  -> Frontend route a
   -> IO ByteString
 renderJsaddleFrontend configs cookies urlEnc r f =
   let jsaddleScript = elAttr "script" ("src" =: "/jsaddle/jsaddle.js") blank


### PR DESCRIPTION
This change allows the head widget to dynamically render based on what the body will later return. `Frontend route` now becomes `Frontend route a`, allowing the `_frontend_body` widget to return a `Dynamic t a` which gets passed as an argument to `_frontend_head`. This allows common use cases like setting `<head>`'s `<title>` element whose value can only be determined by, say, some Xhr request (using [reflex-gadt-api](https://github.com/reflex-frp/reflex-gadt-api) for example) made in an inner body widget.

I'm opening this PR to initiate discussion, esp. on whether this is the right solution to the aforementioned problem.

Example usage:

```haskell
frontend :: Frontend (R FrontendRoute) (Maybe Text)
frontend =
  Frontend
    { _frontend_head = \titDyn -> do
        el "title" $ do 
          dynText $ fromMaybe "Home" <$> titDyn
          text " - MyApp",
      _frontend_body = do
        myAppWidget
    }
```

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
