### PR TITLE
Add cabal.project file for local Haskell development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,25 @@
-# Contribution Guide
+# Contribution Guide <!-- omit in toc -->
 
 Contributions and issue reports are encouraged and appreciated!
 
 - [Opening Issues](#opening-issues)
 - [Submitting Changes](#submitting-changes)
   - [Guidelines for Commit Messages](#guidelines-for-commit-messages)
+    - [Summary Line](#summary-line)
+      - [Note on bumping dependencies](#note-on-bumping-dependencies)
+    - [Body](#body)
   - [Guidelines for Pull Requests](#guidelines-for-pull-requests)
   - [Code Quality](#code-quality)
+    - [Warnings](#warnings)
+    - [Build and Test](#build-and-test)
   - [Documentation](#documentation)
+    - [In the code](#in-the-code)
+    - [In the Changelog](#in-the-changelog)
+    - [In the Readme](#in-the-readme)
 - [Development Environment](#development-environment)
+  - [Building `ob` for testing](#building-ob-for-testing)
+  - [Testing features from an unmerged branch](#testing-features-from-an-unmerged-branch)
+  - [Hacking on Obelisk from within an Obelisk project](#hacking-on-obelisk-from-within-an-obelisk-project)
 
 ## Opening Issues
 
@@ -95,6 +106,8 @@ For other libraries like `obelisk-command` you can use `ghcid`. To launch `ghcid
 ```bash
 nix-shell -A obeliskEnvs.obelisk-command --run "cd lib/command && ghcid"
 ```
+
+[Haskell-Language-Server](https://haskell-language-server.readthedocs.io/en/latest/)(HLS) can be used on the Haskell libraries in `lib`. Simply launch your lsp-client of choice in the `lib` subdirectory.
 
 ### Building `ob` for testing
 

--- a/lib/cabal.project
+++ b/lib/cabal.project
@@ -1,0 +1,26 @@
+-- cabal.project purely for local development.
+-- Nix ignores this file.
+--
+-- Allows HLS to load this Haskell project.
+
+packages:
+    ./asset/manifest
+    ./asset/serve-snap
+    ./backend
+    ./command
+    ./executable-config/inject
+    ./executable-config/lookup
+    ./frontend
+    ./route
+    ./run
+    ./selftest
+    ./snap-extras
+    ./tabulation
+
+-- Disable '-Werror', otherwise compiling with newer GHC versions fails,
+-- because we might have unneeded imports, etc...
+--
+-- For the IDE, that's not what we want.
+
+package *
+  ghc-options: -Wwarn

--- a/lib/hie.yaml
+++ b/lib/hie.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/haskell/hie-bios#cabal for documentation
+#
+# Requires cabal >= 3.4
+cradle:
+  cabal:


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)


This is purely an improvement for the Devs. It makes it much easier to use HLS on the code-base.
