### PR TITLE
Big change-log clean up

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,39 +6,39 @@ This project's release branch is `master`. This log is written from the perspect
 
 * Update reflex-platform to yet unreleased version with GHC 8.10.
   \[Update note once release is cut.\]
-  
+
 * Documentation
-  * [#919](https://github.com/obsidiansystems/obelisk/pull/919): Document useful command for testing obelisk branches to CONTRIBUTING.md
-  * [#913](https://github.com/obsidiansystems/obelisk/pull/913): Add haddocks to Obelisk.Command.Deploy
+  * [#913](https://github.com/obsidiansystems/obelisk/pull/913): Add haddocks to `Obelisk.Command.Deploy`
+  * [#919](https://github.com/obsidiansystems/obelisk/pull/919): Document useful command for testing Obelisk branches to CONTRIBUTING.md
   * [#931](https://github.com/obsidiansystems/obelisk/pull/931): For `ob deploy init`, command-line option `--check-known-host` corrected in readme, caveat added for multiple matching host-keypairs.
 * building
   * [#956](https://github.com/obsidiansystems/obelisk/pull/956): Squelch closure-compiler warnings. They are not very helpful and can cause issues (see: [closure-compiler#3720](https://github.com/google/closure-compiler/issues/3720))
 * nix
+  * [#889](https://github.com/obsidiansystems/obelisk/pull/889): Remove override of `acme` module that pinned it to the version in `nixpkgs-20.03`. This is used for automatic https certificate provisioning.
   * [#968](https://github.com/obsidiansystems/obelisk/pull/968): Expose parts of the server derivation as subattributes. For example, the un-assetified frontend can be built alone with `nix-build -A exe.frontend`.
-  * Remove override of acme module that pinned it to the version in nixpkgs-20.03. This is used for automatic https certificate provisioning.
 * CLI
-  * [#784](https://github.com/obsidiansystems/obelisk/pull/784): hint for users to take advantage of ob shell --no-interpret option for thunks
-  * [#916](https://github.com/obsidiansystems/obelisk/pull/916): Add `check-known-hosts` option in `ob deploy init`.
+  * [#784](https://github.com/obsidiansystems/obelisk/pull/784): Hint for users to take advantage of `ob shell --no-interpret` option for thunks
   * [#870](https://github.com/obsidiansystems/obelisk/pull/870): Host redirection added to `ob deploy`. Readme updated with tutorial for new functionality.
+  * [#916](https://github.com/obsidiansystems/obelisk/pull/916): Add `check-known-hosts` option in `ob deploy init`.
   * [#931](https://github.com/obsidiansystems/obelisk/pull/931): Fix bug in `ob deploy init` where `ssh-keygen` was not found in nix store.
-  * [#934](https://github.com/obsidiansystems/obelisk/pull/934)[#936](https://github.com/obsidiansystems/obelisk/pull/936): obelisk now always uses absolute paths when generating `.ghci` files for REPL and IDE support. This is a **BREAKING** change for some old tools that could not handle absolute paths properly. However, due to the behavior of cross-volume relative paths on certain platforms, such as modern MacOS, we cannot guarantee proper operation of obelisk with relative paths.
-  * [#948](https://github.com/obsidiansystems/obelisk/pull/948): obelisk now always invokes bash instead of the system-wide shell when it can. Some sub-programs, like ghcid, will still use the system-wide shell, which can cause subtle problems due to impurities.
-  * [#949](https://github.com/obsidiansystems/obelisk/pull/949): obelisk now configures its output and error streams to transliterate unsupported to a known-good replacement character.
+  * [#934](https://github.com/obsidiansystems/obelisk/pull/934), [#936](https://github.com/obsidiansystems/obelisk/pull/936): obelisk now always uses absolute paths when generating `.ghci` files for REPL and IDE support. This is a **BREAKING** change for some old tools that could not handle absolute paths properly. However, due to the behavior of cross-volume relative paths on certain platforms, such as modern MacOS, we cannot guarantee proper operation of obelisk with relative paths.
+  * [#948](https://github.com/obsidiansystems/obelisk/pull/948): Obelisk now always invokes `bash` instead of the system-wide shell when it can. Some sub-programs, like `ghcid`, will still use the system-wide shell, which can cause subtle problems due to impurities.
+  * [#949](https://github.com/obsidiansystems/obelisk/pull/949): Obelisk now configures its output and error streams to transliterate unsupported characters to a known-good replacement character.
   * [#951](https://github.com/obsidiansystems/obelisk/pull/951): Add `ob run --port` which allows the user to override the port on which the app is served, rather than always using the port configured in the route.
-  * [#974](https://github.com/obsidiansystems/obelisk/pull/951): Warn the user when invalid fields are present in `default-extensions`/`default-language`.
+  * [#974](https://github.com/obsidiansystems/obelisk/pull/974): Fail `ob run` when invalid fields are present in `default-extensions`/`default-language`, or when Cabal files are otherwise invalid.
 * obelisk-route
-  * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add routeLinkAttr to Obelisk.Route.Frontend. This allows the creation of route links with additional, user-specified attributes.
-  * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`
+  * [#915](https://github.com/obsidiansystems/obelisk/pull/915): Add `routeLinkAttr` to `Obelisk.Route.Frontend`. This allows the creation of route links with additional, user-specified DOM attributes.
+  * [#918](https://github.com/obsidiansystems/obelisk/pull/918): Add GHC 8.10.7 support for `obelisk-route`.
   * [#952](https://github.com/obsidiansystems/obelisk/pull/952): Add a `Semigroupoid` instance for the `Encoder` type, compatible with its existing `Category` instance.
-  * [#957](https://github.com/obsidiansystems/obelisk/pull/957): ob deploy will now detect when the target machine needs to be rebooted after deployment and automatically do so. This is necessary, for example, when the kernel has been updated.
+  * [#957](https://github.com/obsidiansystems/obelisk/pull/957): `ob deploy` will now detect when the target machine needs to be rebooted after deployment, and automatically do so. This is necessary, for example, when the kernel has been updated.
 * Javascript FFI
-  * [#844](https://github.com/obsidiansystems/obelisk/pull/844): Jsaddle FFI example extended in skeleton (example project which is installed by `ob init`). Note the remark on minifier renaming in /skeleton/static/lib.js
-  * [#903](https://github.com/obsidiansystems/obelisk/pull/903): Added support for a file which allows users to specify global variables and namespaces in JS, that should not be used by the Google Closure Compiler during minification of the GHCJS produced JS. See the [FAQ](FAQ.md).
+  * [#844](https://github.com/obsidiansystems/obelisk/pull/844): Jsaddle FFI example extended in skeleton (example project which is installed by `ob init`). Note the remark on minifier renaming in `skeleton/static/lib.js`
+  * [#903](https://github.com/obsidiansystems/obelisk/pull/903): Added support for `externs.js`, a file which allows users to specify JavaScript identifiers which should be avoided by Closure Compiler during its minification step. See the [FAQ](FAQ.md#names-of-some-variables-in-all.js-(produced-by-ghcjs)-collide-with-already-existing-static-JS-files-in-my-project).
 * Static Assets
-  * [#922](https://github.com/obsidiansystems/obelisk/pull/922): Serve .wasm files with the correct MIME type
-  * [#930](https://github.com/obsidiansystems/obelisk/pull/930): Add an error to ob run when `static` is called with a path to a file that doesn't exist
-  * [#940](https://github.com/obsidiansystems/obelisk/pull/940): Instant, auto update to new configs on ob deploy push
-  * [#959](https://github.com/obsidiansystems/obelisk/pull/930): Add an error to ob run when `staticFilePath` is called with a path to a file that doesn't exist
+  * [#922](https://github.com/obsidiansystems/obelisk/pull/922): Serve `.wasm` files with the correct MIME type.
+  * [#930](https://github.com/obsidiansystems/obelisk/pull/930): Add an error to `ob run` when `static` is called with a path to a file that doesn't exist
+  * [#940](https://github.com/obsidiansystems/obelisk/pull/940): Automatically restart the server when configuration is updated via `ob deploy push`.
+  * [#959](https://github.com/obsidiansystems/obelisk/pull/959): Add an error to `ob run` when `staticFilePath` is called with a path to a file that doesn't exist
 
 ## v1.0.0.0 - 2022-01-04
 


### PR DESCRIPTION
Updates the changelog to accurately reflect changes since the last release. Fixes up some PR links, formatting quibbles, grammar, sorts the PRs chronologically within the sections.

I have:

- [X] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)

(no code changes but I thought it'd be funny to keep that part of the PR template)