### PR TITLE
Determine whether a reboot is necessary when deploying, and take the appropriate action

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
   * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`
   * [#952](https://github.com/obsidiansystems/obelisk/pull/952): Add a `Semigroupoid` instance for the `Encoder` type, compatible with its existing `Category` instance.
+  * [#957](https://github.com/obsidiansystems/obelisk/pull/957): ob deploy will now detect when the target machine needs to be rebooted after deployment and automatically do so. This is necessary, for example, when the kernel has been updated.
 * Javascript FFI
   * [#844](https://github.com/obsidiansystems/obelisk/pull/844): Jsaddle FFI example extended in skeleton (example project which is installed by `ob init`). Note the remark on minifier renaming in /skeleton/static/lib.js
   * [#903](https://github.com/obsidiansystems/obelisk/pull/903): Added support for a file which allows users to specify global variables and namespaces in JS, that should not be used by the Google Closure Compiler during minification of the GHCJS produced JS. See the [FAQ](FAQ.md).

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -250,6 +250,9 @@ deployActivationScript
   -> String
 deployActivationScript outPath =
 -- Note that we don't want to $(staticWhich "nix-env") here, because this is executing on a remote machine
+-- This logic follows the nixos auto-upgrade module as of writing.
+-- If the workflow is added to switch-to-configuration proper, we can simplify this:
+-- https://github.com/obsidiansystems/obelisk/issues/958
   [i|set -euxo pipefail
 nix-env -p /nix/var/nix/profiles/system --set "${bashEscape outPath}"
 /nix/var/nix/profiles/system/bin/switch-to-configuration boot

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -251,7 +251,7 @@ deployActivationScript
 deployActivationScript outPath =
 -- Note that we don't want to $(staticWhich "nix-env") here, because this is executing on a remote machine
   [i|set -euxo pipefail
-nix-env -p /nix/var/nix/profiles/system --set "${outPath}"
+nix-env -p /nix/var/nix/profiles/system --set "${bashEscape outPath}"
 /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules})"
 built="$(readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"


### PR DESCRIPTION
This addresses: #955 

We use the same logic as as the [NixOS auto-upgrade module](https://github.com/NixOS/nixpkgs/blob/7ca652795e39b1c61250546492e4f417185246cb/nixos/modules/tasks/auto-upgrade.nix#L147). Though unfortunately, not in a way where we keep apace if that logic were to change. C'est la vie. See: https://github.com/NixOS/nixpkgs/issues/185030

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
