### PR TITLE
Include flag to use relative paths. Absolute paths are now default.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#784](https://github.com/obsidiansystems/obelisk/pull/784): hint for users to take advantage of ob shell --no-interpret option for thunks
   * [#916](https://github.com/obsidiansystems/obelisk/pull/916): Add `check-known-hosts` option in `ob deploy init`.
   * [#870](https://github.com/obsidiansystems/obelisk/pull/870): Host redirection added to `ob deploy`. Readme updated with tutorial for new functionality.
+  * [#934](https://github.com/obsidiansystems/obelisk/pull/934): Change the way `ob run` interprets nix store paths from relative to absolute. This ensures that obelisk works on modern MacOS, where the nix store must be mounted on its own volume, which cannot be referred to with relative paths from the main volume. The old behavior was pertinent to some tool integrations, and can be re-enabled by passing `--use-relative-path`
 * obelisk-route
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
   * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -81,10 +81,15 @@ initSource = foldl1 (<|>)
 initForce :: Parser Bool
 initForce = switch (long "force" <> help "Allow ob init to overwrite files")
 
+-- | Use this option to enable relative paths
+useRelativePathsOpt :: Parser Bool
+useRelativePathsOpt = switch (long "use-relative-path" <> help "Allow ob run with relative paths. It may break on darwin when /nix is mounted on other volumes.")
+
+
 data ObCommand
    = ObCommand_Init InitSource Bool
    | ObCommand_Deploy DeployCommand
-   | ObCommand_Run [(FilePath, Interpret)]
+   | ObCommand_Run [(FilePath, Interpret)] Bool
    | ObCommand_Profile String [String]
    | ObCommand_Thunk ThunkOption
    | ObCommand_Repl [(FilePath, Interpret)]
@@ -109,7 +114,7 @@ obCommand cfg = hsubparser
   (mconcat
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
-    , command "run" $ info (ObCommand_Run <$> interpretOpts) $ progDesc "Run current project in development mode"
+    , command "run" $ info (ObCommand_Run <$> interpretOpts <*> useRelativePathsOpt) $ progDesc "Run current project in development mode"
     , command "profile" $ info (uncurry ObCommand_Profile <$> profileCommand) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkOption) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (ObCommand_Repl <$> interpretOpts) $ progDesc "Open an interactive interpreter"
@@ -401,7 +406,7 @@ ob = \case
       deployPush deployPath deployBuilders
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
-  ObCommand_Run interpretPathsList -> withInterpretPaths interpretPathsList run
+  ObCommand_Run interpretPathsList relPath -> withInterpretPaths interpretPathsList (run relPath)
   ObCommand_Profile basePath rtsFlags -> profile basePath rtsFlags
   ObCommand_Thunk to -> case _thunkOption_command to of
     ThunkCommand_Update config -> for_ thunks (updateThunkToLatest config)

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -174,13 +174,16 @@ profile profileBasePattern rtsFlags = withProjectRoot "." $ \root -> do
     ] <> rtsFlags
       <> [ "-RTS" ]
 
-run :: MonadObelisk m => Bool 
-                      -- ^ use relative paths?
-                      -> FilePath 
-                      -- ^ root folder
-                      -> PathTree Interpret 
-                      -- ^ interpreted paths
-                      -> m ()
+run
+  :: MonadObelisk m => Bool
+  -- ^ use relative paths to the nix store
+  -- which is pertinent to some IDE integration
+  -- tools' functionality. See PR #934
+  -> FilePath
+  -- ^ root folder
+  -> PathTree Interpret
+  -- ^ interpreted paths
+  -> m ()
 run useRelativePaths root interpretPaths = do
   pkgs <- getParsedLocalPkgs root interpretPaths
   (assetType, assets) <- findProjectAssets root


### PR DESCRIPTION
Fixing the relative path problem on macos. A new option was created --use-relative-path. Absolute paths are now defaulted.

See: #899 

Usage:

ob run --use-relative-path

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
