### PR TITLE
Fix cabal warnings

### DIFF
--- a/lib/asset/manifest/obelisk-asset-manifest.cabal
+++ b/lib/asset/manifest/obelisk-asset-manifest.cabal
@@ -8,9 +8,10 @@ Maintainer: maintainer@obsidian.systems
 Stability: Experimental
 Category: Web
 Build-type: Simple
-Cabal-version: >= 1.8
+Cabal-version: >= 1.10
 
 library
+  default-language: Haskell2010
   hs-source-dirs: src
 
   build-depends:
@@ -39,6 +40,7 @@ library
     -fno-warn-unused-do-bind -funbox-strict-fields -fprof-auto-calls
 
 executable obelisk-asset-manifest-generate
+  default-language: Haskell2010
   hs-source-dirs: src-bin
   main-is: generate.hs
   build-depends:
@@ -47,6 +49,7 @@ executable obelisk-asset-manifest-generate
     , text
 
 executable obelisk-asset-th-generate
+  default-language: Haskell2010
   hs-source-dirs: src-bin
   main-is: static-th.hs
   build-depends:

--- a/lib/asset/serve-snap/obelisk-asset-serve-snap.cabal
+++ b/lib/asset/serve-snap/obelisk-asset-serve-snap.cabal
@@ -6,9 +6,10 @@ author: Obsidian Systems LLC
 maintainer: maintainer@obsidian.systems
 category: Web
 build-type: Simple
-cabal-version: >=1.2
+cabal-version: >=1.10
 
 library
+  default-language: Haskell2010
   hs-source-dirs: src
 
   build-depends:


### PR DESCRIPTION
```
Warning: obelisk-asset-manifest.cabal:36:3: The field "other-extensions" is
available only since the Cabal specification version 1.10.
Warning: obelisk-asset-serve-snap.cabal:31:3: The field "other-extensions" is
available only since the Cabal specification version 1.10.

Warning: Packages using 'cabal-version: >= 1.10' and before 'cabal-version:
3.4' must specify the 'default-language' field for each component (e.g.
Haskell98 or Haskell2010). If a component uses different languages in
different modules then list the other ones in the 'other-languages' field.
```

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
