### PR TITLE
hostName conforming with nix specification and `extraDomainName`

### DIFF
--- a/acme.nix
+++ b/acme.nix
@@ -83,6 +83,21 @@ let
         description = "Directory where certificate and other state is stored.";
       };
 
+      extraDomainNames = mkOption {
+        type = types.attrsOf (types.nullOr types.str);
+        default = {};
+        example = literalExample ''
+          {
+            "example.org" = null;
+            "mydomain.org" = null;
+          }
+        '';
+        description = ''
+          A list of extra domain names, which are included in the one certificate to be issued.
+          Setting a distinct server root is deprecated and not functional in 20.03+
+        '';
+      };
+
       extraDomains = mkOption {
         type = types.attrsOf (types.nullOr types.str);
         default = {};

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -145,7 +145,8 @@ deployPush deployPath getNixBuilders = do
         }
       & nixBuildConfig_outLink .~ OutLink_None
       & nixCmdConfig_args .~ (
-        [ strArg "hostName" host
+        -- [ strArg "hostName" host
+        [ strArg "hostName" $ fmap (\c -> if c == '.' then '_' else c) host
         , strArg "adminEmail" adminEmail
         , strArg "routeHost" routeHost
         , strArg "version" version


### PR DESCRIPTION
Trying to deploy with the latest `develop` branch, I had to implement those two changes for everything to go through. There still seems to be a bug in the nginx configuration. The deployment complains:

```warning: the following units failed: nginx-config-reload.service```

But the website is live with all the changes, so this is for later.

I have:

  - [x] Based work on latest `develop` branch
  - [ x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
