### PR TITLE
Uncomment licenses/terms flags

### DIFF
--- a/skeleton/default.nix
+++ b/skeleton/default.nix
@@ -5,13 +5,13 @@
 
     # You must accept the Android Software Development Kit License Agreement at
     # https://developer.android.com/studio/terms in order to build Android apps.
-    # Uncomment and set this to `true` to indicate your acceptance:
-    # config.android_sdk.accept_license = false;
+    # Set this to `true` to indicate your acceptance:
+    config.android_sdk.accept_license = false;
 
     # In order to use Let's Encrypt for HTTPS deployments you must accept
     # their terms of service at https://letsencrypt.org/repository/.
-    # Uncomment and set this to `true` to indicate your acceptance:
-    # terms.security.acme.acceptTerms = false;
+    # Set this to `true` to indicate your acceptance:
+    terms.security.acme.acceptTerms = false;
   }
 }:
 with obelisk;


### PR DESCRIPTION
Unclear why two steps are required for a single opt-in.

It has happened on multiple projects that I uncomment the flag but forget to also toggle it.

An alternative is leaving as a comment with `= true` but the approach here has the advantage that changes upstream to the attribute paths will trigger eval errors/warnings when they happen, not when the flag is next uncommented, minimizing distance between cause and effect.

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
