### PR TITLE
Enable more warnings

### DIFF
--- a/skeleton/backend/backend.cabal
+++ b/skeleton/backend/backend.cabal
@@ -14,12 +14,26 @@ library
                , obelisk-route
   exposed-modules:
     Backend
-  ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -fno-show-valid-hole-fits
+  ghc-options: -Wall -O -fno-show-valid-hole-fits
+               -- unsafe code
+               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
+               -- unneeded code
+               -Widentities -Wredundant-constraints
+  if impl(ghc >= 8.8)
+    ghc-options:
+               -Wmissing-deriving-strategies
 
 executable backend
   main-is: main.hs
   hs-source-dirs: src-bin
-  ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -threaded -fno-show-valid-hole-fits
+  ghc-options: -Wall -O -fno-show-valid-hole-fits -threaded
+               -- unsafe code
+               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
+               -- unneeded code
+               -Widentities -Wredundant-constraints
+  if impl(ghc >= 8.8)
+    ghc-options:
+               -Wmissing-deriving-strategies
   if impl(ghcjs)
     buildable: False
   build-depends: base

--- a/skeleton/common/common.cabal
+++ b/skeleton/common/common.cabal
@@ -12,4 +12,11 @@ library
   exposed-modules:
     Common.Api
     Common.Route
-  ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -fno-show-valid-hole-fits
+  ghc-options: -Wall -O -fno-show-valid-hole-fits
+               -- unsafe code
+               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
+               -- unneeded code
+               -Widentities -Wredundant-constraints
+  if impl(ghc >= 8.8)
+    ghc-options:
+               -Wmissing-deriving-strategies

--- a/skeleton/frontend/frontend.cabal
+++ b/skeleton/frontend/frontend.cabal
@@ -17,7 +17,14 @@ library
                , text
   exposed-modules:
     Frontend
-  ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -fno-show-valid-hole-fits
+  ghc-options: -Wall -O -fno-show-valid-hole-fits
+               -- unsafe code
+               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
+               -- unneeded code
+               -Widentities -Wredundant-constraints
+  if impl(ghc >= 8.8)
+    ghc-options:
+               -Wmissing-deriving-strategies
 
 executable frontend
   main-is: main.hs
@@ -29,7 +36,14 @@ executable frontend
                , reflex-dom
                , obelisk-generated-static
                , frontend
-  ghc-options: -threaded -O -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -fno-show-valid-hole-fits
+  ghc-options: -Wall -O -fno-show-valid-hole-fits -threaded
+               -- unsafe code
+               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
+               -- unneeded code
+               -Widentities -Wredundant-constraints
+  if impl(ghc >= 8.8)
+    ghc-options:
+               -Wmissing-deriving-strategies
   if impl(ghcjs)
     ghc-options: -dedupe
     cpp-options: -DGHCJS_BROWSER


### PR DESCRIPTION
Not sure why `-Wall` doesn't imply these ones - seems like you'd want them by default, especially the partial ones?
https://downloads.haskell.org/~ghc/8.6.3/docs/html/users_guide/using-warnings.html#ghc-flag--Wall
https://downloads.haskell.org/~ghc/8.10.1/docs/html/users_guide/using-warnings.html#ghc-flag--Wall

`Wmissing-deriving-strategies` is missing from the exclusions list on 8.10, but it's definitely not on by default and the flag docs agree: https://downloads.haskell.org/~ghc/8.10.1/docs/html/users_guide/using-warnings.html#ghc-flag--Wmissing-deriving-strategies

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
