### PR TITLE
Allow obelisk-asset-manifest build with ghcjs

### DIFF
--- a/lib/asset/manifest/obelisk-asset-manifest.cabal
+++ b/lib/asset/manifest/obelisk-asset-manifest.cabal
@@ -41,9 +41,6 @@ library
     -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O2
     -fno-warn-unused-do-bind -funbox-strict-fields -fprof-auto-calls
 
-  if impl(ghcjs)
-    buildable: False
-
 executable obelisk-asset-manifest-generate
   default-language: Haskell2010
   hs-source-dirs: src-bin
@@ -52,6 +49,9 @@ executable obelisk-asset-manifest-generate
       base
     , obelisk-asset-manifest
     , text
+
+  if impl(ghcjs)
+    buildable: False
 
 executable obelisk-asset-th-generate
   default-language: Haskell2010
@@ -62,3 +62,6 @@ executable obelisk-asset-th-generate
     , obelisk-asset-manifest
     , filepath
     , text
+
+  if impl(ghcjs)
+    buildable: False


### PR DESCRIPTION
The obelisk-asset-manifest is being used by obelisk-generated-static, (The Obelisk.Asset.TH is being used by frontend.)

The 'exes' have been marked non-buildable.

<!-- Provide a clear overview of your changes. -->

I have:

  - [ ] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
