### PR TITLE
Update GHCID, Gitignore.nix and Nix-thunk

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,8 @@
   }
 , reflex-platform-func ? import ./dep/reflex-platform
 , useGHC810 ? true # false if one wants to use ghc 8.6.5
-}:
+, ...
+}@args:
 let
   reflex-platform = getReflexPlatform { inherit system; };
   inherit (reflex-platform) hackGet nixpkgs;
@@ -25,7 +26,7 @@ let
     ];
 
     haskellOverlays = [
-      (import ./haskell-overlays/misc-deps.nix { inherit hackGet; __useNewerCompiler = useGHC810; })
+      (import ./haskell-overlays/misc-deps.nix { inherit hackGet system; inherit args; __useNewerCompiler = useGHC810; })
       pkgs.obeliskExecutableConfig.haskellOverlay
       (import ./haskell-overlays/obelisk.nix)
       (import ./haskell-overlays/tighten-ob-exes.nix)

--- a/dep/ghcid/default.nix
+++ b/dep/ghcid/default.nix
@@ -1,7 +1,2 @@
 # DO NOT HAND-EDIT THIS FILE
-import ((import <nixpkgs> {}).fetchFromGitHub (
-  let json = builtins.fromJSON (builtins.readFile ./github.json);
-  in { inherit (json) owner repo rev sha256;
-       private = json.private or false;
-     }
-))
+import (import ./thunk.nix)

--- a/dep/ghcid/github.json
+++ b/dep/ghcid/github.json
@@ -2,6 +2,7 @@
   "owner": "ndmitchell",
   "repo": "ghcid",
   "branch": "master",
-  "rev": "f572318f32b1617f6054248e5888af68222f8e50",
-  "sha256": "1icg3r70lg2kmd9gdc024ih1n9nrja98yav74z9nvykqygvv5w0n"
+  "private": false,
+  "rev": "e2852979aa644c8fed92d46ab529d2c6c1c62b59",
+  "sha256": "0bsjbb6n7ssg411k2xj4f881v392hvb7xln99bq1r3vkg14mqqsd"
 }

--- a/dep/ghcid/thunk.nix
+++ b/dep/ghcid/thunk.nix
@@ -1,0 +1,12 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/dep/gitignore.nix/default.nix
+++ b/dep/gitignore.nix/default.nix
@@ -1,8 +1,2 @@
 # DO NOT HAND-EDIT THIS FILE
-let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
-  if !fetchSubmodules && !private then builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
-    inherit owner repo rev sha256 fetchSubmodules private;
-  };
-in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))
+import (import ./thunk.nix)

--- a/dep/gitignore.nix/github.json
+++ b/dep/gitignore.nix/github.json
@@ -3,6 +3,6 @@
   "repo": "gitignore.nix",
   "branch": "master",
   "private": false,
-  "rev": "7415c4feb127845553943a3856cbc5cb967ee5e0",
-  "sha256": "1zd1ylgkndbb5szji32ivfhwh04mr1sbgrnvbrqpmfb67g2g3r9i"
+  "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+  "sha256": "07vg2i9va38zbld9abs9lzqblz193vc5wvqd6h7amkmwf66ljcgh"
 }

--- a/dep/gitignore.nix/thunk.nix
+++ b/dep/gitignore.nix/thunk.nix
@@ -1,0 +1,12 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/dep/nix-thunk/github.json
+++ b/dep/nix-thunk/github.json
@@ -3,6 +3,6 @@
   "repo": "nix-thunk",
   "branch": "master",
   "private": false,
-  "rev": "2b65d2cbf83e77a90b4103418d037ba5b0b32e77",
-  "sha256": "07pr014iifyy1xaiqamkx78xfszr67g8kzysmzgzms0a4470k1i9"
+  "rev": "bef3163ab930f5ffbbca9635b858da761b4dcbfb",
+  "sha256": "0mcrrx3ka3b1n0lccnkm4wn1vwkmnjy1sh2lbj6dr310hf462sdd"
 }

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -66,7 +66,7 @@ rec {
   nix-derivation = haskellLib.doJailbreak super.nix-derivation;
   algebraic-graphs = haskellLib.doJailbreak super.algebraic-graphs;
   snap = haskellLib.doJailbreak super.snap;
-  ghcid = self.callCabal2nix "ghcid" (hackGet ../dep/ghcid) { };
+  ghcid = haskellLib.doJailbreak (self.callCabal2nix "ghcid" (hackGet ../dep/ghcid) { });
 
   snap-core = self.callHackage "snap-core" "1.0.5.0" {};
   snap-server = haskellLib.doJailbreak super.snap-server;

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -1,4 +1,4 @@
-{ hackGet, __useNewerCompiler ? false }:
+{ hackGet, args, __useNewerCompiler ? false, system ? builtins.currentSystem }:
 
 # Fix misc upstream packages
 self: super:
@@ -86,7 +86,10 @@ rec {
   modern-uri = haskellLib.doJailbreak super.modern-uri;
   monad-logger = self.callHackage "monad-logger" "0.3.36" { };
   neat-interpolation = haskellLib.doJailbreak super.neat-interpolation;
-  nix-thunk = (import ../dep/nix-thunk { }).makeRunnableNixThunk (haskellLib.doJailbreak (self.callCabal2nix "nix-thunk" (hackGet ../dep/nix-thunk) { }));
+  nix-thunk = (import ../dep/nix-thunk
+  ({ } // pkgs.lib.optionalAttrs (args ? thunkpkgs) {
+    pkgs = args.thunkpkgs;
+  })).makeRunnableNixThunk (haskellLib.doJailbreak (self.callCabal2nix "nix-thunk" (hackGet ../dep/nix-thunk) { }));
   cli-extras = haskellLib.doJailbreak (self.callCabal2nix "cli-extras" (hackGet ../dep/cli-extras) { });
   cli-git = haskellLib.doJailbreak (haskellLib.overrideCabal (self.callCabal2nix "cli-git" (hackGet ../dep/cli-git) { }) {
     librarySystemDepends = with pkgs; [

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -2,11 +2,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
+{- ORMOLU_DISABLE -}
 {-|
    Description:
    Implementation of the CLI deploy commands. Deployment is done by intializing
@@ -53,6 +54,7 @@ import Obelisk.Command.Project
 import Obelisk.Command.Utils
 
 import "nix-thunk" Nix.Thunk
+import "nix-thunk" Nix.Thunk.Internal
 import Cli.Extras
 
 -- | Options passed to the `init` verb
@@ -178,7 +180,8 @@ deployPush deployPath builders = do
       checkGitCleanStatus srcPath True >>= \case
         True -> wrapNixThunkError $ packThunk (ThunkPackConfig False (ThunkConfig Nothing)) srcPath
         False -> failWith $ T.pack $ "ob deploy push: ensure " <> srcPath <> " has no pending changes and latest is pushed upstream."
-    Left err -> failWith $ "ob deploy push: couldn't read src thunk: " <> T.pack (show err)
+    Left err -> failWith $ "ob deploy push: couldn't read src thunk: " <> prettyReadThunkError err
+
   let version = show . _thunkRev_commit $ _thunkPtr_rev thunkPtr
   let moduleFile = deployPath </> "module.nix"
   moduleFileExists <- liftIO $ doesFileExist moduleFile


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
This should allow anyone using flakes to *properly* install obelisk systemwide as long as they set "thunkpkgs" when importing obelisk default.nix

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
