### PR TITLE
Don't redefine mapSome

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -188,7 +188,7 @@ import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Semigroupoid
-import Data.Some (Some(Some))
+import Data.Some (Some(Some), mapSome)
 import Data.Tabulation
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -254,9 +254,6 @@ infixr 5 :/
 (?/) :: f (Maybe a) -> a -> R f
 r ?/ a = r :/ Just a
 infixr 5 ?/
-
-mapSome :: (forall a. f a -> g a) -> Some f -> Some g
-mapSome f (Some a) = Some $ f a
 
 hoistR :: (forall x. f x -> g x) -> R f -> R g
 hoistR f (x :=> Identity y) = f x :/ y


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
```haskell
import Obelisk.Route
import Data.Some
```

results in
```
    Ambiguous occurrence ‘mapSome’
    It could refer to either ‘Obelisk.Route.mapSome’,
                             imported from ‘Obelisk.Route’ at /path-to-obelisk/skeleton/frontend/src/Frontend.hs:16:1-20
                             (and originally defined
                                at /path-to-obelisk/lib/route/src/Obelisk/Route.hs:259:1-7)
                          or ‘Data.Some.mapSome’,
                             imported from ‘Data.Some’ at /path-to-obelisk/skeleton/frontend/src/Frontend.hs:24:1-16
                             (and originally defined in ‘some-1.0.2:Data.Some.Newtype’)
```

re-exporting seems strictly better than re-defining, though maybe it shouldn't be exported at all?


I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
