### PR TITLE
Remove partial decoding function

### DIFF
--- a/skeleton/frontend/src/Frontend.hs
+++ b/skeleton/frontend/src/Frontend.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -44,9 +45,13 @@ frontend = Frontend
 
       elAttr "img" ("src" =: $(static "obelisk.jpg")) blank
       el "div" $ do
-        exampleConfig <- getConfig "common/example"
-        case exampleConfig of
-          Nothing -> text "No config file found in config/common/example"
-          Just s -> text $ T.decodeUtf8 s
+        let
+          cfg = "common/example"
+          path = "config/" <> cfg
+        getConfig cfg >>= \case
+          Nothing -> text $ "No config file found in " <> path
+          Just bytes -> case T.decodeUtf8' bytes of
+            Left ue -> text $ "Couldn't decode " <> path <> " : " <> T.pack (show ue)
+            Right s -> text s
       return ()
   }


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

Annoying, but should be better than having a partial function laying around in the skeleton.

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
