### PR TITLE
Bump reflex-platform slightly to last 19.09 release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ This project's release branch is `master`. This log is written from the perspect
 
 ## Unreleased
 
-* Update reflex-platform to v0.7.1.0
+* Update reflex-platform to v0.7.2.0
 * Fix bug [#790](https://github.com/obsidiansystems/obelisk/issues/790) which prevented CSS file loading on ios
 * Use TemplateHaskell to determine asset file paths
   * Migration: All uses of `static @"some/path"` become `$(static "some/path")`. Instead of requiring `TypeApplications` and `DataKinds`, modules calling `static` must now enable `TemplateHaskell`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,13 @@
 
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released.
 
-## v0.9.2.0 - 2021-12-28
+## Unreleased (ready to be v0.9.2.1)
 
 * Update reflex-platform to v0.7.2.0
+
+## v0.9.2.0 - 2021-12-28
+
+* Update reflex-platform to v0.7.1.0
 * Fix bug [#790](https://github.com/obsidiansystems/obelisk/issues/790) which prevented CSS file loading on ios
 * Use TemplateHaskell to determine asset file paths
   * Migration: All uses of `static @"some/path"` become `$(static "some/path")`. Instead of requiring `TypeApplications` and `DataKinds`, modules calling `static` must now enable `TemplateHaskell`.

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "develop",
+  "branch": "nixpkgs-19.09",
   "private": false,
-  "rev": "6c2636422a6c721e26481ac5901fb0d359922a90",
-  "sha256": "1axnpqfwzprszfzlab3gk9x3pmd2fhdnjwf4xw9v5k8j9p2j7lv0"
+  "rev": "819e116e09a85fafb7364ba6819ffaa5a76072a0",
+  "sha256": "1j4j6irn2qaajikvm0xfxxfl4l3k94bb03blvpmwyyrv9597vfkp"
 }


### PR DESCRIPTION
Want to maximize the number of small changes we get in before big
Nixpkgs bumps.

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
