### PR TITLE
Remove Nix store path from source maps

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ This project's release branch is `master`. This log is written from the perspect
 
 * Obelisk.Route: add pathQueryEncoder and generalizeIdentity
 * [#1071](https://github.com/obsidiansystems/obelisk/pull/1071): Support deployment information repository sub-directories
+* [#1084](https://github.com/obsidiansystems/obelisk/pull/1084): Fix source maps on Chrome
 
 ## v1.3.0.0
 * [#1047](https://github.com/obsidiansystems/obelisk/pull/1047): Update default ios sdk to 15


### PR DESCRIPTION
Obelisk successfully serves minified JS, the corresponding unminified JS, and the source map that relates the two. But the source map's `sources` field contains the Nix store path of the unminified JS, not a URL. Browsers try to fetch the source code from a bogus URL:
`https://example.com/nix/store/HASH-compressedJs/frontend.jsexe/all.unminified.js`.

This change improves the situation by tweaking the arguments to `closure-compiler`; using relative paths to the JS files instead of absolute paths.

Works on Chromium, but Firefox still has trouble.
