### PR TITLE
Run checkEncoder with template haskell

### DIFF
--- a/skeleton/backend/src/Backend.hs
+++ b/skeleton/backend/src/Backend.hs
@@ -1,10 +1,13 @@
 module Backend where
 
 import Common.Route
+import Common.Route.Checked
+import Data.Functor.Identity
 import Obelisk.Backend
+import Obelisk.Route
 
 backend :: Backend BackendRoute FrontendRoute
 backend = Backend
   { _backend_run = \serve -> serve $ const $ return ()
-  , _backend_routeEncoder = fullRouteEncoder
+  , _backend_routeEncoder = hoistCheck (pure . runIdentity) validFullEncoder
   }

--- a/skeleton/common/common.cabal
+++ b/skeleton/common/common.cabal
@@ -11,6 +11,7 @@ library
   exposed-modules:
     Common.Api
     Common.Route
+    Common.Route.Checked
   ghc-options: -Wall -O -fno-show-valid-hole-fits
                -- unsafe code
                -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields

--- a/skeleton/common/src/Common/Route.hs
+++ b/skeleton/common/src/Common/Route.hs
@@ -34,8 +34,8 @@ data FrontendRoute :: * -> * where
   -- This type is used to define frontend routes, i.e. ones for which the backend will serve the frontend.
 
 fullRouteEncoder
-  :: Encoder (Either Text) Identity (R (FullRoute BackendRoute FrontendRoute)) PageName
-fullRouteEncoder = mkFullRouteEncoder
+  :: Either Text (Encoder Identity Identity (R (FullRoute BackendRoute FrontendRoute)) PageName)
+fullRouteEncoder = checkEncoder $ mkFullRouteEncoder
   (FullRoute_Backend BackendRoute_Missing :/ ())
   (\case
       BackendRoute_Missing -> PathSegment "missing" $ unitEncoder mempty)

--- a/skeleton/common/src/Common/Route/Checked.hs
+++ b/skeleton/common/src/Common/Route/Checked.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Common.Route.Checked where
+
+import Data.Functor.Identity
+import qualified Data.Text as Text
+import Obelisk.Route
+
+import Common.Route
+
+case fullRouteEncoder of
+  Left err -> error $ Text.unpack err
+  Right _ ->
+    [d|
+      validFullEncoder :: Encoder Identity Identity (R (FullRoute BackendRoute FrontendRoute)) PageName
+      Right validFullEncoder = fullRouteEncoder
+    |]

--- a/skeleton/frontend/src-bin/main.hs
+++ b/skeleton/frontend/src-bin/main.hs
@@ -1,10 +1,7 @@
+import Common.Route.Checked
 import Frontend
-import Common.Route
 import Obelisk.Frontend
-import Obelisk.Route.Frontend
 import Reflex.Dom
 
 main :: IO ()
-main = do
-  let Right validFullEncoder = checkEncoder fullRouteEncoder
-  run $ runFrontend validFullEncoder frontend
+main = run $ runFrontend validFullEncoder frontend


### PR DESCRIPTION
Got the idea of using TH for encoders long ago from @ryantrinkle. 

~This has the side effect of speeding up reloads by doing the check only when `Common.Route` is modified instead of every reload. Likely not to be noticed unless relying on large `Universe` instances.~ 
EDIT: Hmm no it doesn't. It's pretty unsatisfying that the lack of a `Lift` instance (at least when using `->` and `Kleisli m` categories) means we need to check twice. All we get is upgrading fails-at-startup to fails-at-compile-time.

I marked this as draft because everytime `Common.Route.Checked` is recompiled in ghci (and thus `ob` commands) I start getting
```
<interactive>: ^^ Could not load 'CommonziRouteziChecked_validFullEncoder_closure', dependency unresolved. See top entry above.


ByteCodeLink.lookupCE
During interactive linking, GHCi couldn't find the following symbol:
  CommonziRouteziChecked_validFullEncoder_closure
This may be due to you not asking GHCi to load extra object files,
archives or DLLs needed by your current session.  Restart GHCi, specifying
the missing library using the -L/path/to/object/dir and -lmissinglibname
flags, or simply by naming the relevant files on the GHCi command line.
Alternatively, this link failure might indicate a bug in GHCi.
If you suspect the latter, please report this as a GHC bug:
  https://www.haskell.org/ghc/reportabug


...done
```
until I recompile `Backend.hs` again. Not using `validFullEncoder` in `Backend.hs` also stops it from triggering

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
