### PR TITLE
obelisk-route: GHC 8.10.7 compatibility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#916](https://github.com/obsidiansystems/obelisk/pull/916): Add `check-known-hosts` option in `ob deploy init`.
 * obelisk-route
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
-* Add GHC 8.10.7 support for `obelisk-route`
+  * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`
 
 ## v1.0.0.0 - 2022-01-04
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#916](https://github.com/obsidiansystems/obelisk/pull/916): Add `check-known-hosts` option in `ob deploy init`.
 * obelisk-route
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
+* Add GHC 8.10.7 support for `obelisk-route`
 
 ## v1.0.0.0 - 2022-01-04
 
@@ -200,4 +201,3 @@ This project's release branch is `master`. This log is written from the perspect
 
 * Use reflex-dom's `HydrationDomBuilder` to "hydrate" statically rendered DOM served by the Obelisk backend (rather than re-creating DOM and replacing it all).
 * Add `HasCookies` and `CookiesT` to allow `ObeliskWidget`s to access cookies during static and "hydrated" DOM rendering.
-

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -15,6 +15,9 @@ in
   # hpack requires cabal >= 3.0 but the ghc865 package set builds it with 2.4 by default
   hpack = super.hpack.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
 
+  # These versions work with both the ghc865 and ghc8107 package sets
+  universe = self.callHackage "universe" "1.2" {};
+  universe-instances-extended = self.callHackage "universe-instances-extended" "1.1.1" {};
 
   regex-base = self.callHackage "regex-base" "0.94.0.0" {};
   regex-posix = self.callHackage "regex-posix" "0.96.0.0" {};

--- a/lib/route/obelisk-route.cabal
+++ b/lib/route/obelisk-route.cabal
@@ -35,7 +35,7 @@ library
                  th-extras,
                  transformers,
                  universe,
-                 universe-dependent-sum
+                 universe-some
   exposed-modules: Obelisk.Route
                    Obelisk.Route.TH
                    Obelisk.Route.Frontend

--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -156,9 +156,16 @@ import Control.Lens
   , view
   , Wrapped (..)
   )
+
+#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ < 810
+import Control.Monad.Trans (lift)
+import Data.Monoid ((<>))
+#endif
+#endif
+
 import Control.Monad.Except
 import qualified Control.Monad.State.Strict as State
-import Control.Monad.Trans (lift)
 import Control.Monad.Writer (execWriter, tell)
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as Aeson
@@ -178,7 +185,6 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
-import Data.Monoid ((<>))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Some (Some(Some))

--- a/lib/route/src/Obelisk/Route/Frontend.hs
+++ b/lib/route/src/Obelisk/Route/Frontend.hs
@@ -56,12 +56,17 @@ module Obelisk.Route.Frontend
   , setAdaptedUriPath
   ) where
 
+#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ < 810
+import Control.Monad ((<=<))
+#endif
+#endif
+
 import Prelude hiding ((.), id)
 
 import Control.Category (Category (..), (.))
 import Control.Category.Cartesian ((&&&))
 import Control.Lens hiding (Bifunctor, bimap, universe, element)
-import Control.Monad ((<=<))
 import Control.Monad.Fix
 import Control.Monad.Morph
 import Control.Monad.Primitive


### PR DESCRIPTION
Make two changes related to `obelisk-route` GHC 8.10.7 compatibility:

1. Remove "redundant import"-warnings in `Obelisk.Route` and `Obelisk.Route.Frontend` (cherry-picked from https://github.com/obsidiansystems/obelisk/pull/917)
2. Make compatible with the nixpkgs ghc8107 package set, by:
   1. Replacing `universe-dependent-sum` with `universe-some`, since the module `Data.Universe.Some.TH` is in `universe-some` for this package set
   2. Pinning `universe` and `universe-instances-extended` to a version that's compatible with both the ghc865 and ghc8107 package set

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [x] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
