### PR TITLE
Expose subcomponents of exe build

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,8 @@ This project's release branch is `master`. This log is written from the perspect
   * [#931](https://github.com/obsidiansystems/obelisk/pull/931): For `ob deploy init`, command-line option `--check-known-host` corrected in readme, caveat added for multiple matching host-keypairs.
 * building
   * [#956](https://github.com/obsidiansystems/obelisk/pull/956): Squelch closure-compiler warnings. They are not very helpful and can cause issues (see: [closure-compiler#3720](https://github.com/google/closure-compiler/issues/3720))
-* nixpkgs-overlays
+* nix
+  * [#968](https://github.com/obsidiansystems/obelisk/pull/968): Expose parts of the server derivation as subattributes. For example, the un-assetified frontend can be built alone with `nix-build -A exe.frontend`.
   * Remove override of acme module that pinned it to the version in nixpkgs-20.03. This is used for automatic https certificate provisioning.
 * CLI
   * [#784](https://github.com/obsidiansystems/obelisk/pull/784): hint for users to take advantage of ob shell --no-interpret option for thunks


### PR DESCRIPTION
Sometimes you want to build not the entire derivation for the obelisk
server, but just a piece of it, like the frontend. This PR exposes them
as subattributes of the full server derivation.

In particular:

  backend
  frontend (not turned into assets)
  frontend-assets
  static-assets

Example usage in an obelisk project:

```
nix-build -A exe.frontend-assets
```

This replaces #507 which had only minor merge conflicts, but I had already mostly transcribed it before picking up on that.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
