### PR TITLE
Refine staticFilePath to perform sanity check

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,7 @@ This project's release branch is `master`. This log is written from the perspect
   * [#922](https://github.com/obsidiansystems/obelisk/pull/922): Serve .wasm files with the correct MIME type
   * [#930](https://github.com/obsidiansystems/obelisk/pull/930): Add an error to ob run when `static` is called with a path to a file that doesn't exist
   * [#940](https://github.com/obsidiansystems/obelisk/pull/940): Instant, auto update to new configs on ob deploy push
+  * [#959](https://github.com/obsidiansystems/obelisk/pull/930): Add an error to ob run when `staticFilePath` is called with a path to a file that doesn't exist
 
 ## v1.0.0.0 - 2022-01-04
 

--- a/lib/asset/manifest/src/Obelisk/Asset/TH.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/TH.hs
@@ -33,8 +33,6 @@ staticPrefix :: FilePath
 staticPrefix = "/static"
 
 -- | Location of the symbolic link to static assets and resources.
---
--- We shouldn't be defining it here, but apparently this is just hard-coded where needed.
 staticOutPath :: FilePath
 staticOutPath = "static.out"
 
@@ -55,7 +53,12 @@ staticAssetHashed root fp = do
 --
 -- If the filepath can not be found in the static output directory,
 -- this will throw a compile-time error.
-staticAssetFilePathRaw :: FilePath -> FilePath -> Q Exp
+staticAssetFilePathRaw
+  :: FilePath
+  -- ^ Add this prefix directory to the embedded filepath @fp@.
+  -> FilePath
+  -- ^ Filepath you want to embed.
+  -> Q Exp
 staticAssetFilePathRaw root = staticAssetWorker root staticOutPath
 
 staticAssetFilePath :: FilePath -> FilePath -> Q Exp
@@ -68,7 +71,15 @@ staticAssetFilePath root fp = do
 -- to 'staticOutPath' and produces a compilation error otherwise.
 -- This helps finding typos in filepaths, etc... at compile-time instead of
 -- run-time.
-staticAssetWorker :: FilePath -> FilePath -> FilePath -> Q Exp
+staticAssetWorker
+  :: FilePath
+  -- ^ Add this prefix directory to the embedded filepath @fp@.
+  -> FilePath
+  -- ^ Directory to which the filepath must have been copied.
+  -- If @fp@ does not exist within this directory, this function will fail.
+  -> FilePath
+  -- ^ Filepath you want to embed.
+  -> Q Exp
 staticAssetWorker root staticOut fp = do
   exists <- runIO $ doesFileExist $ staticOut </> fp
   when (not exists) $

--- a/lib/asset/manifest/src/Obelisk/Asset/TH.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/TH.hs
@@ -32,20 +32,45 @@ assetPath root relativePath =
 staticPrefix :: FilePath
 staticPrefix = "/static"
 
+-- | Location of the symbolic link to static assets and resources.
+--
+-- We shouldn't be defining it here, but apparently this is just hard-coded where needed.
+staticOutPath :: FilePath
+staticOutPath = "static.out"
+
+-- | Embed a filepath via template haskell. Resources embedded this way
+-- are requested from the "/static" route.
+--
+-- If the filepath can not be found in the static output directory,
+-- this will throw a compile-time error.
 staticAssetRaw :: FilePath -> Q Exp
-staticAssetRaw fp = do
-  exists <- runIO $ doesFileExist $ "static.out/" <> fp
-  when (not exists) $
-    fail $ "The file " <> fp <> " was not found in static.out"
-  returnQ $ LitE $ StringL $ staticPrefix </> fp
+staticAssetRaw = staticAssetWorker staticPrefix staticOutPath
 
 staticAssetHashed :: FilePath -> FilePath -> Q Exp
 staticAssetHashed root fp = do
   LitE . StringL . (staticPrefix </>) <$> hashedAssetFilePath root fp
 
+-- | Embed a filepath via template haskell. Differently to 'staticAssetRaw'
+-- this points to a local filepath instead of an URL during deployment.
+--
+-- If the filepath can not be found in the static output directory,
+-- this will throw a compile-time error.
 staticAssetFilePathRaw :: FilePath -> FilePath -> Q Exp
-staticAssetFilePathRaw root fp = returnQ $ LitE $ StringL $ root </> fp
+staticAssetFilePathRaw root = staticAssetWorker root staticOutPath
 
 staticAssetFilePath :: FilePath -> FilePath -> Q Exp
 staticAssetFilePath root fp = do
   LitE . StringL . (root </>) <$> hashedAssetFilePath root fp
+
+-- | @'staticAssetWorker' root staticOut fp@.
+--
+-- Produces @root </> fp@, but checks before that @fp@ has been copied
+-- to 'staticOutPath' and produces a compilation error otherwise.
+-- This helps finding typos in filepaths, etc... at compile-time instead of
+-- run-time.
+staticAssetWorker :: FilePath -> FilePath -> FilePath -> Q Exp
+staticAssetWorker root staticOut fp = do
+  exists <- runIO $ doesFileExist $ staticOut </> fp
+  when (not exists) $
+    fail $ "The file " <> fp <> " was not found in " <> staticOut
+  returnQ $ LitE $ StringL $ root </> fp


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
