### PR TITLE
Update nix to nix 2.13

### DIFF
--- a/dep/nixpkgs_unstable/default.nix
+++ b/dep/nixpkgs_unstable/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/nixpkgs_unstable/github.json
+++ b/dep/nixpkgs_unstable/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs",
+  "private": false,
+  "rev": "22ce075f1c3ffb413dfc53b10ff3e577b5b15941",
+  "sha256": "1pgxmdw7qi5kq1jn9fq1jfv757y67rfgkid2zkip8licyghlgdr1"
+}

--- a/dep/nixpkgs_unstable/thunk.nix
+++ b/dep/nixpkgs_unstable/thunk.nix
@@ -1,0 +1,12 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/haskell-overlays/obelisk.nix
+++ b/haskell-overlays/obelisk.nix
@@ -20,7 +20,7 @@ in
     librarySystemDepends = [
       pkgs.jre
       pkgs.git
-      pkgs.nix
+      pkgs.nixpkgs_unstable.nixVersions.nix_2_13
       pkgs.nix-prefetch-git
       pkgs.openssh
       pkgs.rsync
@@ -38,7 +38,7 @@ in
       pkgs.cabal-install
       pkgs.coreutils
       pkgs.git
-      pkgs.nix
+      pkgs.nixpkgs_unstable.nixVersions.nix_2_13
       pkgs.nix-prefetch-git
       pkgs.rsync
     ];

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -301,7 +301,7 @@ filePermissionIsSafe s umask = not fileWorldWritable && fileGroupWritable <= uma
 nixShellRunConfig :: MonadObelisk m => FilePath -> Bool -> Maybe String -> m NixShellConfig
 nixShellRunConfig root isPure command = do
   nixpkgsPath <- fmap T.strip $ readProcessAndLogStderr Debug $ setCwd (Just root) $
-    proc nixExePath ["eval", "(import .obelisk/impl {}).nixpkgs.path"]
+    proc nixExePath ["eval", "--impure", "--expr", "(import .obelisk/impl {}).nixpkgs.path"]
   nixRemote <- liftIO $ lookupEnv "NIX_REMOTE"
   pure $ def
     & nixShellConfig_pure .~ isPure
@@ -383,8 +383,12 @@ findProjectAssets root = do
   isDerivation <- readProcessAndLogStderr Debug $ setCwd (Just root) $
     proc nixExePath
       [ "eval"
+      , "--impure"
+      , "--expr"
       , "(let a = import ./. {}; in toString (a.reflex.nixpkgs.lib.isDerivation a.passthru.staticFilesImpure))"
       , "--raw"
+      -- `--expr` and `--impure` are a side-effect of a newer nix version
+      -- `nix eval` is no longer the same as 2.3
       -- `--raw` is not available with old nix-instantiate. It drops quotation
       -- marks and trailing newline, so is very convenient for shelling out.
       ]

--- a/nixpkgs-overlays/default.nix
+++ b/nixpkgs-overlays/default.nix
@@ -12,4 +12,6 @@ in {
     lib.cleanSource (gitignoreSource src);
 
   obeliskExecutableConfig = self.callPackage ../lib/executable-config {};
+
+  nixpkgs_unstable = import ../dep/nixpkgs_unstable { };
 }


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
Obelisk is currently using an old version of nix for ob commands, this updates nix to get us on a newer version.

Notable changes:
- `nix eval` has changed due to the new nix commands, added `--impure` and `--expr` to make them function the same again

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
