### PR TITLE
Updating Configs on ob deploy push

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,7 @@ This project's release branch is `master`. This log is written from the perspect
 * Static Assets
   * [#922](https://github.com/obsidiansystems/obelisk/pull/922): Serve .wasm files with the correct MIME type
   * [#930](https://github.com/obsidiansystems/obelisk/pull/930): Add an error to ob run when `static` is called with a path to a file that doesn't exist
+  * [#940](https://github.com/obsidiansystems/obelisk/pull/940): Instant, auto update to new configs on ob deploy push
 
 ## v1.0.0.0 - 2022-01-04
 

--- a/default.nix
+++ b/default.nix
@@ -135,7 +135,7 @@ in rec {
       , internalPort ? 8000
       , backendArgs ? "--port=${toString internalPort}"
       , redirectHosts ? [] # Domains to redirect to routeHost; importantly, these domains will be added to the SSL certificate
-      , configHash ? null
+      , configHash ? ""
       , ...
       }: {...}:
       assert lib.assertMsg (!(builtins.elem routeHost redirectHosts)) "routeHost may not be a member of redirectHosts";
@@ -212,7 +212,7 @@ in rec {
       echo ${version} > $out/version
     '';
 
-  server = { exe, hostName, adminEmail, routeHost, enableHttps, version, module ? serverModules.mkBaseEc2, redirectHosts ? [] }@args:
+  server = { exe, hostName, adminEmail, routeHost, enableHttps, version, module ? serverModules.mkBaseEc2, redirectHosts ? [], configHash ? "" }@args:
     let
       nixos = import (pkgs.path + /nixos);
     in nixos {

--- a/default.nix
+++ b/default.nix
@@ -400,7 +400,7 @@ in rec {
       linuxExeConfigurable = linuxExe;
       linuxExe = linuxExe dummyVersion;
       exe = serverOn mainProjectOut dummyVersion;
-      server = args@{ hostName, adminEmail, routeHost, enableHttps, version, module ? serverModules.mkBaseEc2, redirectHosts ? [] }:
+      server = args@{ hostName, adminEmail, routeHost, enableHttps, version, module ? serverModules.mkBaseEc2, redirectHosts ? [], configHash ? "" }:
         server (args // { exe = linuxExe version; });
       obelisk = import (base' + "/.obelisk/impl") {};
     };

--- a/default.nix
+++ b/default.nix
@@ -135,6 +135,7 @@ in rec {
       , internalPort ? 8000
       , backendArgs ? "--port=${toString internalPort}"
       , redirectHosts ? [] # Domains to redirect to routeHost; importantly, these domains will be added to the SSL certificate
+      , configHash ? null
       , ...
       }: {...}:
       assert lib.assertMsg (!(builtins.elem routeHost redirectHosts)) "routeHost may not be a member of redirectHosts";
@@ -169,6 +170,7 @@ in rec {
         restartIfChanged = true;
         path = [ pkgs.gnutar ];
         script = ''
+          echo "Expecting config hash to be ${configHash}, but not verifying this"
           ln -sft . '${exe}'/*
           mkdir -p log
           exec ./backend ${backendArgs} </dev/null

--- a/default.nix
+++ b/default.nix
@@ -169,6 +169,8 @@ in rec {
         after = [ "network.target" ];
         restartIfChanged = true;
         path = [ pkgs.gnutar ];
+        # Note that the echo here's value is that it causes a server restart
+        # anytime the configs have changed. see deployPush in Obelisk.Command.Deploy
         script = ''
           echo "Expecting config hash to be ${configHash}, but not verifying this"
           ln -sft . '${exe}'/*

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -48,7 +48,7 @@ import Prettyprinter.Render.String (renderString)
 
 import Obelisk.App (MonadObelisk)
 import Obelisk.CliApp (
-  Severity (..), callProcessAndLogOutput, failWith, proc, putLog, readProcessAndLogOutput,
+  Severity (..), callProcessAndLogOutput, failWith, proc, putLog, 
   setCwd, setDelegateCtlc, setEnvOverride, withSpinner, readCreateProcessWithExitCode)
 import Obelisk.Command.Nix
 import Obelisk.Command.Project
@@ -143,12 +143,6 @@ deployInit' thunkPtr (DeployInitOpts deployDir sshKeyPath hostnames route adminE
 
   withSpinner ("Initializing git repository (" <> T.pack deployDir <> ")") $
     initGit deployDir
-
-type CommitHash = T.Text 
-getCommitHash :: MonadObelisk m => FilePath -> FilePath -> m CommitHash
-getCommitHash repo pathWithinRepo = do
-  let git = readProcessAndLogOutput (Debug, Debug) . gitProc repo
-  git ["rev-parse", "HEAD:" <> pathWithinRepo]
 
 -- | Installs an obelisk impl in the staging dir that points at the obelisk of the
 -- project thunk.

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -206,7 +206,7 @@ deployPush deployPath builders = do
         , rawArg "redirectHosts" $ renderString $ layoutCompact $ prettyNix $ Nix.mkList $ Nix.mkStr . T.pack <$> Set.toList redirectHosts
         , strArg "version" version
         , boolArg "enableHttps" enableHttps
-        , strArg "configHash" $ T.unpack configHash
+        , strArg "configHash" $ T.unpack $ T.strip configHash
         ] <> [rawArg "module" ("import " <> toNixPath moduleFile) | moduleFileExists ])
       & nixCmdConfig_builders .~ builders
     pure result

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -182,6 +182,7 @@ deployPush deployPath builders = do
   let version = show . _thunkRev_commit $ _thunkPtr_rev thunkPtr
   let moduleFile = deployPath </> "module.nix"
   moduleFileExists <- liftIO $ doesFileExist moduleFile
+  configHash <- error "Not implemented; we need to ensure that the config directory is committed and fully pushed (i *think* we already do that somewhere) and then we can use git to get the tree hash of the config dir"
   buildOutputByHost <- ifor (Map.fromSet (const ()) hosts) $ \host () -> do
     --TODO: What does it mean if this returns more or less than 1 line of output?
     [result] <- fmap lines $ nixCmd $ NixCmd_Build $ def
@@ -198,6 +199,7 @@ deployPush deployPath builders = do
         , rawArg "redirectHosts" $ renderString $ layoutCompact $ prettyNix $ Nix.mkList $ Nix.mkStr . T.pack <$> Set.toList redirectHosts
         , strArg "version" version
         , boolArg "enableHttps" enableHttps
+        , strArg "configHash" configHash
         ] <> [rawArg "module" ("import " <> toNixPath moduleFile) | moduleFileExists ])
       & nixCmdConfig_builders .~ builders
     pure result

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -48,7 +48,7 @@ import Prettyprinter.Render.String (renderString)
 
 import Obelisk.App (MonadObelisk)
 import Obelisk.CliApp (
-  Severity (..), callProcessAndLogOutput, failWith, proc, putLog, 
+  Severity (..), callProcessAndLogOutput, failWith, proc, putLog,
   setCwd, setDelegateCtlc, setEnvOverride, withSpinner, readCreateProcessWithExitCode)
 import Obelisk.Command.Nix
 import Obelisk.Command.Project
@@ -182,8 +182,8 @@ deployPush deployPath builders = do
   let version = show . _thunkRev_commit $ _thunkPtr_rev thunkPtr
   let moduleFile = deployPath </> "module.nix"
   moduleFileExists <- liftIO $ doesFileExist moduleFile
-  --configHash <- error "Not implemented; we need to ensure that the config directory is committed and fully pushed (i *think* we already do that somewhere) and then we can use git to get the tree hash of the config dir"
-  configHash <- getCommitHash deployPath "config"
+
+  configHash <- getGitHash deployPath "config"
   buildOutputByHost <- ifor (Map.fromSet (const ()) hosts) $ \host () -> do
     --TODO: What does it mean if this returns more or less than 1 line of output?
     [result] <- fmap lines $ nixCmd $ NixCmd_Build $ def
@@ -200,7 +200,7 @@ deployPush deployPath builders = do
         , rawArg "redirectHosts" $ renderString $ layoutCompact $ prettyNix $ Nix.mkList $ Nix.mkStr . T.pack <$> Set.toList redirectHosts
         , strArg "version" version
         , boolArg "enableHttps" enableHttps
-        , strArg "configHash" $ T.unpack $ T.strip configHash
+        , strArg "configHash" $ T.unpack $ T.strip (_gitHash_text configHash)
         ] <> [rawArg "module" ("import " <> toNixPath moduleFile) | moduleFileExists ])
       & nixCmdConfig_builders .~ builders
     pure result

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -260,11 +260,21 @@ toGitRef = \case
     | otherwise -> GitRef_Other r
 
 
-type CommitHash = T.Text 
-getCommitHash :: MonadObelisk m => FilePath -> FilePath -> m CommitHash
-getCommitHash repo pathWithinRepo = do
+-- | A Git hash. Can represent a specific commit, or a file within a
+-- commit.
+newtype GitHash = GitHash { _gitHash_text :: T.Text }
+
+-- | Ask @git@ for the hash of a specific tree (file, directory) within
+-- the given repository. The hash of the given path is always computed
+-- with respect to the @HEAD@ revision.
+getGitHash
+  :: MonadObelisk m
+  => FilePath -- ^ The repository to call @git@ in
+  -> FilePath -- ^ The tree to hash
+  -> m GitHash
+getGitHash repo pathWithinRepo = do
   let git = readProcessAndLogOutput (Debug, Debug) . gitProc repo
-  git ["rev-parse", "HEAD:" <> pathWithinRepo]
+  GitHash <$> git ["rev-parse", "HEAD:" <> pathWithinRepo]
 
 
 type CommitId = Text

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -259,6 +259,14 @@ toGitRef = \case
     | Just s <- "refs/tags/" `T.stripPrefix` r -> GitRef_Tag s
     | otherwise -> GitRef_Other r
 
+
+type CommitHash = T.Text 
+getCommitHash :: MonadObelisk m => FilePath -> FilePath -> m CommitHash
+getCommitHash repo pathWithinRepo = do
+  let git = readProcessAndLogOutput (Debug, Debug) . gitProc repo
+  git ["rev-parse", "HEAD:" <> pathWithinRepo]
+
+
 type CommitId = Text
 
 type GitLsRemoteMaps = (Map GitRef GitRef, Map GitRef CommitId)


### PR DESCRIPTION
Originally from #469 and Issue #372. This fix now ensures that any changes the user makes to the config directory of their deploy directory, will be instantly in use upon ob deploy push. 

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
