### PR TITLE
[Proof of concept]: Computing closure of 'interpret' packages

### DIFF
--- a/skeleton/lib.nix
+++ b/skeleton/lib.nix
@@ -1,0 +1,54 @@
+/*
+  :: [String] -> Map String Derivation
+
+  Given `pkgs`, a set of package names, compute the set of packages which are both dependencies and dependents of `pkgs`.
+
+  Example:
+  ```
+    $ echo 'sandwichedDeps' | nix repl lib.nix --arg pkgs '["backend" "common" "frontend" "reflex-dom-core"]'
+
+    { obelisk-backend = «derivation /nix/store/xbdrjxs0mvs9hjs1c30njvqbc6839p4s-obelisk-backend-0.1.drv»
+    ; obelisk-executable-config-inject = «derivation /nix/store/9y1w40d1lr7s6m7jv4z6aij3n17wqasb-obelisk-executable-config-inject-0.1.drv»
+    ; obelisk-executable-config-lookup = «derivation /nix/store/86d87qfhn3vzsgn5v44n4hc763xp1lx3-obelisk-executable-config-lookup-0.1.1.drv»
+    ; obelisk-frontend = «derivation /nix/store/ljh0wzcqmpwn2faxfflpl2nfiialhjwa-obelisk-frontend-0.1.drv»
+    ; obelisk-route = «derivation /nix/store/nzxaai6s1hxrz6lb9cn0hn24x0pzvp3y-obelisk-route-0.2.drv»;
+    }
+  ```
+*/
+
+{ pkgs
+}: with builtins;
+let
+  proj = import ./default.nix {};
+in
+  with proj.obelisk.nixpkgs.lib; rec {
+    # Why are boot packages null?
+    cabalDeps = p: filter (p: p != null) p.getCabalDeps.libraryHaskellDepends;
+    depAttrs = p: listToAttrs (map (d: nameValuePair (d.pname) d) (cabalDeps p));
+
+    node = mkEdges: p: { ${p.pname} = { drv = p; edges = mkEdges p; };};
+    children = mkEdges: nodes: concatMap (n: map (node mkEdges) (attrValues n.edges)) (attrValues nodes);
+    expand = mkEdges: nodes: foldl' (x: y: x // y) nodes (children mkEdges nodes);
+
+    closureCabalDeps = converge (expand depAttrs);
+    closureEdges = graph: converge (expand (p: graph.${p.pname}.edges));
+
+    dual = nodes:
+      let
+        edges = concatMap (n: map (m: { ${m.pname} = [n]; }) (attrValues n.edges)) (attrValues nodes);
+        adjacencies = zipAttrsWith (name: concatLists) edges;
+        mkNode = k: v: { drv = nodes.${k}.drv; edges = listToAttrs (map (d: nameValuePair d.drv.pname d.drv) v); };
+        preserveNodesWithoutDependents = ns: mapAttrs (k: v: v // {edges = {};}) nodes // ns;
+      in
+        preserveNodesWithoutDependents (mapAttrs mkNode adjacencies);
+
+    merge = foldl' (x: y: x // y) {};
+
+    sandwichedDeps =
+      let
+        g = closureCabalDeps (merge (map (node depAttrs) (map (p: proj.ghc.${p}) pkgs)));
+        d = dual g;
+        dependents = closureEdges d (merge (map (p: { ${p} = d.${p}; }) pkgs));
+      in
+        mapAttrs (k: v: v.drv) (removeAttrs dependents pkgs);
+  }


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
See also: https://well-typed.com/blog/2022/01/multiple-home-units/#closure-property-for-home-units

## Problem
When `ob run` & co try to load packages, the build currently fails if there's an interpreted "sandwich" situation, e.g.
`A -> B -> C` with `B` being compiled and `A`, `C`, interpreted. 
Currently this situation produces confusing errors, as can be observed in the skeleton

```bash
$ nix-thunk create https://github.com/reflex-frp/reflex && nix-thunk unpack reflex && ob run -v  
(...)
these derivations will be built:
  /nix/store/619cssdsjf5xbavm8hf06m54s8rkvf95-reflex-0.8.2.0.drv
  /nix/store/876d4w9rgw7vcsr5bzgwiv4l6wa0ky6q-reflex-dom-core-0.7.0.0.drv
  /nix/store/kbyclxvqrsa4cnvf4xg00f35jmpik0qg-reflex-fsnotify-0.2.1.2.drv
  /nix/store/zsj90j76z30iam3nq6ha5jx82sd9k7cp-reflex-dom-0.6.1.1.drv
  /nix/store/qrg1hnr4ic4vssszyjj3pxphlvswbw8a-ghc-8.6.5-with-packages.drv
building '/nix/store/619cssdsjf5xbavm8hf06m54s8rkvf95-reflex-0.8.2.0.drv'...
setupCompilerEnvironmentPhase
Build with /nix/store/jc9zqp241vz5ziwh0smls0sl1sf6h7np-ghc-8.6.5.
unpacking sources
unpacking source archive /home/alexfmpe/repos/obelisk/skeleton/reflex
do not know how to unpack source archive /home/alexfmpe/repos/obelisk/skeleton/reflex
builder for '/nix/store/619cssdsjf5xbavm8hf06m54s8rkvf95-reflex-0.8.2.0.drv' failed with exit code 1
cannot build derivation '/nix/store/qrg1hnr4ic4vssszyjj3pxphlvswbw8a-ghc-8.6.5-with-packages.drv': 1 dependencies couldn't be built
error: build of '/nix/store/qrg1hnr4ic4vssszyjj3pxphlvswbw8a-ghc-8.6.5-with-packages.drv' failed
```

## Solution
The root issue is that compiled packages can't depend on interpreted packages (all other pairings are valid). 
Meaning, when `A` and `C` are requested in 'interpret' mode, `B` must also transitively be.
After computing the 'interpret' closure, we can act on this problem.

The easiest application is detecting this situation (non-empty sandwich) and let the user know they must interpret extra packages (usually by obtaining more unpacked thunks), which would save time and confusion.
The ideal workflow would 'just work', which would require `ob` to grab the sources (`.src`) of the sandwich derivations and unzip/symlink them so that they can also be loaded into the repl. This would be a major improvement to upstream/downstream mobility.

## Notes
- PR was made to validate the approach with little regard for performance. 
- current implementation is dealing with a pretend simplified scenario where every package has only one library component

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
