### PR TITLE
Allow building obelisk libs with wasm backend

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10']
+        ghc: ['8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10', '9.12']
         os: ['ubuntu-latest', 'macos-13'] # https://github.com/haskell-actions/setup/issues/77
     runs-on: ${{ matrix.os }}
 

--- a/lib/cabal.dependencies.project
+++ b/lib/cabal.dependencies.project
@@ -5,11 +5,12 @@ constraints:
     hnix-store-core < 0.7
   , hnix-store-remote < 0.7
 
+-- https://github.com/haskellari/splitmix/pull/73
+-- https://github.com/haskellari/splitmix/pull/75
 source-repository-package
   type: git
-  location: https://github.com/ymeister/splitmix.git
-  tag: fe4d9e4ec01ba7caf8053d6888ec2e7f89fad874
-  --sha256: 19fbwcmdmb9w34cp19r2j4qywhnjmxxdv4rwci29pzbvgbnnjdia
+  location: https://github.com/alexfmpe/splitmix
+  tag: bd53859c0f41d12f16c3f44fee52f5e9aae26243
 
 -- https://github.com/haskell-cryptography/HsOpenSSL/issues/93#issuecomment-2311816896
 package HsOpenSSL

--- a/lib/cabal.project
+++ b/lib/cabal.project
@@ -5,14 +5,17 @@ packages:
   ./route
   ./tabulation
 
-if !arch(javascript)
+if !arch(javascript) && !arch(wasm32)
   packages:
     ./asset/manifest
     ./asset/serve-snap
     ./backend
-    ./command
     ./run
-    ./selftest
     ./snap-extras
+
+  if impl(ghc < 9.12)
+    packages:
+      ./command
+      ./selftest
 
 import: cabal.dependencies.project


### PR DESCRIPTION
Follow up of https://github.com/reflex-frp/reflex-dom/pull/491

<!-- Provide a clear overview of your changes. -->

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
