### PR TITLE
Make "thunkable" more clear in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,18 @@ At this stage your instance should be booting and become accessible shortly. Not
 Now go to your Obelisk project directory (`~/code/myapp`), and initialize a deployment config (`~/code/myapp-deploy`):
 Your project directory must be "thunkable", i.e. something on which `ob thunk pack` can be called. Usually it will be a git repository whose current revision has been pushed upstream.
 
+An example set of git commands to do this is as follows (Github):
+```bash
+git init
+git add .
+git commit -m "First Commit!"
+git remote add origin git@github.com:username/repo.git
+git push
+```
+
+This will make a "thunkable" project that allows deployment to continue
+
+Continuing with deployment commands:
 ```bash
 cd ~/code/myapp
 SERVER=ec2-35-183-22-197.ca-central-1.compute.amazonaws.com

--- a/README.md
+++ b/README.md
@@ -213,12 +213,15 @@ Now go to your Obelisk project directory (`~/code/myapp`), and initialize a depl
 Your project directory must be "thunkable", i.e. something on which `ob thunk pack` can be called. Usually it will be a git repository whose current revision has been pushed upstream.
 
 An example set of git commands to do this is as follows (Github):
+Create a repo using Github's UI (Public or Private)
+then locally use these commands
 ```bash
+cd ~/code/myapp
 git init
 git add .
 git commit -m "First Commit!"
 git remote add origin git@github.com:username/repo.git
-git push
+git push --set-upstream origin master
 ```
 
 This will make a "thunkable" project that allows deployment to continue


### PR DESCRIPTION
Add an example to deploy instructions to make it clear that a "thunkable" directory is a git repo that's been pushed to a service (self hosted or otherwise)

Closes #997 

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
