### PR TITLE
Take out unused line

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -7,6 +7,7 @@
 1. [How do I fix invalid entitlements?](#how-do-i-fix-invalid-entitlements)
 1. [`ob thunk update` or `ob deploy update` fails](#ob-thunk-update-or-ob-deploy-update-fails)
 1. [How do I fix `Ambiguous module name` errors?](#how-do-i-fix-ambiguous-module-name-errors)
+1. [How do I fix `no C compiler provided for this platform` errors?](#how-do-i-fix-no-c-compiler-provided-for-this-platform-errors)
 
 ### How do I declare a new Haskell dependency?
 
@@ -115,3 +116,9 @@ error:
 ```
 then specify the package you want in the import, e.g:
 `import "cryptonite" Crypto.Hash`
+
+### How do I fix `no C compiler provided for this platform` errors?
+
+This can show up when when doing nix-build (ie for deployment). 
+
+This is probably because you have a package that needs a C compiler (like `snap-core`) in your `common` or `frontend` modules which need to be built for `ghcjs` which does not in fact have a C compiler. You'll need to remove those packages from your cabal files and rework your app to not need them in the frontend.

--- a/lib/frontend/src/Obelisk/Frontend.hs
+++ b/lib/frontend/src/Obelisk/Frontend.hs
@@ -36,7 +36,6 @@ import Control.Monad.Ref
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Data.ByteString (ByteString)
 import Data.Foldable (for_)
-import Data.Functor.Sum
 import Data.Map (Map)
 import Data.Maybe (catMaybes)
 import Data.Monoid ((<>))
@@ -62,8 +61,6 @@ import System.Info (os)
 import Web.Cookie
 
 import Debug.Trace
-
-makePrisms ''Sum
 
 type ObeliskWidget t route m =
   ( DomBuilder t m


### PR DESCRIPTION
Obelisk.Frontend breaks when using lens 5.1.

The line 66 (makePrisms ''Sum) of Obelisk.Frontend was unused and was causing compilations errors.
The corresponding import (Data.Functor.Sum) was also taken out.

The line was taken out since it was unused.


I have:

  - [ x] Based work on latest `develop` branch
  - [ x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
