### PR TITLE
Stanza polyfill for GHC2024

### DIFF
--- a/skeleton/backend/backend.cabal
+++ b/skeleton/backend/backend.cabal
@@ -1,9 +1,21 @@
+cabal-version: 2.2
 name: backend
 version: 0.1
-cabal-version: >= 1.8
 build-type: Simple
 
+common defaults
+  default-language: Haskell2010
+  ghc-options: -Wall -O -fno-show-valid-hole-fits
+               -- unsafe code
+               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
+               -- unneeded code
+               -Widentities -Wredundant-constraints
+  if impl(ghc >= 8.8)
+    ghc-options:
+               -Wmissing-deriving-strategies
+
 library
+  import: defaults
   hs-source-dirs: src
   if impl(ghcjs)
     buildable: False
@@ -14,26 +26,11 @@ library
                , obelisk-route
   exposed-modules:
     Backend
-  ghc-options: -Wall -O -fno-show-valid-hole-fits
-               -- unsafe code
-               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
-               -- unneeded code
-               -Widentities -Wredundant-constraints
-  if impl(ghc >= 8.8)
-    ghc-options:
-               -Wmissing-deriving-strategies
 
 executable backend
+  import: defaults
   main-is: main.hs
   hs-source-dirs: src-bin
-  ghc-options: -Wall -O -fno-show-valid-hole-fits -threaded
-               -- unsafe code
-               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
-               -- unneeded code
-               -Widentities -Wredundant-constraints
-  if impl(ghc >= 8.8)
-    ghc-options:
-               -Wmissing-deriving-strategies
   if impl(ghcjs)
     buildable: False
   build-depends: base

--- a/skeleton/backend/backend.cabal
+++ b/skeleton/backend/backend.cabal
@@ -3,8 +3,60 @@ name: backend
 version: 0.1
 build-type: Simple
 
-common defaults
+common ghc2021
   default-language: Haskell2010
+  default-extensions:
+    BangPatterns
+    BinaryLiterals
+    ConstraintKinds
+    DeriveDataTypeable
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DoAndIfThenElse
+    EmptyCase
+    EmptyDataDecls
+    EmptyDataDeriving
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    ForeignFunctionInterface
+    GADTSyntax
+    GeneralisedNewtypeDeriving
+    HexFloatLiterals
+    ImportQualifiedPost
+    InstanceSigs
+    MonoLocalBinds
+    MultiParamTypeClasses
+    NamedFieldPuns
+    NamedWildCards
+    NumericUnderscores
+    PatternGuards
+    PolyKinds
+    PostfixOperators
+    RankNTypes
+    RelaxedPolyRec
+    ScopedTypeVariables
+    StandaloneDeriving
+    StandaloneKindSignatures
+    StarIsType
+    TraditionalRecordSyntax
+    TupleSections
+    TypeApplications
+    TypeOperators
+
+common ghc2024
+  import: ghc2021
+  default-extensions:
+    DataKinds
+    DerivingStrategies
+    DisambiguateRecordFields
+    GADTs
+    LambdaCase
+    RoleAnnotations
+
+common defaults
+  import: ghc2024
   ghc-options: -Wall -O -fno-show-valid-hole-fits
                -- unsafe code
                -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields

--- a/skeleton/common/common.cabal
+++ b/skeleton/common/common.cabal
@@ -1,16 +1,10 @@
+cabal-version: 2.2
 name: common
 version: 0.1
-cabal-version: >= 1.2
 build-type: Simple
 
-library
-  hs-source-dirs: src
-  build-depends: base
-               , obelisk-route
-               , text
-  exposed-modules:
-    Common.Api
-    Common.Route
+common defaults
+  default-language: Haskell2010
   ghc-options: -Wall -O -fno-show-valid-hole-fits
                -- unsafe code
                -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
@@ -19,3 +13,13 @@ library
   if impl(ghc >= 8.8)
     ghc-options:
                -Wmissing-deriving-strategies
+
+library
+  import: defaults
+  hs-source-dirs: src
+  build-depends: base
+               , obelisk-route
+               , text
+  exposed-modules:
+    Common.Api
+    Common.Route

--- a/skeleton/common/common.cabal
+++ b/skeleton/common/common.cabal
@@ -3,8 +3,60 @@ name: common
 version: 0.1
 build-type: Simple
 
-common defaults
+common ghc2021
   default-language: Haskell2010
+  default-extensions:
+    BangPatterns
+    BinaryLiterals
+    ConstraintKinds
+    DeriveDataTypeable
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DoAndIfThenElse
+    EmptyCase
+    EmptyDataDecls
+    EmptyDataDeriving
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    ForeignFunctionInterface
+    GADTSyntax
+    GeneralisedNewtypeDeriving
+    HexFloatLiterals
+    ImportQualifiedPost
+    InstanceSigs
+    MonoLocalBinds
+    MultiParamTypeClasses
+    NamedFieldPuns
+    NamedWildCards
+    NumericUnderscores
+    PatternGuards
+    PolyKinds
+    PostfixOperators
+    RankNTypes
+    RelaxedPolyRec
+    ScopedTypeVariables
+    StandaloneDeriving
+    StandaloneKindSignatures
+    StarIsType
+    TraditionalRecordSyntax
+    TupleSections
+    TypeApplications
+    TypeOperators
+
+common ghc2024
+  import: ghc2021
+  default-extensions:
+    DataKinds
+    DerivingStrategies
+    DisambiguateRecordFields
+    GADTs
+    LambdaCase
+    RoleAnnotations
+
+common defaults
+  import: ghc2024
   ghc-options: -Wall -O -fno-show-valid-hole-fits
                -- unsafe code
                -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields

--- a/skeleton/common/src/Common/Route.hs
+++ b/skeleton/common/src/Common/Route.hs
@@ -1,13 +1,4 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE EmptyCase #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 module Common.Route where

--- a/skeleton/frontend/frontend.cabal
+++ b/skeleton/frontend/frontend.cabal
@@ -3,8 +3,60 @@ name: frontend
 version: 0.1
 build-type: Simple
 
-common defaults
+common ghc2021
   default-language: Haskell2010
+  default-extensions:
+    BangPatterns
+    BinaryLiterals
+    ConstraintKinds
+    DeriveDataTypeable
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DoAndIfThenElse
+    EmptyCase
+    EmptyDataDecls
+    EmptyDataDeriving
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    ForeignFunctionInterface
+    GADTSyntax
+    GeneralisedNewtypeDeriving
+    HexFloatLiterals
+    ImportQualifiedPost
+    InstanceSigs
+    MonoLocalBinds
+    MultiParamTypeClasses
+    NamedFieldPuns
+    NamedWildCards
+    NumericUnderscores
+    PatternGuards
+    PolyKinds
+    PostfixOperators
+    RankNTypes
+    RelaxedPolyRec
+    ScopedTypeVariables
+    StandaloneDeriving
+    StandaloneKindSignatures
+    StarIsType
+    TraditionalRecordSyntax
+    TupleSections
+    TypeApplications
+    TypeOperators
+
+common ghc2024
+  import: ghc2021
+  default-extensions:
+    DataKinds
+    DerivingStrategies
+    DisambiguateRecordFields
+    GADTs
+    LambdaCase
+    RoleAnnotations
+
+common defaults
+  import: ghc2024
   ghc-options: -Wall -O -fno-show-valid-hole-fits
                -- unsafe code
                -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields

--- a/skeleton/frontend/frontend.cabal
+++ b/skeleton/frontend/frontend.cabal
@@ -1,9 +1,21 @@
+cabal-version: 2.2
 name: frontend
 version: 0.1
-cabal-version: >= 1.8
 build-type: Simple
 
+common defaults
+  default-language: Haskell2010
+  ghc-options: -Wall -O -fno-show-valid-hole-fits
+               -- unsafe code
+               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
+               -- unneeded code
+               -Widentities -Wredundant-constraints
+  if impl(ghc >= 8.8)
+    ghc-options:
+               -Wmissing-deriving-strategies
+
 library
+  import: defaults
   hs-source-dirs: src
   build-depends: base
                , common
@@ -17,16 +29,9 @@ library
                , text
   exposed-modules:
     Frontend
-  ghc-options: -Wall -O -fno-show-valid-hole-fits
-               -- unsafe code
-               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
-               -- unneeded code
-               -Widentities -Wredundant-constraints
-  if impl(ghc >= 8.8)
-    ghc-options:
-               -Wmissing-deriving-strategies
 
 executable frontend
+  import: defaults
   main-is: main.hs
   hs-source-dirs: src-bin
   build-depends: base
@@ -35,14 +40,6 @@ executable frontend
                , obelisk-frontend
                , obelisk-route
                , reflex-dom
-  ghc-options: -Wall -O -fno-show-valid-hole-fits -threaded
-               -- unsafe code
-               -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
-               -- unneeded code
-               -Widentities -Wredundant-constraints
-  if impl(ghc >= 8.8)
-    ghc-options:
-               -Wmissing-deriving-strategies
   if impl(ghcjs)
     ghc-options: -dedupe
     cpp-options: -DGHCJS_BROWSER

--- a/skeleton/frontend/src/Frontend.hs
+++ b/skeleton/frontend/src/Frontend.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Frontend where


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
On top of #1067 

From https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html :

> Currently, [GHC2021](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2021) is used by default if no other language edition is explicitly requested, for backwards compatibility purposes. Since later versions of GHC may use a different language edition by default, users are advised to declare a language edition explicitly. Using [GHC2024](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2024) is recommended for new code.

These stanzas allow one to easily use GHC2021/GHC2024 while still building against 8.6/8.10

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
