### PR TITLE
 command: Use relative paths in getGitHash

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ This project's release branch is `master`. This log is written from the perspect
 ## Unreleased
 
 * Obelisk.Route: add pathQueryEncoder and generalizeIdentity
+* [#1071](https://github.com/obsidiansystems/obelisk/pull/1071): Support deployment information repository sub-directories
 
 ## v1.3.0.0
 * [#1047](https://github.com/obsidiansystems/obelisk/pull/1047): Update default ios sdk to 15

--- a/lib/command/src/Obelisk/Command/Utils.hs
+++ b/lib/command/src/Obelisk/Command/Utils.hs
@@ -266,7 +266,7 @@ getGitHash
   -> m GitHash
 getGitHash repo pathWithinRepo = do
   let git = readProcessAndLogOutput (Debug, Debug) . gitProc repo
-  GitHash <$> git ["rev-parse", "HEAD:" <> pathWithinRepo]
+  GitHash <$> git ["rev-parse", "HEAD:./" <> pathWithinRepo]
 
 
 type CommitId = Text


### PR DESCRIPTION
This seems to be the only part of the code that doesn't expect a relative path to the current working directory, and that's a quirk of `git rev-parse` with a revision specified. (Without `HEAD`, this would also work, but it would work with files not in the repository.)

This change ensures we are always looking at files in the current directory so deployment files do not have to be located in the root of a repository.

I have:

  - [X] Based work on latest `develop` branch
  - [X] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [X] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [X] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)