### PR TITLE
command: Use relative paths in getGitHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,16 +181,14 @@ Obelisk officially supports terminal-based feedback (akin to [`ghcid`](https://g
 
 ### Using GHC 8.10
 
-Obelisk currently uses GHC 8.6 for projects by default, since this is the version on which Obelisk (and reflex-platform more generally) have been most thoroughly tested. However, we understand that this version is significantly behind GHC releases, and thus have experimental support for building with GHC 8.10 instead. To build with GHC 8.10, add the following to your project's `default.nix`:
+Obelisk currently uses GHC 8.10 for projects by default. For legacy GHC 8.6 support, add the following to your project's `default.nix`:
 
 ```diff
   { system ? builtins.currentSystem
   , obelisk ? import ./.obelisk/impl {
       inherit system;
-+     useGHC810 = true;
++     useGHC810 = false;
 ```
-
-If the `useGHC810` argument is set to false, or not given, then GHC 8.6 will be used.
 
 ## Deploying
 

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -266,7 +266,7 @@ getGitHash
   -> m GitHash
 getGitHash repo pathWithinRepo = do
   let git = readProcessAndLogOutput (Debug, Debug) . gitProc repo
-  GitHash <$> git ["rev-parse", "HEAD:" <> pathWithinRepo]
+  GitHash <$> git ["rev-parse", "HEAD:./" <> pathWithinRepo]
 
 
 type CommitId = Text


### PR DESCRIPTION
This seems to be the only part of the code that doesn't expect a relative path to the current working directory, and that's a quirk of `git rev-parse` with a revision specified. (Without HEAD, this would also work.)

This change ensures we are always looking at files in the current directory so deployment files do not have to be located in the root of a repository.

I have:

  - [X] Based work on latest `develop` branch
  - [X] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
