### PR TITLE
Set coding failure mode to transliterate

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#931](https://github.com/obsidiansystems/obelisk/pull/931): Fix bug in `ob deploy init` where `ssh-keygen` was not found in nix store.
   * [#934](https://github.com/obsidiansystems/obelisk/pull/934)[#936](https://github.com/obsidiansystems/obelisk/pull/936): obelisk now always uses absolute paths when generating `.ghci` files for REPL and IDE support. This is a **BREAKING** change for some old tools that could not handle absolute paths properly. However, due to the behavior of cross-volume relative paths on certain platforms, such as modern MacOS, we cannot guarantee proper operation of obelisk with relative paths.
   * [#948](https://github.com/obsidiansystems/obelisk/pull/948): obelisk now always invokes bash instead of the system-wide shell when it can. Some sub-programs, like ghcid, will still use the system-wide shell, which can cause subtle problems due to impurities.
+  * [#949](https://github.com/obsidiansystems/obelisk/pull/949): obelisk now configures its output and error streams to transliterate unsupported to a known-good replacement character.
 * obelisk-route
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
   * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -21,7 +21,8 @@ import System.Directory
 import System.Environment
 import System.FilePath
 import qualified System.Info
-import System.IO (hIsTerminalDevice, stdout, stderr, hGetEncoding, hSetEncoding, mkTextEncoding, textEncodingName)
+import System.IO (hIsTerminalDevice, Handle, stdout, stderr, hGetEncoding, hSetEncoding, mkTextEncoding)
+import GHC.IO.Encoding.Types (textEncodingName)
 import System.Process (rawSystem)
 
 import Obelisk.App
@@ -372,8 +373,8 @@ main' argsCfg = do
   -- TransliterateCodingFailure so that, on encodings which do not
   -- support our fancy characters, we print a replacement character
   -- instead of exploding.
-  hSetTranslit stdout
-  hSetTranslit stderr
+  liftIO $ hSetTranslit stdout
+  liftIO $ hSetTranslit stderr
 
   putLog Debug $ T.pack $ unwords
     [ "Starting Obelisk <" <> obPath <> ">"

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -353,7 +353,7 @@ main :: IO ()
 main = runCommand . main' =<< getArgsConfig
 
 -- | Change the character encoding of the given Handle to transliterate
--- on unsupported characters, instead of throwing an exception.
+-- unsupported characters, instead of throwing an exception.
 hSetTranslit :: Handle -> IO ()
 hSetTranslit h = do
   menc <- hGetEncoding h


### PR DESCRIPTION
This changes the `CodingFailureMode` of the standard output and standard error streams for Obelisk to `TransliterateCodingFailure`; the text encoding is otherwise unchanged. The result is that, rather than exploding on invalid characters, we print a replacement character (currently this is `?`, since that's what GHC does). Fixes #908, fixes #805 and quite possibly #810.

Did you know that this is also how GHC handles _its_ output? [No, seriously](https://hackage.haskell.org/package/ghc-boot-9.2.2/docs/src/GHC-HandleEncoding.html#configureHandleEncoding). 

I have:

  - [X] Based work on latest `develop` branch
  - [X] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)