### PR TITLE
command: Delete extraneous config files during deploy

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ This project's release branch is `master`. This log is written from the perspect
 
 * Obelisk.Route: add pathQueryEncoder and generalizeIdentity
 * [#1071](https://github.com/obsidiansystems/obelisk/pull/1071): Support deployment information repository sub-directories
+* [#1086](https://github.com/obsidiansystems/obelisk/pull/1086): Delete extraneous config files during deploy
 
 ## v1.3.0.0
 * [#1047](https://github.com/obsidiansystems/obelisk/pull/1047): Update default ios sdk to 15

--- a/lib/command/src/Obelisk/Command/Deploy.hs
+++ b/lib/command/src/Obelisk/Command/Deploy.hs
@@ -216,6 +216,8 @@ deployPush deployPath builders = do
         [ "-e " <> sshPath <> " " <> unwords sshOpts
         , "--chown=backend:backend"
         , "-qarvz"
+        -- Don't leave old files behind
+        , "--delete"
         , deployPath </> "config"
         , "root@" <> host <> ":/var/lib/backend"
         ]


### PR DESCRIPTION
This change deletes config files on the server that no longer exist in source. Without this, old config files stick around in the directory, which could result in subtle bugs where code continues to depend on those files existing, only coming to a head when a fresh deployment needs to be done.

I have:

  - [X] Based work on latest `develop` branch
  - [X] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [X] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
