### PR TITLE
assets: staticFilePath should return the unhashed path

### DIFF
--- a/lib/asset/manifest/src/Obelisk/Asset/TH.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/TH.hs
@@ -62,8 +62,10 @@ staticAssetFilePathRaw
 staticAssetFilePathRaw root = staticAssetWorker root staticOutPath
 
 staticAssetFilePath :: FilePath -> FilePath -> Q Exp
-staticAssetFilePath root fp = do
-  LitE . StringL . (root </>) <$> hashedAssetFilePath root fp
+staticAssetFilePath root relativePath = do
+  let fullPath = root </> relativePath
+  qAddDependentFile fullPath
+  pure $ LitE $ StringL fullPath
 
 -- | @'staticAssetWorker' root staticOut fp@.
 --


### PR DESCRIPTION
One of the recent changes to `staticFilePath` resulted in it returning a hashed filename instead of the actual filename. The hashed filename is used for URLs (for cache and cache-busting purposes) and obelisk-asset-serve-snap knows how to handle them. However, we don't need that hashed filename when looking things up on the local disk since we'll already be referring to an asset by its path in the nix store.

Prior to this change, this code: `Graphics.Text.TrueType.loadFontFile $(staticFilePath "fonts/inter/Inter-ExtraBold.ttf")` would work under `ob run` but fail when deployed to the server.

The error message is revealing: `/nix/store/mm2qvdw7j1lwzpbal6i84cxjxj1y716x-static/fonts/inter/0ig14m80pwsxv27k1nr8fjzd3a9dqqjj7fmryginih3mzswp692f-Inter-ExtraBold.ttf: openBinaryFile: does not exist (No such file or directory)`. Inspecting that folder in the nix store reveals (as expected) a file called Inter-ExtraBold.ttf but no version of that file with a hashed prefix.


I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
