### PR TITLE
Allow for multiple static directories

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -77,7 +77,7 @@ in rec {
     touch "$out"
     mkdir -p "$symlinked"
     ${exe} "$src" "$haskellManifest" ${packageName} ${moduleName} "$symlinked"
-  '';
+  '' // {inherit packageName;};
 
   compressedJs = frontend: optimizationLevel: externs: pkgs.runCommand "compressedJs" {} ''
     set -euo pipefail

--- a/default.nix
+++ b/default.nix
@@ -282,8 +282,9 @@ in rec {
                 staticFilesImpure =
                   let fs = self.userSettings.staticFiles;
                   in lib.mapAttrs (_: staticArgs:
+                    # path attr just allows us to watch for file changes
                     if staticArgs.isDrv
-                    then { path = staticArgs.path; src = import staticArgs.src staticArgs.drvArgs; }
+                    then { path = staticArgs.path; src = import staticArgs.path staticArgs.drvArgs; }
                     else { path = staticArgs.path; src = toString staticArgs.path; }
                   ) fs;
                 processedStatic =
@@ -298,6 +299,12 @@ in rec {
                       };
                   in
                     lib.mapAttrs (name: staticArgs: processAssets' (staticArgs // { packageName = name; } )) self.userSettings.staticFiles; 
+                    # lib.mapAttrs (_: staticArgs:
+                    #   if staticArgs.isDrv
+                    #   then processAssets' (import staticArgs.path staticArgs.args)
+                    #   else processAssets' staticArgs.path 
+                    # ) self.userSettings.staticFiles;
+                # The packages whose names and roles are defined by this package
                 predefinedPackages = lib.filterAttrs (_: x: x != null) {
                   ${self.frontendName} = nullIfAbsent (self.base + "/frontend");
                   ${self.commonName} = nullIfAbsent (self.base + "/common");

--- a/lib/asset/manifest/src-bin/static-th.hs
+++ b/lib/asset/manifest/src-bin/static-th.hs
@@ -36,7 +36,7 @@ main = do
       , "staticFilePath =  staticAssetFilePathRaw \"static.out\"" <> " " <> show staticAttrName 
       , "#else"
       , "static = staticAssetHashed " <> show root <> " " <> show staticAttrName 
-      , "staticFilePath = staticAssetFilePath " <> show root <> " " <> show staticAttrName 
+      , "staticFilePath = staticAssetFilePath " <> show root 
       , "#endif"
       ]
     }

--- a/lib/asset/manifest/src-bin/static-th.hs
+++ b/lib/asset/manifest/src-bin/static-th.hs
@@ -8,7 +8,7 @@ import System.FilePath
 main :: IO ()
 main = do
   --TODO: Usage
-  [root, haskellTarget, packageName, moduleName, fileTarget] <- getArgs
+  [root, haskellTarget, packageName, moduleName, fileTarget, staticAttrName] <- getArgs
   paths <- gatherHashedPaths root
   writeCabalProject haskellTarget $ SimplePkg
     { _simplePkg_name = T.pack packageName
@@ -32,11 +32,11 @@ main = do
       , ""
       , "static, staticFilePath :: FilePath -> Q Exp"
       , "#ifdef OBELISK_ASSET_PASSTHRU"
-      , "static = staticAssetRaw"
-      , "staticFilePath =  staticAssetFilePathRaw \"" <> (takeFileName root) <>".out\""
+      , "static = staticAssetRaw" <> " " <> show staticAttrName 
+      , "staticFilePath =  staticAssetFilePathRaw \"static.out\"" <> " " <> show staticAttrName 
       , "#else"
-      , "static = staticAssetHashed " <> show root
-      , "staticFilePath = staticAssetFilePath " <> show root
+      , "static = staticAssetHashed " <> show root <> " " <> show staticAttrName 
+      , "staticFilePath = staticAssetFilePath " <> show root <> " " <> show staticAttrName 
       , "#endif"
       ]
     }

--- a/lib/asset/manifest/src-bin/static-th.hs
+++ b/lib/asset/manifest/src-bin/static-th.hs
@@ -33,7 +33,7 @@ main = do
       , "static, staticFilePath :: FilePath -> Q Exp"
       , "#ifdef OBELISK_ASSET_PASSTHRU"
       , "static = staticAssetRaw"
-      , "staticFilePath =  staticAssetFilePathRaw \"static.out\""
+      , "staticFilePath =  staticAssetFilePathRaw \"" <> (takeFileName root) <>".out\""
       , "#else"
       , "static = staticAssetHashed " <> show root
       , "staticFilePath = staticAssetFilePath " <> show root

--- a/lib/asset/manifest/src/Obelisk/Asset/TH.hs
+++ b/lib/asset/manifest/src/Obelisk/Asset/TH.hs
@@ -66,9 +66,9 @@ staticAssetFilePathRaw
 staticAssetFilePathRaw root staticName = staticAssetWorker root staticOutPath staticName
 
 -- | Return the real location of 'relativePath' 
-staticAssetFilePath :: FilePath -> FilePath -> FilePath -> Q Exp
-staticAssetFilePath root staticPkgName relativePath = do
-  let fullPath = root </> staticPkgName </> relativePath
+staticAssetFilePath :: FilePath -> FilePath -> Q Exp
+staticAssetFilePath root relativePath = do
+  let fullPath = root </> relativePath
   qAddDependentFile fullPath
   pure $ LitE $ StringL fullPath
 

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -457,7 +457,7 @@ getStaticHaskellManifestProjectPaths root = do
   stdout <- readProcessAndLogStderr Debug $ setCwd (Just root) $ proc nixBuildExePath
     [ "--no-out-link"
     , "-E"
-    , "(let a = import ./. {}; in builtins.mapAttrs (_: x: x.haskellManifest) d.passthru.processedStatic)"
+    , "(let a = import ./. {}; in builtins.mapAttrs (_: x: x.haskellManifest) a.passthru.processedStatic)"
     ]
   pure $ T.strip <$> T.lines stdout
 

--- a/lib/command/src/Obelisk/Command/Project.hs
+++ b/lib/command/src/Obelisk/Command/Project.hs
@@ -27,6 +27,7 @@ module Obelisk.Command.Project
   , StaticInfo(..)
   , describeImpureAssetSource
   , watchStaticFilesDerivation
+  , staticOut
   ) where
 
 import Control.Concurrent.MVar (MVar, newMVar, withMVarMasked)

--- a/skeleton/default.nix
+++ b/skeleton/default.nix
@@ -16,6 +16,14 @@
 }:
 with obelisk;
 project ./. ({ ... }: {
+  staticFiles = {
+    obelisk-generated-static = {
+      path = ./static;
+      isDrv = false;
+      drvArgs = null;
+      moduleName = "Obelisk.Generated.Static";
+    };
+  };
   android.applicationId = "systems.obsidian.obelisk.examples.minimal";
   android.displayName = "Obelisk Minimal Example";
   ios.bundleIdentifier = "systems.obsidian.obelisk.examples.minimal";


### PR DESCRIPTION
Providing the capability to have multiple static directories to allow for things such as building and serving a static site made with reflex in a way that doesn't force unrelated frontend code to be rebuilt due to a dependence on the same singular static directory.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
