### PR TITLE
executable-config-lookup: Add MonadException to ConfigsT

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ This project's release branch is `master`. This log is written from the perspect
 * [#1071](https://github.com/obsidiansystems/obelisk/pull/1071): Support deployment information repository sub-directories
 * [#1086](https://github.com/obsidiansystems/obelisk/pull/1086): Delete extraneous config files during deploy
 * [#1099](https://github.com/obsidiansystems/obelisk/pull/1099): `Obelisk.Route`: Add `pairRoute` and deprecate `subPairRoute` and `subPairRoute_`
+* [#1131](https://github.com/obsidiansystems/obelisk/pull/1131): Add `MonadException` instance to `ConfigsT`
 
 ## v1.3.0.0
 * [#1047](https://github.com/obsidiansystems/obelisk/pull/1047): Update default ios sdk to 15

--- a/lib/executable-config/lookup/obelisk-executable-config-lookup.cabal
+++ b/lib/executable-config/lookup/obelisk-executable-config-lookup.cabal
@@ -32,6 +32,7 @@ library
     bytestring,
     containers,
     exceptions,
+    exception-transformers,
     filepath,
     jsaddle,
     mmorph,

--- a/lib/executable-config/lookup/src/Obelisk/Configs.hs
+++ b/lib/executable-config/lookup/src/Obelisk/Configs.hs
@@ -24,6 +24,7 @@ import Control.Applicative (Alternative)
 import Control.Monad (MonadPlus)
 import Control.Monad.Base (MonadBase)
 import Control.Monad.Catch (MonadThrow)
+import Control.Monad.Exception
 #if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail (MonadFail)
 #endif

--- a/lib/executable-config/lookup/src/Obelisk/Configs.hs
+++ b/lib/executable-config/lookup/src/Obelisk/Configs.hs
@@ -109,6 +109,7 @@ newtype ConfigsT m a = ConfigsT { unConfigsT :: ReaderT (Map Text ByteString) m 
     , TriggerEvent t
     , HasDocument
     , DomRenderHook t
+    , MonadException
 #ifndef ghcjs_HOST_OS
     , MonadJSM
 #endif


### PR DESCRIPTION
<!-- Provide a clear overview of your changes. -->

I have:

  - [x] Based work on latest `develop` branch
  - [x] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [x] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
