### PR TITLE
Fix pure eval

### DIFF
--- a/dep/gitignore.nix/github.json
+++ b/dep/gitignore.nix/github.json
@@ -3,6 +3,6 @@
   "repo": "gitignore.nix",
   "branch": "master",
   "private": false,
-  "rev": "7415c4feb127845553943a3856cbc5cb967ee5e0",
-  "sha256": "1zd1ylgkndbb5szji32ivfhwh04mr1sbgrnvbrqpmfb67g2g3r9i"
+  "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+  "sha256": "02wxkdpbhlm3yk5mhkhsp3kwakc16xpmsf2baw57nz1dg459qv8w"
 }

--- a/haskell-overlays/misc-deps.nix
+++ b/haskell-overlays/misc-deps.nix
@@ -85,7 +85,7 @@ rec {
   modern-uri = haskellLib.doJailbreak super.modern-uri;
   monad-logger = self.callHackage "monad-logger" "0.3.36" { };
   neat-interpolation = haskellLib.doJailbreak super.neat-interpolation;
-  nix-thunk = (import ../dep/nix-thunk { }).makeRunnableNixThunk (haskellLib.doJailbreak (self.callCabal2nix "nix-thunk" (hackGet ../dep/nix-thunk) { }));
+  nix-thunk = (import ../dep/nix-thunk { inherit pkgs; }).makeRunnableNixThunk (haskellLib.doJailbreak (self.callCabal2nix "nix-thunk" (hackGet ../dep/nix-thunk) { }));
   cli-extras = haskellLib.doJailbreak (self.callCabal2nix "cli-extras" (hackGet ../dep/cli-extras) { });
   cli-git = haskellLib.doJailbreak (haskellLib.overrideCabal (self.callCabal2nix "cli-git" (hackGet ../dep/cli-git) { }) {
     librarySystemDepends = with pkgs; [


### PR DESCRIPTION
Get rid of two impurities

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [x] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
