### PR TITLE
Run tests in parallel by default when possible 

### DIFF
--- a/lib/route/obelisk-route.cabal
+++ b/lib/route/obelisk-route.cabal
@@ -55,6 +55,10 @@ test-suite roundtrips
   default-language: Haskell2010
   ghc-options: -O
 
+  -- https://gitlab.haskell.org/ghc/ghc/-/issues/25442
+  if !os(wasi)
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N"
+
   build-depends:
     QuickCheck,
     aeson,

--- a/lib/route/obelisk-route.cabal
+++ b/lib/route/obelisk-route.cabal
@@ -1,9 +1,13 @@
+cabal-version: 2.2
 name: obelisk-route
 version: 0.2
-cabal-version: >= 1.8
 build-type: Simple
 
+common warnings
+  ghc-options: -Wall -Werror -fprint-potential-instances -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates
+
 library
+  import: warnings
   hs-source-dirs: src
   build-depends: base,
                  aeson,
@@ -41,14 +45,15 @@ library
                    Obelisk.Route.TH
                    Obelisk.Route.Frontend
 
-  ghc-options: -Wall -Werror -fprint-potential-instances -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O
+  ghc-options: -O
 
 test-suite roundtrips
+  import: warnings
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: test
   default-language: Haskell2010
-  ghc-options: -Wall -Werror -fprint-potential-instances -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O
+  ghc-options: -O
 
   build-depends:
     QuickCheck,


### PR DESCRIPTION
Test suite is really slow under js backend. As in, minutes instead of seconds like under native ghc.
Probably a mix of js being slow and a lot of `Text` usage as generating/encoding `PageName` utterly dominates compared to small encoders.

I have:

  - [x] Based work on latest `develop` branch
  - [ ] Followed the [contribution guide](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#submitting-changes)
  - [ ] Looked for lint in my changes with `hlint .` (lint found code you did not write can be left alone)
  - [ ] Run the test suite: `$(nix-build -A selftest --no-out-link)`
  - [ ] [Updated the changelog](https://github.com/obsidiansystems/obelisk/blob/develop/CONTRIBUTING.md#in-the-changelog)
  - [ ] (Optional) Run CI tests locally: `nix-build release.nix -A build.x86_64-linux --no-out-link` (or `x86_64-darwin` on macOS)
