### PR TITLE
Add an explanation for malfunctioning of ob run in firefox to the FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,5 +1,6 @@
 # Frequently Asked Questions
 
+1. [Why does `ob run` hang in firefox?](#why-does-ob-run-hang-in-firefox)
 1. [How do I declare a new Haskell dependency?](#how-do-i-declare-a-new-haskell-dependency)
 1. [How do I add or override Haskell dependencies in the package set?](#how-do-i-add-or-override-haskell-dependencies-in-the-package-set)
 1. [How do I extend my Obelisk application with more local packages?](#how-do-i-extend-my-obelisk-application-with-more-local-packages)
@@ -140,3 +141,7 @@ var lib = false;
 ```
 
 Any variables defined in this file will not be used in the minification process.
+
+###why-does-ob-run-hang-in-firefox
+
+`ob run` runs the project frontend through the jsaddle library, instead of compiling it to javascript. There is an issue with the way that jsaddle interfaces with the browser which causes `ob run` to fail to operate on some browsers. For more information, see [this issue](https://github.com/ghcjs/jsaddle/issues/64).

--- a/FAQ.md
+++ b/FAQ.md
@@ -142,6 +142,6 @@ var lib = false;
 
 Any variables defined in this file will not be used in the minification process.
 
-###why-does-ob-run-hang-in-firefox
+### Why does ob run hang in firefox?
 
 `ob run` runs the project frontend through the jsaddle library, instead of compiling it to javascript. There is an issue with the way that jsaddle interfaces with the browser which causes `ob run` to fail to operate on some browsers. For more information, see [this issue](https://github.com/ghcjs/jsaddle/issues/64).


### PR DESCRIPTION
See #460 for the counter-intuitive behavior that can arise. There is already an explanation in the README, but it is easy to miss.