### PR TITLE
Cleanup skeleton build-depends

### DIFF
--- a/skeleton/common/common.cabal
+++ b/skeleton/common/common.cabal
@@ -7,7 +7,6 @@ library
   hs-source-dirs: src
   build-depends: base
                , obelisk-route
-               , mtl
                , text
   exposed-modules:
     Common.Api

--- a/skeleton/frontend/frontend.cabal
+++ b/skeleton/frontend/frontend.cabal
@@ -7,13 +7,13 @@ library
   hs-source-dirs: src
   build-depends: base
                , common
-               , obelisk-frontend
-               , obelisk-route
                , jsaddle
-               , reflex-dom-core
-               , obelisk-executable-config-lookup
-               , obelisk-generated-static
                , lens
+               , obelisk-executable-config-lookup
+               , obelisk-frontend
+               , obelisk-generated-static
+               , obelisk-route
+               , reflex-dom-core
                , text
   exposed-modules:
     Frontend
@@ -31,11 +31,10 @@ executable frontend
   hs-source-dirs: src-bin
   build-depends: base
                , common
+               , frontend
                , obelisk-frontend
                , obelisk-route
                , reflex-dom
-               , obelisk-generated-static
-               , frontend
   ghc-options: -Wall -O -fno-show-valid-hole-fits -threaded
                -- unsafe code
                -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
