### PR TITLE
Prevent accidentally getting dependencies with cabal

### DIFF
--- a/skeleton/cabal.project
+++ b/skeleton/cabal.project
@@ -1,3 +1,4 @@
 optional-packages:
   *
 write-ghc-environment-files: never
+active-repositories: :none


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->
This make sure all dependencies are provided by nix and `cabal` can't won't download any, preventing one from forgetting to re-launch the shell after adding a not-currently-available package.

For instance, when doing `cabal build all` inside `nix-shell -A shells.ghcjs` 

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
