### PR TITLE
Always use absolute paths when building .ghci scripts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#916](https://github.com/obsidiansystems/obelisk/pull/916): Add `check-known-hosts` option in `ob deploy init`.
   * [#870](https://github.com/obsidiansystems/obelisk/pull/870): Host redirection added to `ob deploy`. Readme updated with tutorial for new functionality.
   * [#931](https://github.com/obsidiansystems/obelisk/pull/931): Fix bug in `ob deploy init` where `ssh-keygen` was not found in nix store.
-  * [#934](https://github.com/obsidiansystems/obelisk/pull/934): Change the way `ob run` interprets nix store paths from relative to absolute. This ensures that obelisk works on modern MacOS, where the nix store must be mounted on its own volume, which cannot be referred to with relative paths from the main volume. The old behavior was pertinent to some tool integrations, and can be re-enabled by passing `--use-relative-path`
+  * [#934](https://github.com/obsidiansystems/obelisk/pull/934): obelisk now always uses absolute paths when generating `.ghci` files for REPL and IDE support. This is a **BREAKING** change for some old tools that could not handle absolute paths properly. However, due to the behavior of cross-volume relative paths on certain platforms, such as modern MacOS, we cannot guarantee proper operation of obelisk with relative paths.
 * obelisk-route
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
   * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#916](https://github.com/obsidiansystems/obelisk/pull/916): Add `check-known-hosts` option in `ob deploy init`.
   * [#870](https://github.com/obsidiansystems/obelisk/pull/870): Host redirection added to `ob deploy`. Readme updated with tutorial for new functionality.
   * [#931](https://github.com/obsidiansystems/obelisk/pull/931): Fix bug in `ob deploy init` where `ssh-keygen` was not found in nix store.
-  * [#934](https://github.com/obsidiansystems/obelisk/pull/934): obelisk now always uses absolute paths when generating `.ghci` files for REPL and IDE support. This is a **BREAKING** change for some old tools that could not handle absolute paths properly. However, due to the behavior of cross-volume relative paths on certain platforms, such as modern MacOS, we cannot guarantee proper operation of obelisk with relative paths.
+  * [#934](https://github.com/obsidiansystems/obelisk/pull/934)[#936](https://github.com/obsidiansystems/obelisk/pull/936): obelisk now always uses absolute paths when generating `.ghci` files for REPL and IDE support. This is a **BREAKING** change for some old tools that could not handle absolute paths properly. However, due to the behavior of cross-volume relative paths on certain platforms, such as modern MacOS, we cannot guarantee proper operation of obelisk with relative paths.
 * obelisk-route
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
   * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -81,15 +81,10 @@ initSource = foldl1 (<|>)
 initForce :: Parser Bool
 initForce = switch (long "force" <> help "Allow ob init to overwrite files")
 
--- | Use this option to enable relative paths
-useRelativePathsOpt :: Parser Bool
-useRelativePathsOpt = switch (long "use-relative-path" <> help "Allow ob run with relative paths. It may break on darwin when /nix is mounted on other volumes.")
-
-
 data ObCommand
    = ObCommand_Init InitSource Bool
    | ObCommand_Deploy DeployCommand
-   | ObCommand_Run [(FilePath, Interpret)] Bool (Maybe FilePath)
+   | ObCommand_Run [(FilePath, Interpret)] (Maybe FilePath)
    | ObCommand_Profile String [String]
    | ObCommand_Thunk ThunkOption
    | ObCommand_Repl [(FilePath, Interpret)]
@@ -106,7 +101,6 @@ data ObInternal
    = ObInternal_ApplyPackages String String String [String]
    | ObInternal_ExportGhciConfig
       [(FilePath, Interpret)]
-      Bool -- ^ Use relative paths
    deriving Show
 
 obCommand :: ArgsConfig -> Parser ObCommand
@@ -114,7 +108,7 @@ obCommand cfg = hsubparser
   (mconcat
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
-    , command "run" $ info (ObCommand_Run <$> interpretOpts <*> useRelativePathsOpt <*> certDirOpts) $ progDesc "Run current project in development mode"
+    , command "run" $ info (ObCommand_Run <$> interpretOpts <*> certDirOpts) $ progDesc "Run current project in development mode"
     , command "profile" $ info (uncurry ObCommand_Profile <$> profileCommand) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkOption) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (ObCommand_Repl <$> interpretOpts) $ progDesc "Open an interactive interpreter"
@@ -131,11 +125,9 @@ obCommand cfg = hsubparser
 
 internalCommand :: Parser ObInternal
 internalCommand = hsubparser $ mconcat
-  [ command "export-ghci-configuration" $ info (ObInternal_ExportGhciConfig <$> interpretOpts <*> useRelativePathsFlag)
+  [ command "export-ghci-configuration" $ info (ObInternal_ExportGhciConfig <$> interpretOpts)
       $ progDesc "Export the GHCi configuration used by ob run, etc.; useful for IDE integration"
   ]
-  where
-    useRelativePathsFlag = switch (long "use-relative-paths" <> help "Use relative paths")
 
 packageNames :: Parser [String]
 packageNames = some (strArgument (metavar "PACKAGE-NAME..."))
@@ -411,7 +403,7 @@ ob = \case
       deployPush deployPath deployBuilders
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
-  ObCommand_Run interpretPathsList relPath certDir -> withInterpretPaths interpretPathsList (run relPath certDir)
+  ObCommand_Run interpretPathsList certDir -> withInterpretPaths interpretPathsList (run certDir)
   ObCommand_Profile basePath rtsFlags -> profile basePath rtsFlags
   ObCommand_Thunk to -> case _thunkOption_command to of
     ThunkCommand_Update config -> for_ thunks (updateThunkToLatest config)
@@ -431,8 +423,8 @@ ob = \case
   ObCommand_Internal icmd -> case icmd of
     ObInternal_ApplyPackages origPath inPath outPath packagePaths -> do
       liftIO $ Preprocessor.applyPackages origPath inPath outPath packagePaths
-    ObInternal_ExportGhciConfig interpretPathsList useRelativePaths ->
-      liftIO . putStrLn . unlines =<< withInterpretPaths interpretPathsList (exportGhciConfig useRelativePaths)
+    ObInternal_ExportGhciConfig interpretPathsList ->
+      liftIO . putStrLn . unlines =<< withInterpretPaths interpretPathsList exportGhciConfig
 
 -- | A helper for the common case that the command you want to run needs the project root and a resolved
 -- set of interpret paths.


### PR DESCRIPTION
Due to the behavior of cross-volume relative paths on MacOS, we cannot create `.ghci` that employ them. This may break old IDE integration, but alternative solutions will have to be explored if this is still an issue for users. The robustness of the main mode of operation of obelisk, on all supported platforms, must take precedence over experimental integrations.

See #936 for an attempt to preserve backward compatibility which broke self-test in a surprising way.