### PR TITLE
asset: fix staticFilePath outside of ob run

### DIFF
--- a/lib/asset/manifest/src-bin/static-th.hs
+++ b/lib/asset/manifest/src-bin/static-th.hs
@@ -36,7 +36,7 @@ main = do
       , "staticFilePath =  staticAssetFilePathRaw \"static.out\""
       , "#else"
       , "static = staticAssetHashed " <> show root
-      , "staticFilePath = staticAssetFilePathRaw " <> show root
+      , "staticFilePath = staticAssetFilePath " <> show root
       , "#endif"
       ]
     }


### PR DESCRIPTION
Outside of ob run (e.g., when compiling a backend for deployment) we
should be using the hashed static asset file path provided by
staticAssetFilePath, not the raw path provided by
staticAssetFilePathRaw

Prior to this change, nix-build -A ghc.backend fails if the backend uses `staticFilePath` even if `ob run` succeeds, claiming that files are missing that are actually present in the assets folder. The error message also references static.out, even though that isn't used outside of `ob run`.

After this change, both ob run and ghc.backend work. If a file references by staticFilePath is missing and you attempt to compile the backend, you'll get something like the following error:

```
src/Backend/OpenGraphImage.hs:100:20: error:
    • Exception when trying to run compile-time code:
        /nix/store/8d4bxcdk9nc1kr854p8sx384gn6v3cr7-marketing-static/images/OSCircleLogo1.png: openBinaryFile: does not exist (No such file or directory)
      Code: staticFilePath "images/OSCircleLogo1.png"
    • In the untyped splice:
        $(staticFilePath "images/OSCircleLogo1.png")
    |
100 |   f <- BS.readFile $(staticFilePath "images/OSCircleLogo1.png")
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: builder for '/nix/store/0f14wz5538iafh15ackbb5z0z9ihh21x-backend-0.1.drv' failed with exit code 1;
       last 10 log lines:
       > src/Backend/OpenGraphImage.hs:100:20: error:
       >     • Exception when trying to run compile-time code:
       >         /nix/store/8d4bxcdk9nc1kr854p8sx384gn6v3cr7-marketing-static/images/OSCircleLogo1.png: openBinaryFile: does not exist (No such file or directory)
       >       Code: staticFilePath "images/OSCircleLogo1.png"
       >     • In the untyped splice:
       >         $(staticFilePath "images/OSCircleLogo1.png")
       >     |
       > 100 |   f <- BS.readFile $(staticFilePath "images/OSCircleLogo1.png")
       >     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >
       For full logs, run 'nix log /nix/store/0f14wz5538iafh15ackbb5z0z9ihh21x-backend-0.1.drv'.
```

This worked prior to https://github.com/obsidiansystems/obelisk/pull/959 which hasn't yet been released, so I haven't included a changelog entry.

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
