### PR TITLE
ob run: allow overriding the port

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#934](https://github.com/obsidiansystems/obelisk/pull/934)[#936](https://github.com/obsidiansystems/obelisk/pull/936): obelisk now always uses absolute paths when generating `.ghci` files for REPL and IDE support. This is a **BREAKING** change for some old tools that could not handle absolute paths properly. However, due to the behavior of cross-volume relative paths on certain platforms, such as modern MacOS, we cannot guarantee proper operation of obelisk with relative paths.
   * [#948](https://github.com/obsidiansystems/obelisk/pull/948): obelisk now always invokes bash instead of the system-wide shell when it can. Some sub-programs, like ghcid, will still use the system-wide shell, which can cause subtle problems due to impurities.
   * [#949](https://github.com/obsidiansystems/obelisk/pull/949): obelisk now configures its output and error streams to transliterate unsupported to a known-good replacement character.
+  * [#951](https://github.com/obsidiansystems/obelisk/pull/949): Add `ob run --port` which allows the user to override the port on which the app is served, rather than always using the port configured in the route.
 * obelisk-route
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
   * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`

--- a/default.nix
+++ b/default.nix
@@ -386,7 +386,7 @@ in rec {
           main :: IO ()
           main = do
             [portStr, assets, profFileName] <- getArgs
-            Obelisk.Run.run (read portStr) Nothing (Obelisk.Run.runServeAsset assets) Backend.backend Frontend.frontend
+            Obelisk.Run.run (read portStr) Nothing Nothing (Obelisk.Run.runServeAsset assets) Backend.backend Frontend.frontend
               `finally` writeProfilingData (profFileName ++ ".rprof")
         '';
       in nixpkgs.runCommand "ob-run" {

--- a/default.nix
+++ b/default.nix
@@ -386,7 +386,7 @@ in rec {
           main :: IO ()
           main = do
             [portStr, assets, profFileName] <- getArgs
-            Obelisk.Run.run (defaultRunApp Backend.backend Frontend.frontend (Obelisk.Run.runServeAsset assets)){ Obelisk.Run._runApp_backendPort = read portStr }
+            Obelisk.Run.run (Obelisk.Run.defaultRunApp Backend.backend Frontend.frontend (Obelisk.Run.runServeAsset assets)){ Obelisk.Run._runApp_backendPort = read portStr }
               `finally` writeProfilingData (profFileName ++ ".rprof")
         '';
       in nixpkgs.runCommand "ob-run" {

--- a/default.nix
+++ b/default.nix
@@ -386,7 +386,7 @@ in rec {
           main :: IO ()
           main = do
             [portStr, assets, profFileName] <- getArgs
-            Obelisk.Run.run (read portStr) Nothing Nothing (Obelisk.Run.runServeAsset assets) Backend.backend Frontend.frontend
+            Obelisk.Run.run (defaultRunApp Backend.backend Frontend.frontend (Obelisk.Run.runServeAsset assets)){ _runApp_backendPort = read portSrt }
               `finally` writeProfilingData (profFileName ++ ".rprof")
         '';
       in nixpkgs.runCommand "ob-run" {

--- a/default.nix
+++ b/default.nix
@@ -386,7 +386,7 @@ in rec {
           main :: IO ()
           main = do
             [portStr, assets, profFileName] <- getArgs
-            Obelisk.Run.run (defaultRunApp Backend.backend Frontend.frontend (Obelisk.Run.runServeAsset assets)){ _runApp_backendPort = read portSrt }
+            Obelisk.Run.run (defaultRunApp Backend.backend Frontend.frontend (Obelisk.Run.runServeAsset assets)){ _runApp_backendPort = read portStr }
               `finally` writeProfilingData (profFileName ++ ".rprof")
         '';
       in nixpkgs.runCommand "ob-run" {

--- a/default.nix
+++ b/default.nix
@@ -386,7 +386,7 @@ in rec {
           main :: IO ()
           main = do
             [portStr, assets, profFileName] <- getArgs
-            Obelisk.Run.run (defaultRunApp Backend.backend Frontend.frontend (Obelisk.Run.runServeAsset assets)){ _runApp_backendPort = read portStr }
+            Obelisk.Run.run (defaultRunApp Backend.backend Frontend.frontend (Obelisk.Run.runServeAsset assets)){ Obelisk.Run._runApp_backendPort = read portStr }
               `finally` writeProfilingData (profFileName ++ ".rprof")
         '';
       in nixpkgs.runCommand "ob-run" {

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -114,7 +114,7 @@ obCommand cfg = hsubparser
       (   ObCommand_Run
       <$> interpretOpts
       <*> certDirOpts
-      <*> (Just <$> option auto (long "port" <> short 'p' <> help "Port number for server" <> metavar "INT") <|> pure Nothing))
+      <*> (Just <$> option auto (long "port" <> short 'p' <> help "Port number for server; overrides common/config/route" <> metavar "INT") <|> pure Nothing))
       $ progDesc "Run current project in development mode"
     , command "profile" $ info (uncurry ObCommand_Profile <$> profileCommand) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkOption) $ progDesc "Manipulate thunk directories"

--- a/lib/command/src/Obelisk/Command.hs
+++ b/lib/command/src/Obelisk/Command.hs
@@ -24,6 +24,7 @@ import qualified System.Info
 import System.IO (hIsTerminalDevice, Handle, stdout, stderr, hGetEncoding, hSetEncoding, mkTextEncoding)
 import GHC.IO.Encoding.Types (textEncodingName)
 import System.Process (rawSystem)
+import Network.Socket (PortNumber)
 
 import Obelisk.App
 import Obelisk.CliApp
@@ -85,7 +86,7 @@ initForce = switch (long "force" <> help "Allow ob init to overwrite files")
 data ObCommand
    = ObCommand_Init InitSource Bool
    | ObCommand_Deploy DeployCommand
-   | ObCommand_Run [(FilePath, Interpret)] (Maybe FilePath)
+   | ObCommand_Run [(FilePath, Interpret)] (Maybe FilePath) (Maybe PortNumber)
    | ObCommand_Profile String [String]
    | ObCommand_Thunk ThunkOption
    | ObCommand_Repl [(FilePath, Interpret)]
@@ -109,7 +110,12 @@ obCommand cfg = hsubparser
   (mconcat
     [ command "init" $ info (ObCommand_Init <$> initSource <*> initForce) $ progDesc "Initialize an Obelisk project"
     , command "deploy" $ info (ObCommand_Deploy <$> deployCommand cfg) $ progDesc "Prepare a deployment for an Obelisk project"
-    , command "run" $ info (ObCommand_Run <$> interpretOpts <*> certDirOpts) $ progDesc "Run current project in development mode"
+    , command "run" $ info
+      (   ObCommand_Run
+      <$> interpretOpts
+      <*> certDirOpts
+      <*> (Just <$> option auto (long "port" <> short 'p' <> help "Port number for server" <> metavar "INT") <|> pure Nothing))
+      $ progDesc "Run current project in development mode"
     , command "profile" $ info (uncurry ObCommand_Profile <$> profileCommand) $ progDesc "Run current project with profiling enabled"
     , command "thunk" $ info (ObCommand_Thunk <$> thunkOption) $ progDesc "Manipulate thunk directories"
     , command "repl" $ info (ObCommand_Repl <$> interpretOpts) $ progDesc "Open an interactive interpreter"
@@ -423,7 +429,7 @@ ob = \case
       deployPush deployPath deployBuilders
     DeployCommand_Update -> deployUpdate "."
     DeployCommand_Test (platform, extraArgs) -> deployMobile platform extraArgs
-  ObCommand_Run interpretPathsList certDir -> withInterpretPaths interpretPathsList (run certDir)
+  ObCommand_Run interpretPathsList certDir servePort -> withInterpretPaths interpretPathsList (run certDir servePort)
   ObCommand_Profile basePath rtsFlags -> profile basePath rtsFlags
   ObCommand_Thunk to -> case _thunkOption_command to of
     ThunkCommand_Update config -> for_ thunks (updateThunkToLatest config)

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -178,12 +178,14 @@ run
   :: MonadObelisk m
   => Maybe FilePath
   -- ^ Certificate Directory path (optional)
+  -> Maybe Socket.PortNumber
+  -- ^ override the route's port number?
   -> FilePath
   -- ^ root folder
   -> PathTree Interpret
   -- ^ interpreted paths
   -> m ()
-run certDir root interpretPaths = do
+run certDir portOverride root interpretPaths = do
   pkgs <- getParsedLocalPkgs root interpretPaths
   (assetType, assets) <- findProjectAssets root
   manifestPkg <- parsePackagesOrFail . (:[]) . T.unpack =<< getHaskellManifestProjectPath root
@@ -200,6 +202,7 @@ run certDir root interpretPaths = do
     runGhcid root True (ghciArgs <> dotGhciArgs) pkgs $ Just $ unwords
       [ "Obelisk.Run.run"
       , show freePort
+      , "(" ++ show portOverride ++ ")"
       , "(" ++ show certDir ++ ")"
       , "(Obelisk.Run.runServeAsset " ++ show assets ++ ")"
       , "Backend.backend"

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -200,13 +200,14 @@ run certDir portOverride root interpretPaths = do
   freePort <- getFreePort
   withGhciScriptArgs pkgs $ \dotGhciArgs -> do
     runGhcid root True (ghciArgs <> dotGhciArgs) pkgs $ Just $ unwords
-      [ "Obelisk.Run.run"
-      , show freePort
-      , "(" ++ show portOverride ++ ")"
-      , "(" ++ show certDir ++ ")"
-      , "(Obelisk.Run.runServeAsset " ++ show assets ++ ")"
+      [ "Obelisk.Run.run (defaultRunApp"
       , "Backend.backend"
       , "Frontend.frontend"
+      , "(Obelisk.Run.runServeAsset " ++ show assets ++ ")"
+      , ") { _runApp_backendPort =", show freePort
+      , ", _runApp_forceFrontendPort =", show portOverride
+      , ", _runApp_tlsCertDirectory =", show certDir
+      , "}"
       ]
 
 runRepl :: MonadObelisk m => FilePath -> PathTree Interpret -> m ()

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -200,13 +200,13 @@ run certDir portOverride root interpretPaths = do
   freePort <- getFreePort
   withGhciScriptArgs pkgs $ \dotGhciArgs -> do
     runGhcid root True (ghciArgs <> dotGhciArgs) pkgs $ Just $ unwords
-      [ "Obelisk.Run.run (defaultRunApp"
+      [ "Obelisk.Run.run (Obelisk.Run.defaultRunApp"
       , "Backend.backend"
       , "Frontend.frontend"
       , "(Obelisk.Run.runServeAsset " ++ show assets ++ ")"
-      , ") { _runApp_backendPort =", show freePort
-      , ", _runApp_forceFrontendPort =", show portOverride
-      , ", _runApp_tlsCertDirectory =", show certDir
+      , ") { Obelisk.Run._runApp_backendPort =", show freePort
+      ,   ", Obelisk.Run._runApp_forceFrontendPort =", show portOverride
+      ,   ", Obelisk.Run._runApp_tlsCertDirectory =", show certDir
       , "}"
       ]
 

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -226,7 +226,6 @@ bindPortTCPRetry :: Settings
                  -> Int
                  -> IO Socket
 bindPortTCPRetry settings m n = catch (bindPortTCP (settingsPort settings) (settingsHost settings)) $ \(e :: IOError) -> do
-  print (settingsHost settings, settingsPort settings)
   m e
   threadDelay $ 1000000 * n
   bindPortTCPRetry settings (\_ -> pure ()) n

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -22,7 +22,7 @@ import Prelude hiding ((.), id)
 import Control.Category
 import Control.Concurrent
 import Control.Exception
-import Control.Lens ((%~), (^?), _Just, _Right)
+import Control.Lens ((%~), (^?), (?~), _Just, _Right)
 import qualified Data.Attoparsec.ByteString.Char8 as A
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -135,7 +135,7 @@ runWidget conf configs frontend validFullEncoder = do
       redirectHost = _runConfig_redirectHost conf
       redirectPort = _runConfig_redirectPort conf
       beforeMainLoop = do
-        putStrLn $ "Frontend running on " ++ T.unpack (URI.render (uri & uriAuthority . _Right . authPort .~ Just (fromInteger (fromIntegral port))))
+        putStrLn $ "Frontend running on " ++ T.unpack (URI.render (uri & uriAuthority . _Right . authPort ?~ (fromInteger (fromIntegral port))))
       settings = setBeforeMainLoop beforeMainLoop (setPort port (setTimeout 3600 defaultSettings))
       -- Providing TLS here will also incidentally provide it to proxied requests to the backend.
       prepareRunner = case uri ^? uriScheme . _Just . unRText of

--- a/lib/run/src/Obelisk/Run.hs
+++ b/lib/run/src/Obelisk/Run.hs
@@ -21,6 +21,7 @@ import Prelude hiding ((.), id)
 
 import Control.Category
 import Control.Concurrent
+import Control.Applicative
 import Control.Exception
 import Control.Lens ((%~), (^?), (?~), _Just, _Right)
 import qualified Data.Attoparsec.ByteString.Char8 as A
@@ -77,37 +78,87 @@ import Web.Cookie
 import qualified System.Which
 #endif
 
-run
-  :: Int -- ^ Port to run the backend
-  -> Maybe Int
-  -> Maybe FilePath -- ^ Optional directory in which to find "cert.pem", "chain.pem" and "privkey.pem" to be used for TLS.
-                    -- If this is Nothing and TLS is enabled, we'll generate a self-signed cert.
-  -> ([Text] -> Snap ()) -- ^ Static asset handler
-  -> Backend backendRoute frontendRoute -- ^ Backend
-  -> Frontend (R frontendRoute) -- ^ Frontend
-  -> IO ()
-run port frontendPort certDir serveStaticAsset backend frontend = do
+-- | The arguments to 'run', specifying the configuration and
+-- implementation of an Obelisk application.
+data RunApp backendRoute frontendRoute
+  = RunApp
+    { _runApp_backendPort      :: Int
+      -- ^ What port should we serve the backend on? This is used for
+      -- internal communication.
+    , _runApp_backendHost      :: ByteString
+      -- ^ The hostname on which the backend is running. By default,
+      -- this is @127.0.0.1@, i.e., the local machine. Routes not
+      -- handled by the frontend will be redirected to this host.
+    , _runApp_forceFrontendPort :: Maybe Int
+      -- ^ If set, overrides the port on which the frontend will be
+      -- served. If unset, the port will be parsed from the configured
+      -- route.
+    , _runApp_tlsCertDirectory :: Maybe FilePath
+      -- ^ Optional directory in which to find "cert.pem", "chain.pem"
+      -- and "privkey.pem" to be used for TLS.
+      -- If this is 'Nothing' and TLS is enabled, we'll generate a
+      -- self-signed cert.
+    , _runApp_staticHandler    :: [Text] -> Snap ()
+      -- ^ How to serve static assets.
+    , _runApp_backend          :: Backend backendRoute frontendRoute
+      -- ^ The backend.
+    , _runApp_frontend         :: Frontend (R frontendRoute)
+      -- ^ The frontend.
+    }
+
+-- | Construct a 'RunApp' with sane defaults. The TLS certificate
+-- directory will be set to 'Nothing', the backend host will be the
+-- local machine (@127.0.0.1@), the backend port will be set to @3001@,
+-- the frontend port will be fetched from the route configuration.
+defaultRunApp
+  :: Backend backendRoute frontendRoute -- ^ The backend to use
+  -> Frontend (R frontendRoute)         -- ^ The frontend to use
+  -> ([Text] -> Snap ())                -- ^ How to serve static assets
+  -> RunApp backendRoute frontendRoute
+defaultRunApp be fe static = RunApp
+  { _runApp_backendPort = 3001
+  , _runApp_backendHost = "127.0.0.1"
+  , _runApp_forceFrontendPort = Nothing
+  , _runApp_tlsCertDirectory = Nothing
+  , _runApp_staticHandler = static
+  , _runApp_backend = be
+  , _runApp_frontend = fe
+  }
+
+-- | Run an Obelisk application, including the frontend and backend. The
+-- backend routes are served on the port given by '_runApp_backendPort',
+-- but are also accessible through the frontend.
+run :: RunApp backendRoute frontendRoute -> IO ()
+run toRun = do
   prettifyOutput
-  let handleBackendErr (e :: IOException) = hPutStrLn stderr $ "backend stopped; make a change to your code to reload - error " <> show e
+
+  let handleBackendErr (e :: IOException) =
+        hPutStrLn stderr $ "backend stopped; make a change to your code to reload - error " <> show e
+
   --TODO: Use Obelisk.Backend.runBackend; this will require separating the checking and running phases
-  case checkEncoder $ _backend_routeEncoder backend of
+  case checkEncoder $ _backend_routeEncoder (_runApp_backend toRun) of
     Left e -> hPutStrLn stderr $ "backend error:\n" <> T.unpack e
     Right validFullEncoder -> do
       publicConfigs <- getPublicConfigs
-      backendTid <- forkIO $ handle handleBackendErr $ withArgs ["--quiet", "--port", show port] $
-        _backend_run backend $ \serveRoute ->
+
+      -- We start the backend server listening on the
+      -- '_runApp_backendPort'. The backend and frontend run in
+      -- different servers: The frontend server will pass any routes it
+      -- can't handle to this process.
+      backendTid <- forkIO $ handle handleBackendErr $ withArgs ["--quiet", "--port", show (_runApp_backendPort toRun)] $
+        _backend_run (_runApp_backend toRun) $ \serveRoute ->
           runSnapWithCommandLineArgs $
             getRouteWith validFullEncoder >>= \case
               Identity r -> case r of
                 FullRoute_Backend backendRoute :/ a -> serveRoute $ backendRoute :/ a
                 FullRoute_Frontend obeliskRoute :/ a ->
-                  serveDefaultObeliskApp appRouteToUrl (($ allJsUrl) <$> defaultGhcjsWidgets) serveStaticAsset frontend publicConfigs $ obeliskRoute :/ a
+                  serveDefaultObeliskApp appRouteToUrl (($ allJsUrl) <$> defaultGhcjsWidgets)
+                    (_runApp_staticHandler toRun) (_runApp_frontend toRun) publicConfigs $ obeliskRoute :/ a
                   where
                     appRouteToUrl (k :/ v) = renderObeliskRoute validFullEncoder (FullRoute_Frontend (ObeliskRoute_App k) :/ v)
                     allJsUrl = renderAllJsPath validFullEncoder
 
-      let conf = defRunConfig { _runConfig_redirectPort = port, _runConfig_certDir = certDir, _runConfig_portOverride = frontendPort }
-      runWidget conf publicConfigs frontend validFullEncoder `finally` killThread backendTid
+      runWidget toRun publicConfigs validFullEncoder `finally` killThread backendTid
 
 -- Convenience wrapper to handle path segments for 'Snap.serveAsset'
 runServeAsset :: FilePath -> [Text] -> Snap ()
@@ -123,24 +174,42 @@ getConfigRoute configs = case Map.lookup "common/route" configs of
           Nothing -> Left $ "Couldn't parse route as URI; value read was: " <> T.pack (show stripped)
     Nothing -> Left $ "Couldn't find config file common/route; it should contain the site's canonical root URI" <> T.pack (show $ Map.keys configs)
 
+-- | Start the frontend (given in the 'RunApp' record), with the given
+-- configuration and the given 'FullRoute' encoder, which must be valid.
 runWidget
-  :: RunConfig
+  :: RunApp backendRoute frontendRoute
   -> Map Text ByteString
-  -> Frontend (R frontendRoute)
   -> Encoder Identity Identity (R (FullRoute backendRoute frontendRoute)) PageName
   -> IO ()
-runWidget conf configs frontend validFullEncoder = do
+runWidget toRun configs validFullEncoder = do
   uri <- either (fail . T.unpack) pure $ getConfigRoute configs
-  let port = fromMaybe (fromIntegral $ fromMaybe 80 $ uri ^? uriAuthority . _Right . authPort . _Just) (_runConfig_portOverride conf)
-      redirectHost = _runConfig_redirectHost conf
-      redirectPort = _runConfig_redirectPort conf
+  let -- Before we can do anything, we need to pick a port to serve the
+      -- backend on. If the user has asked to override it, then we use that:
+      -- they know what they're doing. Otherwise, we'll use the port
+      -- specified in the route.
+      port = fromMaybe 80 $ (_runApp_forceFrontendPort toRun)
+                        <|> (fmap fromIntegral $ uri ^? uriAuthority . _Right . authPort . _Just)
+      -- This is the *actual* URI on which the frontend is served, i.e.
+      -- the URI from the route configuration but, possibly, with the
+      -- port we picked above. We need to compute this for two reasons:
+      --
+      --   1. The log. Self-explanatory.
+      --   2. JSaddle needs to know where the frontend is served.
+      actualUri = uri & uriAuthority . _Right . authPort ?~ fromInteger (fromIntegral port)
+
+      -- This is the server that will handle the backend requests. We
+      -- support shuttling them off to any host:port pair.
+      redirectHost = _runApp_backendHost toRun
+      redirectPort = _runApp_backendPort toRun
+
       beforeMainLoop = do
-        putStrLn $ "Frontend running on " ++ T.unpack (URI.render (uri & uriAuthority . _Right . authPort ?~ (fromInteger (fromIntegral port))))
+        putStrLn $ "Frontend running on " ++ T.unpack (URI.render actualUri)
       settings = setBeforeMainLoop beforeMainLoop (setPort port (setTimeout 3600 defaultSettings))
+
       -- Providing TLS here will also incidentally provide it to proxied requests to the backend.
       prepareRunner = case uri ^? uriScheme . _Just . unRText of
         Just "https" -> do
-          case _runConfig_certDir conf of
+          case _runApp_tlsCertDirectory toRun of
             Nothing -> do
               -- Generate a private key and self-signed certificate for TLS
               privateKey <- RSA.generateRSAKey' 2048 3
@@ -164,23 +233,32 @@ runWidget conf configs frontend validFullEncoder = do
               putStrLn $ "Using certificate information from: " ++ certDir
               return $ runTLSSocket (tlsSettingsChain (certDir </> "cert.pem") [certDir </> "chain.pem"] (certDir </> "key.pem"))
         _ -> return runSettingsSocket
+
   runner <- prepareRunner
   bracket
-    (bindPortTCPRetry settings (logPortBindErr port) (_runConfig_retryTimeout conf))
+    (bindPortTCPRetry settings (logPortBindErr port) 1)
     close
     (\skt -> do
         man <- newManager defaultManagerSettings
-        app <- obeliskApp configs defaultConnectionOptions frontend validFullEncoder uri $ fallbackProxy redirectHost redirectPort man
+        app <- obeliskApp configs defaultConnectionOptions (_runApp_frontend toRun) validFullEncoder actualUri $ fallbackProxy redirectHost redirectPort man
         runner settings skt app)
 
+
+-- | Build a WAI 'Application' to serve the given Obelisk 'Frontend',
+-- using the specified 'Encoder' to parse routes. Any requests whose
+-- route does not result in a 'FullRoute_Frontend' parse will be
+-- redirected to the backend.
 obeliskApp
   :: forall frontendRoute backendRoute
-  .  Map Text ByteString
-  -> ConnectionOptions
-  -> Frontend (R frontendRoute)
+  .  Map Text ByteString -- ^ The parsed configuration
+  -> ConnectionOptions   -- ^ Connection options for the JSaddle websocket
+  -> Frontend (R frontendRoute) -- ^ The Obelisk frontend
   -> Encoder Identity Identity (R (FullRoute backendRoute frontendRoute)) PageName
+     -- ^ An encoder for parsing frontend routes.
   -> URI
-  -> Application
+    -- ^ The 'URI' on which the 'Frontend' will be served. Used for
+    -- establishing the JSaddle websocket connection.
+  -> Application -- ^ A WAI 'Application' which handles backend requests.
   -> IO Application
 obeliskApp configs opts frontend validFullEncoder uri backend = do
   let mode = FrontendMode
@@ -261,20 +339,3 @@ parseSsPid = do
 fallbackProxy :: ByteString -> Int -> Manager -> Application
 fallbackProxy host port = RP.waiProxyTo handleRequest RP.defaultOnExc
   where handleRequest _req = return $ RP.WPRProxyDest $ RP.ProxyDest host port
-
-data RunConfig = RunConfig
-  { _runConfig_portOverride :: Maybe Int
-  , _runConfig_redirectHost :: ByteString
-  , _runConfig_redirectPort :: Int
-  , _runConfig_retryTimeout :: Int -- seconds
-  , _runConfig_certDir :: Maybe FilePath
-  }
-
-defRunConfig :: RunConfig
-defRunConfig = RunConfig
-  { _runConfig_portOverride = Nothing
-  , _runConfig_redirectHost = "127.0.0.1"
-  , _runConfig_redirectPort = 3001
-  , _runConfig_retryTimeout = 1
-  , _runConfig_certDir = Nothing
-  }

--- a/lib/selftest/src/Obelisk/SelfTest.hs
+++ b/lib/selftest/src/Obelisk/SelfTest.hs
@@ -210,6 +210,14 @@ main' isVerbose httpManager obeliskRepoReadOnly = withInitCache $ \initCache -> 
     it "complains when static files are missing in root directory" $ inTmpObInit $ const $ testObRunInDirWithMissingStaticFile' Nothing
     it "complains when static files are missing in sub directory" $ inTmpObInit $ const $ testObRunInDirWithMissingStaticFile' (Just "frontend")
 
+    it "respects the port given on the command line" $ inTmpObInit $ \testDir -> do
+      [port] <- liftIO $ getFreePorts 1
+      maskExitSuccess $ runHandles ob ["run", "-p", T.pack (show port)] [] $ \_stdin stdout stderr -> do
+        uri <- handleObRunStdout httpManager stdout stderr
+        unless (T.pack (show port ++ "/") `T.isSuffixOf` T.strip uri) $
+          error $ "Expected the URI to end in " ++ show port ++ " but it ended in " ++ T.unpack uri
+        exit 0
+
   describe "ob repl" $ do
     it "accepts stdin commands" $ inTmpObInit $ \_ -> do
       setStdin "print 3\n:q"


### PR DESCRIPTION
Adds a switch `--port` to `ob run` to override, from the command line, the port specified in the route. Fixes #950. 

I have:

  - [X] Based work on latest `develop` branch
  - [X] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [X] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [X] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
