### PR TITLE
WIP: Add support for aarch64-darwin (m1/m2 macos) and aarch64-linux

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -3,6 +3,6 @@
   "repo": "reflex-platform",
   "branch": "nixpkgs-unstable",
   "private": false,
-  "rev": "813214a13f9911ff300db6d60dee64ca0a4b586f",
-  "sha256": "1cfm52ja0zwa2lmy5b41srapdqyfv974c7v7vdcxahv6wfy2hc1x"
+  "rev": "7da6287c6bf3762311021459ac7135b01f3d7cb1",
+  "sha256": "1jigc2y4g2hiibvb5d5r1q59sd0nvlkszvfh87drwc3i5kady1sf"
 }

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "release/1.1.0.0",
+  "branch": "aa/aarch64-darwin",
   "private": false,
-  "rev": "4aa4e254d5f6134dcf700a55c4c065376f7061da",
-  "sha256": "1flwgp76j5v1m4fbdnk5psnpzx2m1vika6lylvs9l9x6krwbv7d6"
+  "rev": "25b5d9bd8ca0a8a2f8161a2ec22780d3ab594b82",
+  "sha256": "1nhlgakqdimjvhhc8yhqzjqxq94gn0b754bfx6sf5xrzcwch64z7"
 }

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "aa/aarch64-darwin",
+  "branch": "nixpkgs-unstable",
   "private": false,
-  "rev": "25b5d9bd8ca0a8a2f8161a2ec22780d3ab594b82",
-  "sha256": "1nhlgakqdimjvhhc8yhqzjqxq94gn0b754bfx6sf5xrzcwch64z7"
+  "rev": "813214a13f9911ff300db6d60dee64ca0a4b586f",
+  "sha256": "1cfm52ja0zwa2lmy5b41srapdqyfv974c7v7vdcxahv6wfy2hc1x"
 }

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -109,4 +109,6 @@ rec {
   github = self.callHackage "github" "0.28" {};
   http2 = haskellLib.dontCheck super.http2;
   http-streams = haskellLib.dontCheck super.http-streams;
+  ghc-lib-parser = super.ghc-lib-parser_8_10_7_20220219;
+  ghc-lib-parser-ex = super.ghc-lib-parser-ex_8_10_0_24;
 }


### PR DESCRIPTION
Based on https://github.com/reflex-frp/reflex-platform/pull/804

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
