### PR TITLE
Update default ios sdk to 15

### DIFF
--- a/skeleton/default.nix
+++ b/skeleton/default.nix
@@ -1,7 +1,7 @@
 { system ? builtins.currentSystem
 , obelisk ? import ./.obelisk/impl {
     inherit system;
-    iosSdkVersion = "13.2";
+    iosSdkVersion = "15.0";
 
     # You must accept the Android Software Development Kit License Agreement at
     # https://developer.android.com/studio/terms in order to build Android apps.


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
