### PR TITLE
Invoke shells in a more pure way; escape ghcid commands differently

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#870](https://github.com/obsidiansystems/obelisk/pull/870): Host redirection added to `ob deploy`. Readme updated with tutorial for new functionality.
   * [#931](https://github.com/obsidiansystems/obelisk/pull/931): Fix bug in `ob deploy init` where `ssh-keygen` was not found in nix store.
   * [#934](https://github.com/obsidiansystems/obelisk/pull/934)[#936](https://github.com/obsidiansystems/obelisk/pull/936): obelisk now always uses absolute paths when generating `.ghci` files for REPL and IDE support. This is a **BREAKING** change for some old tools that could not handle absolute paths properly. However, due to the behavior of cross-volume relative paths on certain platforms, such as modern MacOS, we cannot guarantee proper operation of obelisk with relative paths.
+  * [#948](https://github.com/obsidiansystems/obelisk/pull/948): obelisk now always invokes bash instead of the system-wide shell when it can. Some sub-programs, like ghcid, will still use the system-wide shell, which can cause subtle problems due to impurities.
 * obelisk-route
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
   * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`

--- a/lib/cliapp/obelisk-cliapp.cabal
+++ b/lib/cliapp/obelisk-cliapp.cabal
@@ -26,6 +26,7 @@ library
     , time
     , transformers
     , utf8-string
+    , which
   exposed-modules:
     Obelisk.CliApp
   other-modules:

--- a/lib/cliapp/src/Obelisk/CliApp/Process.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Process.hs
@@ -77,7 +77,7 @@ proc cmd args = ProcessSpec (Process.proc cmd args) Nothing
 bashPath :: FilePath
 bashPath = $(staticWhich "bash")
 
--- | We do not use Process.shell because it invokes "/bin/sh", which
+-- | We do not use Process.shell because it invokes @/bin/sh@, which
 -- is a huge impurity for us. Unfortunately, we cannot guarantee that
 -- our dependent executables, such as ghcid, do the same.
 --

--- a/lib/cliapp/src/Obelisk/CliApp/Process.hs
+++ b/lib/cliapp/src/Obelisk/CliApp/Process.hs
@@ -77,7 +77,7 @@ proc cmd args = ProcessSpec (Process.proc cmd args) Nothing
 bashPath :: FilePath
 bashPath = $(staticWhich "bash")
 
--- | We do not use Process.shell because it invokes @/bin/sh@, which
+-- | We do not use Process.shell because it invokes @\/bin\/sh@, which
 -- is a huge impurity for us. Unfortunately, we cannot guarantee that
 -- our dependent executables, such as ghcid, do the same.
 --

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -313,7 +313,7 @@ nixShellRunConfig root isPure command = do
       , [cs]
       ])
 
--- | Escape using ANSI C-style quotes $''
+-- | Escape using ANSI C-style quotes @$''@
 -- This does not work with all shells! Ideally, we would control exactly which shell is used,
 -- down to its sourced configuration, throughout the obelisk environment. At this time, this
 -- is not feasible.
@@ -323,7 +323,7 @@ bashEscape = BSU.toString . bytes . bash . BSU.fromString
 -- | Escape using Bourne style shell escaping
 -- This is not as robust, but is necessary if we are passing to a shell we don't control.
 -- The most prominent issue is that 'System.Process' executes shell commands by invoking
--- @/bin/sh@ instead of something configurable. While we can avoid this by specifying a shell manually,
+-- @\/bin\/sh@ instead of something configurable. While we can avoid this by specifying a shell manually,
 -- we cannot guarantee that our dependencies do the same. In particular, ghcid invokes its
 -- subcommands that way.
 shEscape :: String -> String

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -568,7 +568,7 @@ runGhcid root chdirToRoot ghciArgs (toList -> packages) mcmd =
       , maybe [] (\cmd -> ["--test=" <> cmd]) mcmd
       -- N.B. the subcommand to ghcid has to be itself escaped.
       -- We have to use 'shEscape' instead of 'bashEscape' because
-      -- ghcid invokes System.Process with a shell command, which uses @/bin/sh@
+      -- ghcid invokes System.Process with a shell command, which uses @\/bin\/sh@
       -- instead of the @bash@ we have in scope.
       -- This is not guaranteed to be bash on non-NixOS systems.
       , ["--command=" <> unwords (fmap shEscape ("ghci" : ghciArgs))]

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -567,7 +567,11 @@ runGhcid root chdirToRoot ghciArgs (toList -> packages) mcmd =
       , map (\x -> "--restart=" <> x) restartFiles
       , maybe [] (\cmd -> ["--test=" <> cmd]) mcmd
       -- N.B. the subcommand to ghcid has to be itself escaped.
-      , ["--command=" <> unwords (fmap bashEscape ("ghci" : ghciArgs))]
+      -- We have to use 'shEscape' instead of 'bashEscape' because
+      -- ghcid invokes System.Process with a shell command, which uses @/bin/sh@
+      -- instead of the @bash@ we have in scope.
+      -- This is not guaranteed to be bash on non-NixOS systems.
+      , ["--command=" <> unwords (fmap shEscape ("ghci" : ghciArgs))]
       ]
     adjustRoot x = if chdirToRoot then makeRelative root x else x
     reloadFiles = map adjustRoot [root </> "config"]


### PR DESCRIPTION
System.Process invokes `shell` commands using "/bin/sh". Uh-oh! That's
not what we want at all. So, instead, we manually invoke our shells
explicitly using "/usr/bin/env" so that the "sh" alias that nix-shell
installs is picked up.

However, we cannot control the executables we depend on, like ghcid,
which also use System.Process. Since that is the case, we need to fall
back to more generic, but less "surefire" escaping, that works for all
bourne-style shells.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [x] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
