### PR TITLE
Bump reflex-platform to get reflex-0.8.1.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ This project's release branch is `master`. This log is written from the perspect
 
 ## Unreleased
 
+* Update reflex-platform to v0.7.1.0
 * Fix bug [#790](https://github.com/obsidiansystems/obelisk/issues/790) which prevented CSS file loading on ios
 * Use TemplateHaskell to determine asset file paths
   * Migration: All uses of `static @"some/path"` become `$(static "some/path")`. Instead of requiring `TypeApplications` and `DataKinds`, modules calling `static` must now enable `TemplateHaskell`.

--- a/dep/logging-effect/default.nix
+++ b/dep/logging-effect/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/logging-effect/github.json
+++ b/dep/logging-effect/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "ocharles",
+  "repo": "logging-effect",
+  "private": false,
+  "rev": "efc856b62aec15f0087be0edb7ba621ed49b0bb1",
+  "sha256": "13nr3zw39415js1af2vd322vhzwqb2rkrv7b5lkd97h211d7zbj9"
+}

--- a/dep/logging-effect/thunk.nix
+++ b/dep/logging-effect/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -3,6 +3,6 @@
   "repo": "reflex-platform",
   "branch": "aa/reflex-0.8.1.0",
   "private": false,
-  "rev": "768fbc11efc6d1bd9245d06b2597d9c58044942b",
-  "sha256": "06s3jj795pgl8zsnng9yjahh8mnwqrf95zrldsz5rnvxdvzl3mnf"
+  "rev": "0cf69c9352b5528942dcc19b0b9f88a49ae47930",
+  "sha256": "1a0hdgcwnjp04rzzqigjwbz20ss7n1lqzdg0mm8kpc74ynh86vrp"
 }

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -3,6 +3,6 @@
   "repo": "reflex-platform",
   "branch": "aa/reflex-0.8.1.0",
   "private": false,
-  "rev": "31927e7b6cbd87053aac819caa822a0b5bc57d7a",
-  "sha256": "1wr0f18msciddla8jw2dqgyzfbwzz7v7kw4mclpdhmzxkf7x94gd"
+  "rev": "768fbc11efc6d1bd9245d06b2597d9c58044942b",
+  "sha256": "06s3jj795pgl8zsnng9yjahh8mnwqrf95zrldsz5rnvxdvzl3mnf"
 }

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "aa/reflex-0.8.1.0",
+  "branch": "release/0.7.1.0",
   "private": false,
-  "rev": "0cf69c9352b5528942dcc19b0b9f88a49ae47930",
-  "sha256": "1a0hdgcwnjp04rzzqigjwbz20ss7n1lqzdg0mm8kpc74ynh86vrp"
+  "rev": "95ab759c0f12b10d0d012e5a7762321c80e721e4",
+  "sha256": "1k99nadp3m4xjzl52pm39ijkd6nw634dhy8m0rvn49cv20431gpi"
 }

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "release/0.7.0.0",
+  "branch": "aa/reflex-0.8.1.0",
   "private": false,
-  "rev": "27a7851a780ff21472d85f9a02fb84635ef9027a",
-  "sha256": "1m4zlw91dpjlbdchjyxhvhv3k7lilm0qa17dhhww868xxc27sann"
+  "rev": "31927e7b6cbd87053aac819caa822a0b5bc57d7a",
+  "sha256": "1wr0f18msciddla8jw2dqgyzfbwzz7v7kw4mclpdhmzxkf7x94gd"
 }

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -13,8 +13,6 @@ in
   regex-posix = self.callHackage "regex-posix" "0.96.0.0" {};
   regex-tdfa = self.callHackage "regex-tdfa" "1.3.1.0" {};
   test-framework = haskellLib.dontCheck (self.callHackage "test-framework" "0.8.2.0" {});
-  hnix = haskellLib.dontCheck (self.callHackage "hnix" "0.8.0" {});
-  hnix-store-core = self.callHackage "hnix-store-core" "0.2.0.0" {};
 
   aeson-gadt-th = self.callHackage "aeson-gadt-th" "0.2.4" {};
 
@@ -22,5 +20,9 @@ in
   # Exports more internals
   snap-core = haskellLib.dontCheck (self.callCabal2nix "snap-core" (hackGet ../dep/snap-core) {});
 
+  logging-effect = self.callCabal2nix "logging-effect" (hackGet ../dep/logging-effect) {};
+  resourcet = self.callHackage "resourcet" "1.2.4.2" {};
+  unliftio-core = self.callHackage "unliftio-core" "0.2.0.1" {};
   shelly = self.callHackage "shelly" "1.9.0" {};
+  monad-logger = self.callHackage "monad-logger" "0.3.36" {};
 }

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -13,6 +13,8 @@ in
   regex-posix = self.callHackage "regex-posix" "0.96.0.0" {};
   regex-tdfa = self.callHackage "regex-tdfa" "1.3.1.0" {};
   test-framework = haskellLib.dontCheck (self.callHackage "test-framework" "0.8.2.0" {});
+  hnix = haskellLib.dontCheck super.hnix;
+  hnix-store = haskellLib.dontCheck super.hnix-store;
 
   aeson-gadt-th = self.callHackage "aeson-gadt-th" "0.2.4" {};
 

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -14,6 +14,7 @@ in
   regex-tdfa = self.callHackage "regex-tdfa" "1.3.1.0" {};
   test-framework = haskellLib.dontCheck (self.callHackage "test-framework" "0.8.2.0" {});
   hnix = haskellLib.dontCheck super.hnix;
+  hnix-store-core = haskellLib.dontCheck super.hnix-store-core;
   hnix-store = haskellLib.dontCheck super.hnix-store;
 
   aeson-gadt-th = self.callHackage "aeson-gadt-th" "0.2.4" {};

--- a/lib/cliapp/src/Obelisk/CliApp/Types.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Types.hs
@@ -47,8 +47,6 @@ type CliThrow e m = MonadError e m
 putLog :: CliLog m => Severity -> Text -> m ()
 putLog sev = logMessage . Output_Log . WithSeverity sev
 
-deriving instance MonadFail m => MonadFail (LoggingT Output m)
-
 newtype DieT e m a = DieT { unDieT :: ReaderT (e -> (Text, Int)) (LoggingT Output m) a }
   deriving
     ( Functor, Applicative, Monad, MonadIO, MonadFail


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
