### PR TITLE
Fix overlap logic in shadowEncoder

### DIFF
--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -711,12 +711,12 @@ shadowEncoder f g = Encoder $ do
         Left a -> _encoderImpl_encode vf a
         Right b -> _encoderImpl_encode vg b
     , _encoderImpl_decode = \c ->
-        let mb = Right <$> _encoderImpl_decode vg c
-        in flip catchError (\_ -> mb) $ do
-          a <- _encoderImpl_decode vf c
-          case c == _encoderImpl_encode vf a of
-            False -> mb
-            True -> pure $ Left a
+        let ma = Left <$> _encoderImpl_decode vf c
+        in flip catchError (\_ -> ma) $ do
+          b <- _encoderImpl_decode vg c
+          case c == _encoderImpl_encode vg b of
+            False -> ma
+            True -> pure $ Right b
     }
 
 enum1Encoder

--- a/lib/route/src/Obelisk/Route.hs
+++ b/lib/route/src/Obelisk/Route.hs
@@ -166,7 +166,7 @@ import Control.Monad.Trans (lift)
 import Data.Monoid ((<>))
 #endif
 #if __GLASGOW_HASKELL__ >= 906
-import Control.Monad (forM, (<=<))
+import Control.Monad (forM, guard, (<=<))
 import Control.Monad.Trans (lift)
 #endif
 #endif
@@ -532,6 +532,7 @@ maybeToEitherEncoder = unsafeMkEncoder $ EncoderImpl
 
 maybeEncoder
   :: ( MonadError Text check
+     , Eq b
      , Show a
      , Show b
      , check ~ parse
@@ -681,14 +682,15 @@ tshow = T.pack . show
 
 shadowEncoder
   :: ( Universe a
+     , Eq c
      , MonadError Text check
      , Show a
      , Show b
      , Show c
      , check ~ parse --TODO: Get rid of this
      )
-  => Encoder check parse a c -- ^ Overlaps; should have a small number of possible routes
-  -> Encoder check parse b c -- ^ Gets overlapped
+  => Encoder check parse a c -- ^ should have a small number of possible routes
+  -> Encoder check parse b c
   -> Encoder check parse (Either a b) c
 shadowEncoder f g = Encoder $ do
   vf <- unEncoder f
@@ -697,7 +699,9 @@ shadowEncoder f g = Encoder $ do
   overlaps <- fmap catMaybes $ forM universe $ \a -> do
     let c = _encoderImpl_encode vf a
     mb <- gCanParse c
-    pure $ fmap (\b -> (a, b, c)) mb
+    pure $ mb >>= \b -> do
+      guard $ _encoderImpl_encode vg b == c
+      pure (a, b, c)
   case overlaps of
     [] -> pure ()
     _ -> throwError $ "shadowEncoder: overlap detected: " <> T.unlines
@@ -706,7 +710,13 @@ shadowEncoder f g = Encoder $ do
     { _encoderImpl_encode = \case
         Left a -> _encoderImpl_encode vf a
         Right b -> _encoderImpl_encode vg b
-    , _encoderImpl_decode = \c -> (Left <$> _encoderImpl_decode vf c) `catchError` \_ -> Right <$> _encoderImpl_decode vg c
+    , _encoderImpl_decode = \c ->
+        let mb = Right <$> _encoderImpl_decode vg c
+        in flip catchError (\_ -> mb) $ do
+          a <- _encoderImpl_decode vf c
+          case c == _encoderImpl_encode vf a of
+            False -> mb
+            True -> pure $ Left a
     }
 
 enum1Encoder

--- a/lib/route/test/Main.hs
+++ b/lib/route/test/Main.hs
@@ -275,13 +275,17 @@ overlaps =
   in
     testGroup "Overlaps"
       [ testGroup "No false positives" $ prop isRight $ \t ->
-        [ t "shadowEncoder" $ shadowEncoder bc ac
+        [ testGroup "shadowEncoder"
+          [ t "A | B -> C" $ shadowEncoder bc ac
+          ]
         ]
       , testGroup "No false negatives" $ prop isLeft $ \t ->
         [ t "enumEncoder" $ enumEncoder @_ @_ @Word8 (*2)
         , t "pathComponentEncoder" overlappingFragmentEncoder
-        , t "shadowEncoder" $ unsafeShowShadowEncoder @Word8 @Int8
-        , t "shadowEncoder" $ unsafeShowShadowEncoder @Word8 @Word8
+        , testGroup "shadowEncoder"
+          [ t "Word8 | Int8 -> Text" $ unsafeShowShadowEncoder @Word8 @Int8
+          , t "Word8 | Word8 -> Text" $ unsafeShowShadowEncoder @Word8 @Word8
+          ]
         ]
       ]
 
@@ -291,8 +295,10 @@ roundtrips = testGroup "Roundtrip" $ fold
   , arity0 $ \t ->
     [ t "dmapEncoder" xymapEncoder
     , t "pathFieldEncoder" xypathFieldEncoder
-    , t "shadowEncoder" $ unsafeShowShadowEncoder @Word8 @Char
-    , t "shadowEncoder" $ shadowEncoder ac bc
+    , testGroup "shadowEncoder"
+      [ t "Word8 | Char -> Text" $ unsafeShowShadowEncoder @Word8 @Char
+      , t "A | B -> C" $ shadowEncoder ac bc
+      ]
     , t "handleEncoder" $ generalizeIdentity $ handleEncoder @_ @_ @Input (error "Must not be used") id
     ]
   , arity1 $ \t ->

--- a/lib/route/test/Main.hs
+++ b/lib/route/test/Main.hs
@@ -274,8 +274,8 @@ overlaps =
 
   in
     testGroup "Overlaps"
-      [ testGroup "No false positives" $ prop isRight $ \_t ->
-        [ -- t "shadowEncoder" $ shadowEncoder bc ac -- https://github.com/obsidiansystems/obelisk/pull/987
+      [ testGroup "No false positives" $ prop isRight $ \t ->
+        [ t "shadowEncoder" $ shadowEncoder bc ac
         ]
       , testGroup "No false negatives" $ prop isLeft $ \t ->
         [ t "enumEncoder" $ enumEncoder @_ @_ @Word8 (*2)
@@ -292,7 +292,7 @@ roundtrips = testGroup "Roundtrip" $ fold
     [ t "dmapEncoder" xymapEncoder
     , t "pathFieldEncoder" xypathFieldEncoder
     , t "shadowEncoder" $ unsafeShowShadowEncoder @Word8 @Char
-    --, t "shadowEncoder" $ shadowEncoder ac bc --https://github.com/obsidiansystems/obelisk/pull/987
+    , t "shadowEncoder" $ shadowEncoder ac bc
     , t "handleEncoder" $ generalizeIdentity $ handleEncoder @_ @_ @Input (error "Must not be used") id
     ]
   , arity1 $ \t ->

--- a/lib/route/test/Main.hs
+++ b/lib/route/test/Main.hs
@@ -28,7 +28,7 @@ import Control.Category.Monoidal
 import Control.Lens (Iso', Prism', lazy, lens, reversed, _Just, _Left, _Right)
 import Data.Dependent.Map (DMap)
 import Data.Dependent.Sum (DSum((:=>)) )
-import Data.Either (isLeft, isRight)
+import Data.Either (fromRight, isLeft, isRight)
 import Data.Foldable (Foldable(fold))
 import Data.Functor.Identity (Identity)
 import Data.Int (Int8)
@@ -111,15 +111,16 @@ instance Arbitrary (DMap XYField Identity) where
 
 data A = A deriving (Bounded, Enum, Eq, Ord, Show, Universe)
 data B = B deriving (Bounded, Enum, Eq, Ord, Show, Universe)
-data C = C1 | C2 deriving (Bounded, Enum, Eq, Ord, Show, Universe)
+data C = C1 | C2 | C3 deriving (Bounded, Enum, Eq, Ord, Show, Universe)
 instance Arbitrary A where arbitrary = pure A
 instance Arbitrary B where arbitrary = pure B
+instance Arbitrary C where arbitrary = oneof $ fmap pure [C1, C2, C3]
 
 ac :: Encoder' A C
 ac = generalizeIdentity $ handleEncoder (\_ -> A) $ enumEncoder $ \A -> C1
 
 bc :: Encoder' B C
-bc = enumEncoder $ \B -> C2
+bc = generalizeIdentity $ handleEncoder (\_ -> B) $ enumEncoder $ \B -> C2
 
 type Encoder' a b = Encoder (Either Text) (Either Text) a b
 type Cont a = forall r. (a -> r) -> r
@@ -269,23 +270,41 @@ exhaustive =
 overlaps :: TestTree
 overlaps =
   let
-    prop :: (forall x y. Either x y -> Bool) -> Cont (forall a b. TestName -> Encoder' a b -> TestTree)
-    prop is f = f $ \n -> testProperty n . is . checkEncoder @(Either Text)
+    check :: (forall x y. Either x y -> Bool) -> Cont (forall a b. TestName -> Encoder' a b -> TestTree)
+    check is f = f $ \n -> testProperty n . is . checkEncoder @(Either Text)
+
+    whenApplicable = fromRight $ property Discard
+
+    shadows
+      :: (Arbitrary z, Eq x, Eq y, Eq z, Show x, Show y, Show z, Universe x)
+      => TestName -> Encoder' x z -> Encoder' y z -> TestTree
+    shadows lbl x2z' y2z' = testProperty lbl $ whenApplicable $ do
+      x2z  <- checkEncoder x2z'
+      y2z  <- checkEncoder y2z'
+      xy2z <- checkEncoder (shadowEncoder x2z' y2z')
+      pure $ withMaxSuccess 1e3 $ \z -> whenApplicable $ do
+        x <- tryDecode x2z z
+        y <- tryDecode y2z z
+        pure $ property $ encode y2z y /= z ==> tryDecode xy2z z == Right (Left x)
 
   in
     testGroup "Overlaps"
-      [ testGroup "No false positives" $ prop isRight $ \t ->
+      [ testGroup "No false positives" $ check isRight $ \t ->
         [ testGroup "shadowEncoder"
           [ t "A | B -> C" $ shadowEncoder bc ac
           ]
         ]
-      , testGroup "No false negatives" $ prop isLeft $ \t ->
+      , testGroup "No false negatives" $ check isLeft $ \t ->
         [ t "enumEncoder" $ enumEncoder @_ @_ @Word8 (*2)
         , t "pathComponentEncoder" overlappingFragmentEncoder
         , testGroup "shadowEncoder"
           [ t "Word8 | Int8 -> Text" $ unsafeShowShadowEncoder @Word8 @Int8
           , t "Word8 | Word8 -> Text" $ unsafeShowShadowEncoder @Word8 @Word8
           ]
+        ]
+      , testGroup "Shadowing of non-canonical encodings"
+        [ shadows "A | B -> C" ac bc
+        , shadows "B | A -> C" bc ac
         ]
       ]
 


### PR DESCRIPTION
`shadowEncoder`'s overlap check is neither sound nor complete. To avoid the "n * m" performance of checking everything against everything, it iterates one axis only. The idea is that if there's a collision, decoding with the other encoder will give us the collision - but decoding to something alone does not mean that a collision exists!

Consider 

```haskell
data A = A deriving (Bounded, Enum, Eq, Ord, Show, Universe)
data B = B deriving (Bounded, Enum, Eq, Ord, Show, Universe)
data C = C1 | C2 deriving (Bounded, Enum, Eq, Ord, Show, Universe)

ac :: (MonadError Text check, MonadError Text parse) => Encoder check parse A C
ac = unsafeMkEncoder $ EncoderImpl
  { _encoderImpl_encode = \A -> C1
  , _encoderImpl_decode = \_ -> pure A
  }

bc :: (MonadError Text check, MonadError Text parse) => Encoder check parse B C
bc = enumEncoder $ \B -> C2
```

where the `A`s and `B`s do not overlap when encoding. This is what happens on develop:
```haskell
> ffor (checkEncoder $ shadowEncoder ac bc) $ \enc -> ffor [Left A, Right B] $ tryDecode enc . encode @(Either Text) enc
Right [Right (Left A),Right (Left A)]

> ffor (checkEncoder $ shadowEncoder bc ac) $ \enc -> ffor [Right A, Left B] $ tryDecode enc . encode @(Either Text) enc
Left "shadowEncoder: overlap detected: first encoder encodes B as C2, which second encoder decodes as A
```

In the first case the roundtrip law is broken as the decoding to `A` shadows the decoding to `B`.
In the second case we have a false positive for overlaps.

With this PR we instead get
```haskell
> ffor (checkEncoder $ shadowEncoder ac bc) $ \enc -> ffor [Left A, Right B] $ tryDecode enc . encode @(Either Text) enc  
Right [Right (Left A),Right (Right B)]

> ffor (checkEncoder $ shadowEncoder bc ac) $ \enc -> ffor [Right A, Left B] $ tryDecode enc . encode @(Either Text) enc
Right [Right (Right A),Right (Left B)]
```

Though I wonder whether `shadowEncoder` is a good name at all, since we can't allow shadowing because that breaks round-trips? Unless this "Overlaps" / "Gets overlapped" business is about unreachable encodings, for which we can do anything we want? See #988.

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
