### PR TITLE
Replace `.`s in host name with underscores.

### DIFF
--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -145,7 +145,7 @@ deployPush deployPath getNixBuilders = do
         }
       & nixBuildConfig_outLink .~ OutLink_None
       & nixCmdConfig_args .~ (
-        [ strArg "hostName" host
+        [ strArg "hostName" $ fmap (\c -> if c == '.' then '_' else c) host
         , strArg "adminEmail" adminEmail
         , strArg "routeHost" routeHost
         , strArg "version" version


### PR DESCRIPTION
Commit https://github.com/NixOS/nixpkgs/commit/993baa587c4b82e791686f6ce711bcd4ee8ef933 changes how `hostName` is validated within the nixos configuration. This changes makes it such that running `ob deploy push` on NixOS version > 20.03 fails.

I tried pushing a sample project with this change both locally (21.11) and on a remote machine (19.09).

I have:

  - [X] Based work on latest `develop` branch
  - [X] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
