### PR TITLE
Fix MacOS builds on Big Sur+

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "develop",
+  "branch": "dylang/fix-macos",
   "private": false,
-  "rev": "6c8830e059a6d2859cb1b65acefed3c2f1d216d3",
-  "sha256": "sha256:06kv45yq8qan0p22wzj5c9mx11ns1wddyqjr1xasjjkf6gaf0080"
+  "rev": "ddf014ec612078353dc1520c659515937cc683fe",
+  "sha256": "sha256:1v21x8ngcbxdvb2c22j3mwpbwh983gskx6dm9jka5fhmg4ybqzig"
 }

--- a/haskell-overlays/obelisk.nix
+++ b/haskell-overlays/obelisk.nix
@@ -15,7 +15,7 @@ in
   obelisk-asset-manifest = self.callCabal2nix "obelisk-asset-manifest" (obeliskCleanSource ../lib/asset/manifest) {};
   obelisk-asset-serve-snap = self.callCabal2nix "obelisk-asset-serve-snap" (obeliskCleanSource ../lib/asset/serve-snap) {};
   obelisk-backend = self.callCabal2nix "obelisk-backend" (obeliskCleanSource ../lib/backend) {};
-  obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (obeliskCleanSource ../lib/command) {}) {
+  obelisk-command = haskellLib.overrideCabal (self.callCabal2nix "obelisk-command" (obeliskCleanSource ../lib/command) {}) (drv: {
     librarySystemDepends = [
       pkgs.jre
       pkgs.git
@@ -26,7 +26,8 @@ in
       pkgs.which
       (haskellLib.justStaticExecutables self.ghcid)
     ];
-  };
+
+  });
   obelisk-frontend = self.callCabal2nix "obelisk-frontend" (obeliskCleanSource ../lib/frontend) {};
   obelisk-run = onLinux (self.callCabal2nix "obelisk-run" (obeliskCleanSource ../lib/run) {}) (pkg:
     haskellLib.overrideCabal pkg (drv: { librarySystemDepends = [ pkgs.iproute ]; })

--- a/lib/command/src/Obelisk/Command/Nix.hs
+++ b/lib/command/src/Obelisk/Command/Nix.hs
@@ -24,6 +24,7 @@ module Obelisk.Command.Nix
   , nixShellConfig_common
   , nixShellConfig_pure
   , nixShellConfig_run
+  , nixShellConfig_env
   , OutLink (..)
   , Target (..)
   , target_attr
@@ -165,7 +166,8 @@ data NixShellConfig = NixShellConfig
   { _nixShellConfig_common :: NixCommonConfig
   , _nixShellConfig_pure :: Bool
   , _nixShellConfig_run :: Maybe String
-  }
+  , _nixShellConfig_env :: [( String, String )]
+ }
 
 makeLenses ''NixShellConfig
 
@@ -173,7 +175,7 @@ instance HasNixCommonConfig NixShellConfig where
   nixCommonConfig = nixShellConfig_common
 
 instance Default NixShellConfig where
-  def = NixShellConfig def False Nothing
+  def = NixShellConfig def False Nothing [("","")]
 
 data NixCmd
   = NixCmd_Build NixBuildConfig


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
GHC 8.6.5 needs a patch to properly load frameworks which is what the r-p bump does

We don't set the NIX_PATH in the nix-shell command env which ends up making nix-shell fall back to system-bash which we shouldn't rely on existing (or working properly). The haskell portion of this sets NIX_PATH to nixpkgs to properly pull bash from nixpkgs

depends on https://github.com/reflex-frp/reflex-platform/pull/810

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
