### PR TITLE
Change snap config

### DIFF
--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -200,9 +200,10 @@ run certDir root interpretPaths = do
     runGhcid root True (ghciArgs <> dotGhciArgs) pkgs $ Just $ unwords
       [ "Obelisk.Run.run"
       , show freePort
+      , "(Obelisk.Backend._backend_updateSnapConfig Backend.backend)"
       , "(" ++ show certDir ++ ")"
       , "(Obelisk.Run.runServeAsset " ++ show assets ++ ")"
-      , "Backend.backend'"
+      , "Backend.backend"
       , "Frontend.frontend"
       ]
 

--- a/lib/command/src/Obelisk/Command/Run.hs
+++ b/lib/command/src/Obelisk/Command/Run.hs
@@ -202,7 +202,7 @@ run certDir root interpretPaths = do
       , show freePort
       , "(" ++ show certDir ++ ")"
       , "(Obelisk.Run.runServeAsset " ++ show assets ++ ")"
-      , "Backend.backend"
+      , "Backend.backend'"
       , "Frontend.frontend"
       ]
 

--- a/lib/run/obelisk-run.cabal
+++ b/lib/run/obelisk-run.cabal
@@ -36,6 +36,7 @@ library
     , reflex
     , reflex-dom-core
     , snap-core
+    , snap-server
     , streaming-commons
     , text
     , time

--- a/skeleton/backend/src/Backend.hs
+++ b/skeleton/backend/src/Backend.hs
@@ -7,4 +7,6 @@ backend :: Backend BackendRoute FrontendRoute
 backend = Backend
   { _backend_run = \serve -> serve $ const $ return ()
   , _backend_routeEncoder = fullRouteEncoder
+  , _backend_updateSnapConfig = id 
   }
+


### PR DESCRIPTION
Allows the Obelisk user to directly configure the snap-server / http configuration via an added backend field 

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
