### PR TITLE
Remove trace statement

### DIFF
--- a/lib/frontend/src/Obelisk/Frontend.hs
+++ b/lib/frontend/src/Obelisk/Frontend.hs
@@ -66,8 +66,6 @@ import qualified Obelisk.ExecutableConfig.Lookup as Lookup
 import System.Info (os)
 import Web.Cookie
 
-import Debug.Trace
-
 type ObeliskWidget t route m =
   ( DomBuilder t m
   , MonadFix m
@@ -132,7 +130,6 @@ nodeListNodes es = do
 
 setInitialRoute :: Bool -> JSM ()
 setInitialRoute useHash = do
-  traceM "setInitialRoute"
   window <- DOM.currentWindowUnchecked
   initialLocation <- DOM.getLocation window
   initialUri <- getLocationUri initialLocation


### PR DESCRIPTION
This message confused me for a bit because I thought it was coming from jsaddle.
`setInitialRoute` only gets called by `runFrontend` and only when not running under ghcjs so it only pops up in native executables which is how it went undetected for so many years. 

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
