### PR TITLE
Fix project shells

### DIFF
--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -12,9 +12,9 @@ module Obelisk.Command.Project
   , initProject
   , nixShellRunConfig
   , nixShellRunProc
-  , obShellRunProc
   , nixShellWithHoogle
   , nixShellWithoutPkgs
+  , mkObNixShellProc
   , obeliskDirName
   , toImplDir
   , toObeliskDir
@@ -318,8 +318,29 @@ bashEscape = BSU.toString . bytes . bash . BSU.fromString
 nixShellRunProc :: NixShellConfig -> ProcessSpec
 nixShellRunProc cfg = setDelegateCtlc True $ proc nixShellPath $ runNixShellConfig cfg
 
-obShellRunProc :: FilePath -> Text -> ProcessSpec
-obShellRunProc root cmd = setDelegateCtlc True $ setCwd (Just root) $ proc "ob" ["shell", T.unpack cmd]
+mkObNixShellProc
+  :: MonadObelisk m
+  => FilePath -- ^ Path to project root
+  -> Bool -- ^ Should this be a pure shell?
+  -> Bool -- ^ Should we chdir to the package root in the shell?
+  -> Map Text FilePath -- ^ Package names mapped to their paths
+  -> String -- ^ Shell attribute to use (e.g. @"ghc"@, @"ghcjs"@, etc.)
+  -> Maybe String -- ^ If 'Just' run the given command; otherwise just open the interactive shell
+  -> m ProcessSpec
+mkObNixShellProc root isPure chdirToRoot packageNamesAndPaths shellAttr command = do
+  packageNamesAndAbsPaths <- liftIO $ for packageNamesAndPaths makeAbsolute
+  defShellConfig <- nixShellRunConfig root isPure command
+  let setCwd_ = if chdirToRoot then setCwd (Just root) else id
+  pure $ setCwd_ $ nixShellRunProc $ defShellConfig
+    & nixShellConfig_common . nixCmdConfig_target . target_expr ?~
+        "{root, pkgs, shell}: ((import root {}).passthru.__unstable__.self.extend (_: _: {\
+          \shellPackages = builtins.fromJSON pkgs;\
+        \})).project.shells.${shell}"
+    & nixShellConfig_common . nixCmdConfig_args .~
+        [ rawArg "root" $ toNixPath $ if chdirToRoot then "." else root
+        , strArg "pkgs" (T.unpack $ decodeUtf8 $ BSL.toStrict $ Json.encode packageNamesAndAbsPaths)
+        , strArg "shell" shellAttr
+        ]
 
 nixShellWithoutPkgs
   :: MonadObelisk m
@@ -331,19 +352,7 @@ nixShellWithoutPkgs
   -> Maybe String -- ^ If 'Just' run the given command; otherwise just open the interactive shell
   -> m ()
 nixShellWithoutPkgs root isPure chdirToRoot packageNamesAndPaths shellAttr command = do
-  packageNamesAndAbsPaths <- liftIO $ for packageNamesAndPaths makeAbsolute
-  defShellConfig <- nixShellRunConfig root isPure command
-  let setCwd_ = if chdirToRoot then setCwd (Just root) else id
-  runProcess_ $ setCwd_ $ nixShellRunProc $ defShellConfig
-    & nixShellConfig_common . nixCmdConfig_target . target_expr ?~
-        "{root, pkgs, shell}: ((import root {}).passthru.__unstable__.self.extend (_: _: {\
-          \shellPackages = builtins.fromJSON pkgs;\
-        \})).project.shells.${shell}"
-    & nixShellConfig_common . nixCmdConfig_args .~
-        [ rawArg "root" $ toNixPath $ if chdirToRoot then "." else root
-        , strArg "pkgs" (T.unpack $ decodeUtf8 $ BSL.toStrict $ Json.encode packageNamesAndAbsPaths)
-        , strArg "shell" shellAttr
-        ]
+  runProcess_ =<< mkObNixShellProc root isPure chdirToRoot packageNamesAndPaths shellAttr command
 
 nixShellWithHoogle :: MonadObelisk m => FilePath -> Bool -> String -> Maybe String -> m ()
 nixShellWithHoogle root isPure shell' command = do

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -12,6 +12,7 @@ module Obelisk.Command.Project
   , initProject
   , nixShellRunConfig
   , nixShellRunProc
+  , obShellRunProc
   , nixShellWithHoogle
   , nixShellWithoutPkgs
   , obeliskDirName
@@ -316,6 +317,9 @@ bashEscape = BSU.toString . bytes . bash . BSU.fromString
 
 nixShellRunProc :: NixShellConfig -> ProcessSpec
 nixShellRunProc cfg = setDelegateCtlc True $ proc nixShellPath $ runNixShellConfig cfg
+
+obShellRunProc :: FilePath -> Text -> ProcessSpec
+obShellRunProc root cmd = setDelegateCtlc True $ setCwd (Just root) $ proc "ob" ["shell", T.unpack cmd]
 
 nixShellWithoutPkgs
   :: MonadObelisk m

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -523,13 +523,12 @@ loadPackageIndex root = do
   liftIO $ getInstalledPackages Verbosity.silent compiler [GlobalPackageDB] programDb
   where
     getPathInNixEnvironment cmd = do
-      procSpec <- runProc <$> nixShellRunConfig root True (Just cmd)
-      (_,Just h,_,_) <- createProcess_ "loadPackageIndex" procSpec
+      (_,Just h,_,_) <- createProcess_ "loadPackageIndex" $ procSpec cmd
       path <- liftIO $ hGetLine h >>= canonicalizePath
       liftIO $ hClose h
       pure path
-    runProc =
-      overCreateProcess (\cs -> cs { std_out = CreatePipe }) . nixShellRunProc
+    procSpec =
+      overCreateProcess (\cs -> cs { std_out = CreatePipe }) . obShellRunProc root
 
 baseGhciOptions :: [String]
 baseGhciOptions =

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -72,16 +72,12 @@ import System.Directory
 import System.Environment (getExecutablePath)
 import System.FilePath
 import qualified System.Info
-import System.IO (hClose, hGetLine)
 import System.IO.Temp (withSystemTempDirectory)
-import System.Process (CreateProcess (..), StdStream (..))
 
 import Obelisk.App (MonadObelisk, getObelisk, runObelisk)
 import Obelisk.CliApp (
     Severity (..),
-    createProcess_,
     failWith,
-    overCreateProcess,
     proc,
     putLog,
     readCreateProcessWithExitCode,
@@ -481,7 +477,7 @@ getGhciSessionSettings (toList -> packageInfos) pathBase useRelativePaths = do
   -- all paths to 'pathBase'.
   selfExe <- liftIO $ canonicalizePath =<< getExecutablePath
   canonicalPathBase <- liftIO $ canonicalizePath pathBase
-  installedPackageIndex <- loadPackageIndex pathBase
+  installedPackageIndex <- loadPackageIndex packageInfos pathBase
 
   (pkgFiles, pkgSrcPaths :: [NonEmpty FilePath]) <- fmap unzip $ liftIO $ for packageInfos $ \pkg -> do
     canonicalSrcDirs <- traverse canonicalizePath $ (_cabalPackageInfo_packageRoot pkg </>) <$> _cabalPackageInfo_sourceDirs pkg
@@ -514,8 +510,8 @@ getGhciSessionSettings (toList -> packageInfos) pathBase useRelativePaths = do
         _ -> error $ "Couldn't resolve dependency for " <> prettyShow dep
 
 -- Load the package index used by the GHC in this path's nix project
-loadPackageIndex :: (MonadObelisk m) => FilePath -> m InstalledPackageIndex
-loadPackageIndex root = do
+loadPackageIndex :: MonadObelisk m => [CabalPackageInfo] -> FilePath -> m InstalledPackageIndex
+loadPackageIndex packageInfos root = do
   ghcPath <- getPathInNixEnvironment "bash -c 'type -p ghc'"
   ghcPkgPath <- getPathInNixEnvironment "bash -c 'type -p ghc-pkg'"
   (compiler, _platform, programDb) <- liftIO
@@ -523,12 +519,8 @@ loadPackageIndex root = do
   liftIO $ getInstalledPackages Verbosity.silent compiler [GlobalPackageDB] programDb
   where
     getPathInNixEnvironment cmd = do
-      (_,Just h,_,_) <- createProcess_ "loadPackageIndex" $ procSpec cmd
-      path <- liftIO $ hGetLine h >>= canonicalizePath
-      liftIO $ hClose h
-      pure path
-    procSpec =
-      overCreateProcess (\cs -> cs { std_out = CreatePipe }) . obShellRunProc root
+      path <- readProcessAndLogStderr Debug =<< mkObNixShellProc root False True (packageInfoToNamePathMap packageInfos) "ghc" (Just cmd)
+      liftIO $ canonicalizePath $ T.unpack $ T.strip path
 
 baseGhciOptions :: [String]
 baseGhciOptions =


### PR DESCRIPTION
Search for dependencies inside `ob shell` as a tentative solution for fixing ob run/repl/watch.
I'm not really sure what the existing behavior is supposed to be, but `nixShellRunConfig` ends up failing on linux with
```
error: iOS builds are not supported on this platform.
ob: fd:11: hGetLine: end of file
```
and likewise on mac for Android. So does running `nix-shell` when there's only a `default.nix`. This is probably not a problem if one has remote builders setup for the other platform.

It seems like having a `shell.nix` that uses `shells.ghc` gets ob run/etc working *if* the project contains backend/frontend/common and no other packages. In particular, in obelisk/skeleton we get 
```
ob: Couldn't resolve dependency for logging-effect -any
CallStack (from HasCallStack):
  error, called at src/Obelisk/Command/Run.hs:514:14 in obelisk-command-0.9.0.1-GmAsx8iwxzhBQBzbMewBj8:Obelisk.Command.Run
```
`logging-effect` is an indirect dependency of (at least) `obelisk-command`

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
