### PR TITLE
Nixpkgs 20.03

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "develop",
+  "branch": "nixpkgs-20.03",
   "private": false,
-  "rev": "6c2636422a6c721e26481ac5901fb0d359922a90",
-  "sha256": "1axnpqfwzprszfzlab3gk9x3pmd2fhdnjwf4xw9v5k8j9p2j7lv0"
+  "rev": "58068e6818c8ee0a53d7b622789e6f2d4955f32e",
+  "sha256": "18x01afx3g9d4d2if7k44iig81sb8qyjhb5gx2czqci50lsi4krp"
 }

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -3,6 +3,6 @@
   "repo": "reflex-platform",
   "branch": "nixpkgs-20.03",
   "private": false,
-  "rev": "58068e6818c8ee0a53d7b622789e6f2d4955f32e",
-  "sha256": "18x01afx3g9d4d2if7k44iig81sb8qyjhb5gx2czqci50lsi4krp"
+  "rev": "52e00a07baccac3171dea0e237e74444bbf07ef4",
+  "sha256": "00a5kg0apf08sa54vf4rk4zjl9yq994pdckjkz4113kbsh2hbyan"
 }


### PR DESCRIPTION
This is primarily to fix https://github.com/obsidiansystems/obelisk/issues/851

There will be more bumps incoming, but reflex-platform doesn't yet fully build with 20.09.

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
