### PR TITLE
Require Applicative parse when creating encoders

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -330,7 +330,7 @@ unsafeEncoder = Encoder
 -- Law:
 -- forall p. _encoderImpl_decode ve . _encoderImpl_encode ve p == pure
 -- Note that the reverse may not be the case: when parsing, a route may be canonicalized, and erroneous routes may be collapsed to a single 404 route.  However, as a consequence of the law, encode . decode must be idempotent.
-data EncoderImpl parse decoded encoded = EncoderImpl
+data EncoderImpl parse decoded encoded = Applicative parse => EncoderImpl
   { _encoderImpl_decode :: !(encoded -> parse decoded) -- Can fail; can lose information; must always succeed on outputs of `_encoderImpl_encode` and result in the original value
   , _encoderImpl_encode :: !(decoded -> encoded) -- Must be injective
   }
@@ -361,7 +361,7 @@ hoistCheck :: (forall t. check t -> check' t) -> Encoder check parse a b -> Enco
 hoistCheck f (Encoder x) = Encoder (f x)
 
 -- | Transform the parse monad of an 'Encoder' by applying a natural transformation.
-hoistParse :: (Functor check)
+hoistParse :: (Functor check, Applicative parse')
   => (forall t. parse t -> parse' t) -> Encoder check parse a b -> Encoder check parse' a b
 hoistParse f (Encoder x) = Encoder (fmap (\(EncoderImpl dec enc) -> EncoderImpl (f . dec) enc) x)
 
@@ -935,8 +935,9 @@ handleEncoder
   -> Encoder check Identity a b
 handleEncoder recover e = Encoder $ do
   i <- unEncoder e
-  return $ i
-    { _encoderImpl_decode = \a -> pure $ case _encoderImpl_decode i a of
+  pure $ EncoderImpl
+    { _encoderImpl_encode = _encoderImpl_encode i
+    , _encoderImpl_decode = \a -> pure $ case _encoderImpl_decode i a of
       Right r -> r
       Left err -> recover err
     }


### PR DESCRIPTION
https://github.com/obsidiansystems/obelisk/pull/984 required me to state a law in terms of `Applicative parse` within a function that doesn't actually have that constraint. It turns out `EncoderImpl` itself has that awkwardness. One way of addressing that is to require `Applicative` (and thus `pure`) to exist when constructing such values.

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
