### PR TITLE
Route link functions now open new tab on Ctrl-Click

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ This project's release branch is `master`. This log is written from the perspect
 
 * nixpkgs-overlays
   * Remove override of acme module that pinned it to the version in nixpkgs-20.03. This is used for automatic https certificate provisioning.
+* Fix a bug in `Obelisk.Route.Frontend` where `routeLink`, `routeLinkDynAttr`, and `dynRouteLink` would not behave exactly like `<a href="...">` when run by JavaScript. These functions now open a new tab when Ctrl-clicked.
 
 ## v1.0.0.0 - 2022-01-04
 

--- a/lib/route/obelisk-route.cabal
+++ b/lib/route/obelisk-route.cabal
@@ -19,6 +19,7 @@ library
                  ghcjs-dom,
                  http-types,
                  jsaddle,
+                 jsaddle-dom,
                  lens,
                  mmorph,
                  monad-control,

--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -76,20 +76,24 @@ import qualified Data.List as L
 import Data.Map (Map)
 import Data.Maybe (fromMaybe)
 import Data.Monoid
-import Data.Proxy
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Type.Coercion
 import qualified GHCJS.DOM as DOM
 import qualified GHCJS.DOM.Types as DOM
 import qualified GHCJS.DOM.Window as Window
-import Language.Javascript.JSaddle (MonadJSM, jsNull, liftJSM) --TODO: Get rid of this - other platforms can also be routed
+import Language.Javascript.JSaddle (MonadJSM, function, jsNull, liftJSM, toJSVal) --TODO: Get rid of this - other platforms can also be routed
 import Network.URI
 import Reflex.Class
-import Reflex.Dom.Builder.Class
-import Reflex.Dom.Core
+import Reflex.Dom.Builder.Class hiding (preventDefault)
+import Reflex.Dom.Core hiding (preventDefault)
 import Reflex.Host.Class
 import Unsafe.Coerce
+
+import JSDOM.Generated.Event (preventDefault)
+import JSDOM.Generated.EventTarget (addEventListener)
+import JSDOM.Generated.MouseEvent (MouseEvent(..), getCtrlKey)
+import JSDOM.Types (DOM, EventListener(..), IsEventTarget, askDOM, runDOM)
 
 import Obelisk.Configs
 import Obelisk.Route
@@ -495,6 +499,40 @@ runRouteViewT routeEncoder switchover useHash a = do
           setState = attachWith f ((,) <$> current historyState <*> current route) changeState
   return result
 
+getClickEvent :: (MonadJSM m, TriggerEvent t m, IsEventTarget (RawElement d)) => Element er d t -> (MouseEvent -> DOM ()) -> m (Event t MouseEvent)
+getClickEvent elm onComplete = do
+  (sendEv, sendFn) <- newTriggerEvent
+
+  liftJSM $ do
+    ctx <- askDOM
+
+    let
+      haskellHandler _ _ [res] = do
+        let
+          mouseEv = MouseEvent res
+        liftIO $ sendFn mouseEv
+        runDOM (onComplete mouseEv) ctx
+      haskellHandler _ _ _ = pure ()
+
+    jsHandler <- function haskellHandler >>= toJSVal
+    addEventListener (_element_raw elm) (T.pack "click") (Just $ EventListener jsHandler) False
+
+  pure sendEv
+
+preventDefaultClick :: MouseEvent -> DOM ()
+preventDefaultClick mouseEv = do
+  wasCtrlPressed <- getCtrlKey mouseEv
+  unless wasCtrlPressed $
+    preventDefault mouseEv
+
+whenCtrlPressed :: (PerformEvent t m, MonadJSM (Performable m)) => Event t MouseEvent -> Dynamic t a -> m (Event t a)
+whenCtrlPressed clickEv xDyn = do
+  xEv <- performEvent $ (,) <$> current xDyn <@> clickEv <&> \(x, mouseClick) -> do
+    getCtrlKey mouseClick >>= \wasCtrlPressed -> if wasCtrlPressed
+      then pure Nothing
+      else pure $ Just x
+  pure $ fmapMaybe id xEv
+
 -- | A link widget that, when clicked, sets the route to the provided route. In non-javascript
 -- contexts, this widget falls back to using @href@s to control navigation
 routeLink
@@ -503,6 +541,11 @@ routeLink
      , RouteToUrl route m
      , SetRoute t route m
      , Prerender t m
+     , MonadJSM m
+     , TriggerEvent t m
+     , PerformEvent t m
+     , MonadJSM (Performable m)
+     , IsEventTarget (RawElement (DomBuilderSpace m))
      )
   => route -- ^ Target route
   -> m a -- ^ Child widget
@@ -518,6 +561,11 @@ routeLinkImpl
      ( DomBuilder t m
      , RouteToUrl route m
      , SetRoute t route m
+     , MonadJSM m
+     , TriggerEvent t m
+     , PerformEvent t m
+     , MonadJSM (Performable m)
+     , IsEventTarget (RawElement (DomBuilderSpace m))
      )
   => route -- ^ Target route
   -> m a -- ^ Child widget
@@ -525,10 +573,11 @@ routeLinkImpl
 routeLinkImpl r w = do
   enc <- askRouteToUrl
   let cfg = (def :: ElementConfig EventResult t (DomBuilderSpace m))
-        & elementConfig_eventSpec %~ addEventSpecFlags (Proxy :: Proxy (DomBuilderSpace m)) Click (\_ -> preventDefault)
         & elementConfig_initialAttributes .~ "href" =: enc r
   (e, a) <- element "a" cfg w
-  setRoute $ r <$ domEvent Click e
+  clickEv <- getClickEvent e preventDefaultClick
+  routeEv <- whenCtrlPressed clickEv $ constDyn r
+  setRoute routeEv
   return (domEvent Click e, a)
 
 scrollToTop :: forall m t. (Prerender t m, Monad m) => Event t () -> m ()
@@ -544,6 +593,11 @@ dynRouteLink
      , RouteToUrl route m
      , SetRoute t route m
      , Prerender t m
+     , MonadJSM m
+     , TriggerEvent t m
+     , PerformEvent t m
+     , MonadJSM (Performable m)
+     , IsEventTarget (RawElement (DomBuilderSpace m))
      )
   => Dynamic t route -- ^ Target route
   -> m a -- ^ Child widget
@@ -560,6 +614,11 @@ dynRouteLinkImpl
      , PostBuild t m
      , RouteToUrl route m
      , SetRoute t route m
+     , MonadJSM m
+     , TriggerEvent t m
+     , PerformEvent t m
+     , MonadJSM (Performable m)
+     , IsEventTarget (RawElement (DomBuilderSpace m))
      )
   => Dynamic t route -- ^ Target route
   -> m a -- ^ Child widget
@@ -568,12 +627,12 @@ dynRouteLinkImpl dr w = do
   enc <- askRouteToUrl
   er <- dynamicAttributesToModifyAttributes $ ("href" =:) . enc <$> dr
   let cfg = (def :: ElementConfig EventResult t (DomBuilderSpace m))
-        & elementConfig_eventSpec %~ addEventSpecFlags (Proxy :: Proxy (DomBuilderSpace m)) Click (\_ -> preventDefault)
         & elementConfig_modifyAttributes .~ er
   (e, a) <- element "a" cfg w
-  let clk = domEvent Click e
-  setRoute $ tag (current dr) clk
-  return (clk, a)
+  clickEv <- getClickEvent e preventDefaultClick
+  routeEv <- whenCtrlPressed clickEv dr
+  setRoute routeEv
+  return (domEvent Click e, a)
 
 -- | An @a@-tag link widget that, when clicked, sets the route to current value of the
 -- provided dynamic route. In non-JavaScript contexts the value of the dynamic post
@@ -585,6 +644,11 @@ routeLinkDynAttr
      , RouteToUrl (R route) m
      , SetRoute t (R route) m
      , Prerender t m
+     , MonadJSM m
+     , TriggerEvent t m
+     , PerformEvent t m
+     , MonadJSM (Performable m)
+     , IsEventTarget (RawElement (DomBuilderSpace m))
      )
   => Dynamic t (Map AttributeName Text) -- ^ Attributes for @a@ element. Note that if @href@ is present it will be ignored
   -> Dynamic t (R route) -- ^ Target route
@@ -602,6 +666,11 @@ routeLinkDynAttrImpl
      , PostBuild t m
      , RouteToUrl (R route) m
      , SetRoute t (R route) m
+     , MonadJSM m
+     , TriggerEvent t m
+     , PerformEvent t m
+     , MonadJSM (Performable m)
+     , IsEventTarget (RawElement (DomBuilderSpace m))
      )
   => Dynamic t (Map AttributeName Text) -- ^ Attributes for @a@ element. Note that if @href@ is present it will be ignored
   -> Dynamic t (R route) -- ^ Target route
@@ -611,12 +680,12 @@ routeLinkDynAttrImpl dAttr dr w = do
   enc <- askRouteToUrl
   er <- dynamicAttributesToModifyAttributes $ zipDynWith (<>) (("href" =:) . enc <$> dr) dAttr
   let cfg = (def :: ElementConfig EventResult t (DomBuilderSpace m))
-        & elementConfig_eventSpec %~ addEventSpecFlags (Proxy :: Proxy (DomBuilderSpace m)) Click (\_ -> preventDefault)
         & elementConfig_modifyAttributes .~ er
   (e, a) <- element "a" cfg w
-  let clk = domEvent Click e
-  setRoute $ tag (current dr) clk
-  return (clk, a)
+  clickEv <- getClickEvent e preventDefaultClick
+  routeEv <- whenCtrlPressed clickEv dr
+  setRoute routeEv
+  return (domEvent Click e, a)
 
 -- On ios due to sandboxing when loading the page from a file adapt the
 -- path to be based on the hash.


### PR DESCRIPTION
For details, refer to this issue: https://github.com/obsidiansystems/obelisk/issues/657#issuecomment-1103618210.
I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
