### PR TITLE
Update README.md - nix-daemon restart on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Obelisk assumes basic knowledge of [Haskell](https://www.haskell.org/) and [Refl
           ```nix
           sandbox = true
           ```
+          then restart the nix daemon
+          ```bash
+          sudo systemctl restart nix-daemon
+          ```
         * If you're on MacOS, disable sandboxing (there are still some impure dependencies for now) by adding the following:
           ```nix
           sandbox = false


### PR DESCRIPTION
Current instructions for nix-daemon only apply to MacOS however after seeing ghc building again on linux, I tried restarting the nix-daemon via systemctl (linux-specific) and it went from building GHC to instantaneously done. 

I put WIP because I'd like to verify that this wasn't flukey. Nix should behave similarly to how it would on MacOS where we know to restart the daemon. 

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
