### PR TITLE
Add `pairRoute`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,9 +4,10 @@ This project's release branch is `master`. This log is written from the perspect
 
 ## Unreleased
 
-* Obelisk.Route: add pathQueryEncoder and generalizeIdentity
+* [#1038](https://github.com/obsidiansystems/obelisk/pull/1038): `Obelisk.Route`: Add `pathQueryEncoder` and `generalizeIdentity`
 * [#1071](https://github.com/obsidiansystems/obelisk/pull/1071): Support deployment information repository sub-directories
 * [#1086](https://github.com/obsidiansystems/obelisk/pull/1086): Delete extraneous config files during deploy
+* [#1099](https://github.com/obsidiansystems/obelisk/pull/1099): `Obelisk.Route`: Add `pairRoute` and deprecate `subPairRoute` and `subPairRoute_`
 
 ## v1.3.0.0
 * [#1047](https://github.com/obsidiansystems/obelisk/pull/1047): Update default ios sdk to 15


### PR DESCRIPTION
`subPairRoute` / `subPairRoute_` promoted a bad style, this function should be used instead.

<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
