### PR TITLE
Nixpkgs 20.09

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -3,6 +3,6 @@
   "repo": "reflex-platform",
   "branch": "develop",
   "private": false,
-  "rev": "6c2636422a6c721e26481ac5901fb0d359922a90",
-  "sha256": "1axnpqfwzprszfzlab3gk9x3pmd2fhdnjwf4xw9v5k8j9p2j7lv0"
+  "rev": "2df765f73e7e638a795508a2fb67b98e9f3bbf7d",
+  "sha256": "1pjw8wwbblwncrndv1dwv0bqd4qn0rlpp6zc213pv1n54lhil4wc"
 }

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "release/0.7.1.0",
+  "branch": "develop",
   "private": false,
-  "rev": "95ab759c0f12b10d0d012e5a7762321c80e721e4",
-  "sha256": "1k99nadp3m4xjzl52pm39ijkd6nw634dhy8m0rvn49cv20431gpi"
+  "rev": "6c2636422a6c721e26481ac5901fb0d359922a90",
+  "sha256": "1axnpqfwzprszfzlab3gk9x3pmd2fhdnjwf4xw9v5k8j9p2j7lv0"
 }

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -9,6 +9,13 @@ let
 in
 
 {
+  # Actually broken in current nixpkgs master due to MonadFail changes
+  git = haskellLib.markUnbroken super.git;
+
+  # hpack requires cabal >= 3.0 but the ghc865 package set builds it with 2.4 by default
+  hpack = super.hpack.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
+
+
   regex-base = self.callHackage "regex-base" "0.94.0.0" {};
   regex-posix = self.callHackage "regex-posix" "0.96.0.0" {};
   regex-tdfa = self.callHackage "regex-tdfa" "1.3.1.0" {};

--- a/lib/command/src/Obelisk/Command/Preprocessor.hs
+++ b/lib/command/src/Obelisk/Command/Preprocessor.hs
@@ -10,7 +10,7 @@ import Data.List (intersperse, isPrefixOf, sortOn)
 import Data.Maybe (fromMaybe)
 import qualified Data.Text.Lazy.Builder as TL
 import qualified Data.Text.Lazy.Encoding as TL
-import Distribution.Compiler (CompilerFlavor (..))
+import Distribution.Compiler (CompilerFlavor (..), perCompilerFlavorToList)
 import Language.Haskell.Extension (Extension (..), Language(..))
 import System.Directory (canonicalizePath)
 import System.IO (IOMode (..), hPutStrLn, stderr, withFile)
@@ -88,7 +88,9 @@ generateHeader origPath packageInfo =
     ghcOptList
       = filter (not . isPrefixOf "-O")
       $ fromMaybe []
-      $ lookup GHC (_cabalPackageInfo_compilerOptions packageInfo)
+      $ lookup GHC
+      $ perCompilerFlavorToList
+      $ _cabalPackageInfo_compilerOptions packageInfo
     optList = _cabalPackageInfo_cppOptions packageInfo <> ghcOptList
 
 lineNumberPragma :: FilePath -> TL.Builder

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -44,8 +44,8 @@ import Data.Time.Format (formatTime, defaultTimeLocale)
 import Data.Traversable (for)
 import Debug.Trace (trace)
 import Distribution.Compiler (CompilerFlavor(..))
-import Distribution.PackageDescription.Parsec (parseGenericPackageDescription)
-import Distribution.Parsec.ParseResult (runParseResult)
+import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+import Distribution.Parsec.Warning (PWarning)
 import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Compiler (PackageDB (GlobalPackageDB))
 import Distribution.Simple.Configure (configCompilerEx, getInstalledPackages)
@@ -54,14 +54,14 @@ import Distribution.Simple.Program.Db (defaultProgramDb)
 import qualified Distribution.System as Dist
 import Distribution.Types.BuildInfo (buildable, cppOptions, defaultExtensions, defaultLanguage, hsSourceDirs, options, targetBuildDepends)
 import Distribution.Types.CondTree (simplifyCondTree)
+import Distribution.Types.ConfVar (ConfVar (Arch, Impl, OS))
 import Distribution.Types.Dependency (Dependency (..), depPkgName)
-import Distribution.Types.GenericPackageDescription (ConfVar (Arch, Impl, OS), condLibrary)
+import Distribution.Types.GenericPackageDescription (condLibrary)
 import Distribution.Types.InstalledPackageInfo (compatPackageKey)
 import Distribution.Types.Library (libBuildInfo)
 import Distribution.Types.PackageName (mkPackageName)
 import Distribution.Types.VersionRange (anyVersion)
 import Distribution.Utils.Generic (toUTF8BS, readUTF8File)
-import qualified Distribution.Parsec.Common as Dist
 import qualified Distribution.Verbosity as Verbosity (silent)
 import qualified Hpack.Config as Hpack
 import qualified Hpack.Render as Hpack
@@ -338,7 +338,7 @@ parseCabalPackage dir = parseCabalPackage' dir >>= \case
 parseCabalPackage'
   :: (MonadIO m)
   => FilePath -- ^ Package directory
-  -> m (Either T.Text (Maybe ([Dist.PWarning], CabalPackageInfo)))
+  -> m (Either T.Text (Maybe ([PWarning], CabalPackageInfo)))
 parseCabalPackage' pkg = runExceptT $ do
   (cabalContents, packageFile, packageName) <- guessCabalPackageFile pkg >>= \case
     Left GuessPackageFileError_NotFound -> throwError $ "No .cabal or package.yaml file found in " <> T.pack pkg

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -43,7 +43,7 @@ import Data.Time.Clock (getCurrentTime)
 import Data.Time.Format (formatTime, defaultTimeLocale)
 import Data.Traversable (for)
 import Debug.Trace (trace)
-import Distribution.Compiler (CompilerFlavor(..))
+import Distribution.Compiler (CompilerFlavor(..), PerCompilerFlavor)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
 import Distribution.Parsec.Warning (PWarning)
 import Distribution.Pretty (prettyShow)
@@ -55,10 +55,11 @@ import qualified Distribution.System as Dist
 import Distribution.Types.BuildInfo (buildable, cppOptions, defaultExtensions, defaultLanguage, hsSourceDirs, options, targetBuildDepends)
 import Distribution.Types.CondTree (simplifyCondTree)
 import Distribution.Types.ConfVar (ConfVar (Arch, Impl, OS))
-import Distribution.Types.Dependency (Dependency (..), depPkgName)
+import Distribution.Types.Dependency (Dependency (..), depPkgName, depVerRange)
 import Distribution.Types.GenericPackageDescription (condLibrary)
 import Distribution.Types.InstalledPackageInfo (compatPackageKey)
 import Distribution.Types.Library (libBuildInfo)
+import Distribution.Types.LibraryName (LibraryName(..))
 import Distribution.Types.PackageName (mkPackageName)
 import Distribution.Types.VersionRange (anyVersion)
 import Distribution.Utils.Generic (toUTF8BS, readUTF8File)
@@ -103,7 +104,7 @@ data CabalPackageInfo = CabalPackageInfo
     -- ^ List of globally enable extensions of the library component
   , _cabalPackageInfo_defaultLanguage :: Maybe Language
     -- ^ List of globally set languages of the library component
-  , _cabalPackageInfo_compilerOptions :: [(CompilerFlavor, [String])]
+  , _cabalPackageInfo_compilerOptions :: PerCompilerFlavor [String]
     -- ^ List of compiler-specific options (e.g., the "ghc-options" field of the cabal file)
   , _cabalPackageInfo_cppOptions :: [String]
     -- ^ List of CPP (C Preprocessor) options (e.g. the "cpp-options" field of the cabal file)
@@ -383,7 +384,7 @@ parseCabalPackage' pkg = runExceptT $ do
         }
     Right Nothing -> pure Nothing
     Left (_, errors) ->
-      throwError $ T.pack $ "Failed to parse " <> packageFile <> ":\n" <> unlines (map show errors)
+      throwError $ T.pack $ "Failed to parse " <> packageFile <> ":\n" <> unlines (map show $ toList errors)
 
 parsePackagesOrFail :: (MonadObelisk m, Foldable f) => f FilePath -> m (NE.NonEmpty CabalPackageInfo)
 parsePackagesOrFail dirs' = do
@@ -502,9 +503,9 @@ getGhciSessionSettings (toList -> packageInfos) pathBase useRelativePaths = do
       map (dependencyPackageId installedPackageIndex) $
           filter ((`notElem` packageNames) . depPkgName) $
           concatMap _cabalPackageInfo_buildDepends packageInfos <>
-            [Dependency (mkPackageName "obelisk-run") anyVersion]
+            [Dependency (mkPackageName "obelisk-run") anyVersion (Set.singleton LMainLibName)]
     dependencyPackageId installedPackageIndex dep =
-      case lookupDependency installedPackageIndex dep of
+      case lookupDependency installedPackageIndex (depPkgName dep) (depVerRange dep) of
         ((_version,installedPackageInfo:_) :_) ->
           compatPackageKey installedPackageInfo
         _ -> error $ "Couldn't resolve dependency for " <> prettyShow dep


### PR DESCRIPTION
Only tested with a pet project so far.
`nix-build -A exe` worked right away with the bump, but the `ob` commands had broken dependencies.
I tried to bump hpack's cabal rather than spend time trying to get an older hpack to work, but don't know the implications. One thing I noticed is that when `.obelisk/impl` is unpacked, both `Cabal` packages are around:

```$ ob shell "ghc-pkg list" | grep -i cabal
    Cabal-2.4.0.1
    Cabal-3.2.0.0
```

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
