### PR TITLE
Remove leading slash in generated asset paths

### DIFF
--- a/lib/asset/manifest/src/Obelisk/Asset/TH.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/TH.hs
@@ -30,7 +30,7 @@ assetPath root relativePath =
   LitE . StringL <$> hashedAssetFilePath root relativePath
 
 staticPrefix :: FilePath
-staticPrefix = "/static"
+staticPrefix = "static"
 
 staticAssetRaw :: FilePath -> Q Exp
 staticAssetRaw fp = do


### PR DESCRIPTION
[#831](https://github.com/obsidiansystems/obelisk/pull/831) changed the
way that we generate routes for static assets. The old approach would
place the assets at a path starting with "static". The new approach
added a leading slash, which, when rendered in URLs, would lead to
double slashes at the beginning of routes in places where the user had
not expected there to be a slash. This can lead to 404's for assets for
older projects.

This change brings the current behavior in line with the old behavior.

<!-- Provide a clear overview of your changes. -->

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
