### PR TITLE
Document need for nix-command in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Obelisk assumes basic knowledge of [Haskell](https://www.haskell.org/) and [Refl
         ```nix
         nix.binaryCaches = [ "https://nixcache.reflex-frp.org" ];
         nix.binaryCachePublicKeys = [ "ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=" ];
+		nix.settings.experimental-features = [ "nix-command" ];
         ```
         and rebuild your NixOS configuration (e.g. `sudo nixos-rebuild switch`).
     1. If you are using another operating system or Linux distribution, ensure that these lines are present in your Nix configuration file (`/etc/nix/nix.conf` on most systems; [see full list](https://nixos.org/nix/manual/#sec-conf-file)):
@@ -57,6 +58,7 @@ Obelisk assumes basic knowledge of [Haskell](https://www.haskell.org/) and [Refl
         binary-caches = https://cache.nixos.org https://nixcache.reflex-frp.org
         binary-cache-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=
         binary-caches-parallel-connections = 40
+		experimental-features = nix-command
         ```
         * If you're on a Linux distribution other than NixOS, enable sandboxing (see these [issue 172](https://github.com/obsidiansystems/obelisk/issues/172#issuecomment-411507818) or [issue 6](https://github.com/obsidiansystems/obelisk/issues/6) if you run into build problems) by adding the following:
           ```nix

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Obelisk assumes basic knowledge of [Haskell](https://www.haskell.org/) and [Refl
         ```nix
         nix.binaryCaches = [ "https://nixcache.reflex-frp.org" ];
         nix.binaryCachePublicKeys = [ "ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=" ];
-	nix.settings.experimental-features = [ "nix-command" ];
+        nix.settings.experimental-features = [ "nix-command" ];
         ```
         and rebuild your NixOS configuration (e.g. `sudo nixos-rebuild switch`).
     1. If you are using another operating system or Linux distribution, ensure that these lines are present in your Nix configuration file (`/etc/nix/nix.conf` on most systems; [see full list](https://nixos.org/nix/manual/#sec-conf-file)):
@@ -58,7 +58,7 @@ Obelisk assumes basic knowledge of [Haskell](https://www.haskell.org/) and [Refl
         binary-caches = https://cache.nixos.org https://nixcache.reflex-frp.org
         binary-cache-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=
         binary-caches-parallel-connections = 40
-	experimental-features = nix-command
+        experimental-features = nix-command
         ```
         * If you're on a Linux distribution other than NixOS, enable sandboxing (see these [issue 172](https://github.com/obsidiansystems/obelisk/issues/172#issuecomment-411507818) or [issue 6](https://github.com/obsidiansystems/obelisk/issues/6) if you run into build problems) by adding the following:
           ```nix

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Obelisk assumes basic knowledge of [Haskell](https://www.haskell.org/) and [Refl
         ```nix
         nix.binaryCaches = [ "https://nixcache.reflex-frp.org" ];
         nix.binaryCachePublicKeys = [ "ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=" ];
-		nix.settings.experimental-features = [ "nix-command" ];
+	nix.settings.experimental-features = [ "nix-command" ];
         ```
         and rebuild your NixOS configuration (e.g. `sudo nixos-rebuild switch`).
     1. If you are using another operating system or Linux distribution, ensure that these lines are present in your Nix configuration file (`/etc/nix/nix.conf` on most systems; [see full list](https://nixos.org/nix/manual/#sec-conf-file)):
@@ -58,7 +58,7 @@ Obelisk assumes basic knowledge of [Haskell](https://www.haskell.org/) and [Refl
         binary-caches = https://cache.nixos.org https://nixcache.reflex-frp.org
         binary-cache-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=
         binary-caches-parallel-connections = 40
-		experimental-features = nix-command
+	experimental-features = nix-command
         ```
         * If you're on a Linux distribution other than NixOS, enable sandboxing (see these [issue 172](https://github.com/obsidiansystems/obelisk/issues/172#issuecomment-411507818) or [issue 6](https://github.com/obsidiansystems/obelisk/issues/6) if you run into build problems) by adding the following:
           ```nix


### PR DESCRIPTION
**only changes documentation

Obelisk uses nix eval in a number of places which will fail and be unknown to the user if they don't have the -v option.

In any case, it would be easiest to notify users of the need for nix-command in order for Obelisk to function as expected.

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [x] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [x] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
